### PR TITLE
Support for test level tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,12 @@
 /testplan/examples/**/*report.txt
 
 .idea/
+build/
+dist/
+*.egg-info/
 
 .cache/
-
+.pytest_cache/
 
 CMakeFiles/
 CMakeCache.txt

--- a/doc/en/introduction.rst
+++ b/doc/en/introduction.rst
@@ -21,7 +21,7 @@ Components
 The three main components of a Testplan are:
 
   1. **Test** (:py:class:`~testplan.testing.multitest.base.MultiTest`,
-     (:py:class:`~testplan.testing.cpp.gtest.GTest`)
+     :py:class:`~testplan.testing.cpp.gtest.GTest`)
      is defined as a runnable that will be executed
      by :py:class:`~testplan.base.Testplan` and create a
      :py:class:`~testplan.report.testing.base.TestReport`. Multiple tests can be

--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -652,19 +652,22 @@ How can I troubleshoot a problem?
 Tagging
 -------
 
-Testplan has support for suite and testcase level tagging (Suite level tags are
-also implicitly applied to each testcase of that suite). It's possible to run
-subset of tests using ``--tags`` or ``--tags-all`` arguments. The difference
-between ``--tags`` and ``--tags-all`` is that ``--tags tagA tagB`` will run any
-test case that is tagged with ``tagA`` **OR** ``tagB`` whereas
-``--tags-all tagA tagB`` will run test cases that are tagged with both
+Testplan supports test filtering via tags, which can be assigned to top level
+tests via ``tags`` argument (e.g. ``GTest(name='CPP Tests', tags='TagA')``,
+``MultiTest(name='My Test', tags=('TagB', 'TagC')``). MultiTest framework also
+has further support for suite and testcase level tagging as well.
+
+It's possible to run subset of tests using ``--tags`` or ``--tags-all`` arguments.
+The difference between ``--tags`` and ``--tags-all`` is that
+``--tags tagA tagB`` will run any test that is tagged with ``tagA`` **OR**
+``tagB`` whereas ``--tags-all tagA tagB`` will run tests that are tagged with both
 ``tagA`` **AND** ``tagB``.
 
 .. note::
 
     If you apply the same tag value both on suite level and testcase level, the
-    tag filtering will still work as expected. However you will also get warnings,
-    as applying the same testsuite tag explicitly to a testcase is a redundant
+    tag filtering will still work as expected. However keep in mind that
+    applying the same testsuite tag explicitly to a testcase is a redundant
     operation.
 
 There are multiple ways to assign tags to a target:
@@ -719,6 +722,11 @@ Example
 
 .. code-block:: python
 
+  # Top level test instance tagging
+  my_gtest = GTest(name='My GTest', tags='tagA')
+
+  # Testsuite & test case level tagging
+
   @testsuite(tags='tagA')
   class SampleTestAlpha(object):
 
@@ -753,6 +761,11 @@ Example
       @testcase(tags={'category': ['tagC', 'tagD'])
       def method_3(self, env, result):
         ...
+
+
+  my_multitest = MultiTest(
+      name='My MultiTest', tags=['tagE', 'tagF']
+      suites=[SampleTestAlpha(), SampleTestBeta()])
 
 
 Runs all testcases from ``SampleTestAlpha`` (suite level match),

--- a/test/functional/exporters/testing/test_pdf.py
+++ b/test/functional/exporters/testing/test_pdf.py
@@ -89,24 +89,24 @@ def test_tag_filtered_pdf(tmpdir):
                 name='Multitest 1',
                 category='multitest',
                 tags_index={
-                    'simple': frozenset(['foo', 'bar']),
-                    'color': frozenset(['red'])
+                    'simple': {'foo', 'bar'},
+                    'color': {'red'}
                 },
             ),
             TestGroupReport(
                 name='Multitest 2',
                 category='multitest',
                 tags_index={
-                    'simple': frozenset(['foo',]),
-                    'color': frozenset(['blue'])
+                    'simple': {'foo'},
+                    'color': {'blue'}
                 },
             ),
             TestGroupReport(
                 name='Multitest 3',
                 category='multitest',
                 tags_index={
-                    'simple': frozenset(['bar']),
-                    'color': frozenset(['green'])
+                    'simple': {'bar'},
+                    'color': {'green'}
                 },
             ),
         ]

--- a/test/functional/exporters/testing/test_pdf.py
+++ b/test/functional/exporters/testing/test_pdf.py
@@ -145,12 +145,13 @@ def test_tag_filtered_pdf(tmpdir):
 
     for path in should_exist:
         path = os.path.join(pdf_dir, path)
-        assert os.path.exists(path)
+        assert os.path.exists(path), 'Could not generate PDF: {}'.format(path)
         assert os.stat(path).st_size > 0
 
     for path in should_not_exist:
         path = os.path.join(pdf_dir, path)
-        assert not os.path.exists(path)
+        assert not os.path.exists(path), (
+            'Should not have been generated PDF: {}'.format(path))
 
 
 def test_implicit_exporter_initialization(tmpdir):

--- a/test/functional/testplan/testing/fixtures/base/failing/report.py
+++ b/test/functional/testplan/testing/fixtures/base/failing/report.py
@@ -3,7 +3,7 @@ from testplan.report.testing import TestReport, TestGroupReport, Status
 
 my_test_report = TestGroupReport(
     name='MyTest',
-    category='DummyTest',
+    category='dummytest',
     entries=[],
 )
 

--- a/test/functional/testplan/testing/fixtures/base/passing/report.py
+++ b/test/functional/testplan/testing/fixtures/base/passing/report.py
@@ -5,7 +5,7 @@ expected_report = TestReport(
     entries=[
         TestGroupReport(
             name='MyTest',
-            category='DummyTest',
+            category='dummytest',
             entries=[]
         ),
     ]

--- a/test/functional/testplan/testing/fixtures/base/sleeping/report.py
+++ b/test/functional/testplan/testing/fixtures/base/sleeping/report.py
@@ -3,7 +3,7 @@ from testplan.report.testing import TestReport, TestGroupReport, Status
 
 my_test_report = TestGroupReport(
     name='MyTest',
-    category='DummyTest',
+    category='dummytest',
     entries=[],
 )
 

--- a/test/functional/testplan/testing/fixtures/cpp/gtest/failing/report.py
+++ b/test/functional/testplan/testing/fixtures/cpp/gtest/failing/report.py
@@ -5,7 +5,7 @@ expected_report = TestReport(
     entries=[
         TestGroupReport(
             name='MyGTest',
-            category='GTest',
+            category='gtest',
             entries=[
                 TestGroupReport(
                     name='SquareRootTest',

--- a/test/functional/testplan/testing/fixtures/cpp/gtest/passing/report.py
+++ b/test/functional/testplan/testing/fixtures/cpp/gtest/passing/report.py
@@ -5,7 +5,7 @@ expected_report = TestReport(
     entries=[
         TestGroupReport(
             name='MyGTest',
-            category='GTest',
+            category='gtest',
             entries=[
                 TestGroupReport(
                     name='SquareRootTest',

--- a/test/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/test/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -8,7 +8,11 @@ from testplan import Testplan
 from testplan.common.entity.base import Environment, ResourceStatus
 from testplan.common.utils.context import context
 from testplan.common.utils.path import default_runpath
+from testplan.common.utils.testing import log_propagation_disabled
 from testplan.testing.multitest.driver.tcp import TCPServer, TCPClient
+
+from testplan.logger import TESTPLAN_LOGGER
+
 
 
 def runpath_maker(obj):
@@ -117,9 +121,10 @@ def test_multitest_drivers_in_testplan():
         assert server.status.tag == ResourceStatus.NONE
         assert client.status.tag == ResourceStatus.NONE
 
-        plan.run()
-        res = plan.result
+        with log_propagation_disabled(TESTPLAN_LOGGER):
+            plan.run()
 
+        res = plan.result
         assert res.run is True
         if idx == 0:
             assert plan.runpath == runpath_maker(None)

--- a/test/functional/testplan/testing/test_tagging.py
+++ b/test/functional/testplan/testing/test_tagging.py
@@ -1,7 +1,12 @@
+import pytest
+
+from testplan.common.utils.testing import check_report, log_propagation_disabled
+
+from testplan.report.testing import TestReport, TestGroupReport, TestCaseReport
 from testplan.testing.multitest import MultiTest, testsuite, testcase
+from testplan.logger import TESTPLAN_LOGGER
 
 from testplan import Testplan
-from testplan.testing import tagging
 
 
 @testsuite(tags={'color': ['red', 'blue']})
@@ -36,77 +41,408 @@ class BetaSuite(object):
         pass
 
 
-def test_multitest_tagging():
+@testsuite
+class GammaSuite(object):
+
+    @testcase
+    def test_method_0(self, env, result):
+        pass
+
+    @testcase(
+        parameters=('AAA', 'BBB'),
+        tag_func=lambda kwargs: {'symbol': kwargs['value'].lower()},
+        tags={'speed': 'slow'},
+    )
+    def test_param(self, env, result, value):
+        pass
+
+    @testcase(
+        parameters=('XXX', 'YYY'),
+        tags={'speed': 'fast'}
+    )
+    def test_param_2(self, env, result, value):
+        pass
+
+
+report_for_multitest_without_tags = TestGroupReport(
+    name='MyMultitest',
+    category='multitest',
+    tags={},
+    tags_index={
+        'simple': {'foo', 'bar'},
+        'symbol': {'aaa', 'bbb'},
+        'speed': {'slow', 'fast'},
+        'color': {'red', 'blue', 'yellow', 'green'},
+    },
+    entries=[
+        TestGroupReport(
+            name='AlphaSuite',
+            category='suite',
+            tags={'color': {'red', 'blue'}},
+            tags_index={
+                'color': {'red', 'blue', 'green'},
+                'simple': {'foo', 'bar'},
+            },
+            entries=[
+                TestCaseReport(
+                    name='test_method_0',
+                    tags={},
+                    tags_index={
+                        'color': {'red', 'blue'},
+                    },
+                ),
+                TestCaseReport(
+                    name='test_method_1',
+                    tags={
+                        'simple': {'foo', 'bar'},
+                    },
+                    tags_index={
+                        'color': {'red', 'blue'},
+                    },
+                ),
+                TestCaseReport(
+                    name='test_method_2',
+                    tags={
+                        'color': {'green'},
+                    },
+                    tags_index={
+                        'color': {'red', 'blue', 'green'}
+                    }
+                ),
+            ]
+        ),
+        TestGroupReport(
+            name='BetaSuite',
+            category='suite',
+            tags={'color': {'yellow'}},
+            tags_index={
+                'color': {'yellow', 'red'},
+                'simple': {'foo'}
+            },
+            entries=[
+                TestCaseReport(
+                    name='test_method_0',
+                    tags={},
+                    tags_index={
+                        'color': {'yellow'},
+                    },
+                ),
+                TestCaseReport(
+                    name='test_method_1',
+                    tags={
+                        'simple': {'foo'},
+                    },
+                    tags_index={
+                        'color': {'yellow'},
+                        'simple': {'foo'}
+                    },
+                ),
+                TestCaseReport(
+                    name='test_method_2',
+                    tags={
+                        'color': {'red'},
+                    },
+                    tags_index={
+                        'color': {'yellow', 'red'},
+                    },
+                ),
+            ],
+        ),
+        TestGroupReport(
+            name='GammaSuite',
+            category='suite',
+            tags={},
+            tags_index={
+                'symbol': {'aaa', 'bbb'},
+                'speed': {'slow', 'fast'}
+            },
+            entries=[
+                TestCaseReport(
+                    name='test_method_0',
+                    tags={},
+                    tags_index={},
+                ),
+                TestGroupReport(
+                    name='test_param',
+                    category='parametrization',
+                    tags={
+                        'speed': {'slow'},
+                    },
+                    tags_index={
+                        'speed': {'slow'},
+                        'symbol': {'aaa', 'bbb'},
+                    },
+                    entries=[
+                        TestCaseReport(
+                            name='test_param__value_AAA',
+                            tags={
+                                'symbol': {'aaa'},
+                            },
+                            tags_index={
+                                'speed': {'slow'},
+                                'symbol': {'aaa'},
+                            }
+                        ),
+                        TestCaseReport(
+                            name='test_param__value_BBB',
+                            tags={
+                                'symbol': {'bbb'},
+                            },
+                            tags_index={
+                                'speed': {'slow'},
+                                'symbol': {'bbb'},
+                            }
+                        ),
+                    ]
+                ),
+                TestGroupReport(
+                    name='test_param_2',
+                    category='parametrization',
+                    tags={
+                        'speed': {'fast'},
+                    },
+                    tags_index={
+                        'speed': {'fast'},
+                    },
+                    entries=[
+                        TestCaseReport(
+                            name='test_param_2__value_XXX',
+                            tags={},
+                            tags_index={
+                                'speed': {'fast'},
+                            }
+                        ),
+                        TestCaseReport(
+                            name='test_param_2__value_YYY',
+                            tags={},
+                            tags_index={
+                                'speed': {'fast'},
+                            }
+                        ),
+                    ]
+                )
+            ]
+        )
+    ]
+)
+
+
+report_for_multitest_with_tags = TestGroupReport(
+    name='MyMultitest',
+    category='multitest',
+    tags={
+        'color': {'orange'},
+        'environment': {'server'}
+    },
+    tags_index={
+        'simple': {'foo', 'bar'},
+        'symbol': {'aaa', 'bbb'},
+        'speed': {'slow', 'fast'},
+        'color': {'orange', 'red', 'blue', 'yellow', 'green'},
+        'environment': {'server'}
+    },
+    entries=[
+        TestGroupReport(
+            name='AlphaSuite',
+            category='suite',
+            tags={'color': {'red', 'blue'}},
+            tags_index={
+                'color': {'red', 'blue', 'orange', 'green'},
+                'simple': {'foo', 'bar'},
+                'environment': {'server'}
+            },
+            entries=[
+                TestCaseReport(
+                    name='test_method_0',
+                    tags={},
+                    tags_index={
+                        'color': {'red', 'blue', 'orange'},
+                        'environment': {'server'}
+                    },
+                ),
+                TestCaseReport(
+                    name='test_method_1',
+                    tags={
+                        'simple': {'foo', 'bar'},
+                    },
+                    tags_index={
+                        'color': {'red', 'blue', 'orange'},
+                        'environment': {'server'}
+                    },
+                ),
+                TestCaseReport(
+                    name='test_method_2',
+                    tags={
+                        'color': {'green'},
+                    },
+                    tags_index={
+                        'environment': {'server'},
+                        'color': {'red', 'blue', 'orange', 'green'}}
+                ),
+            ]
+        ),
+        TestGroupReport(
+            name='BetaSuite',
+            category='suite',
+            tags={'color': {'yellow'}},
+            tags_index={
+                'color': {'yellow', 'orange', 'red'},
+                'environment': {'server'},
+                'simple': {'foo'}
+            },
+            entries=[
+                TestCaseReport(
+                    name='test_method_0',
+                    tags={},
+                    tags_index={
+                        'color': {'yellow', 'orange'},
+                        'environment': {'server'},
+                    },
+                ),
+                TestCaseReport(
+                    name='test_method_1',
+                    tags={
+                        'simple': {'foo'},
+                    },
+                    tags_index={
+                        'color': {'yellow', 'orange'},
+                        'environment': {'server'},
+                        'simple': {'foo'}
+                    },
+                ),
+                TestCaseReport(
+                    name='test_method_2',
+                    tags={
+                        'color': {'red'},
+                    },
+                    tags_index={
+                        'color': {'yellow', 'orange', 'red'},
+                        'environment': {'server'},
+                    },
+                ),
+            ]
+        ),
+        TestGroupReport(
+            name='GammaSuite',
+            category='suite',
+            tags={},
+            tags_index={
+                'color': {'orange'},
+                'environment': {'server'},
+                'symbol': {'aaa', 'bbb'},
+                'speed': {'slow', 'fast'}
+            },
+            entries=[
+                TestCaseReport(
+                    name='test_method_0',
+                    tags={},
+                    tags_index={
+                        'color': {'orange'},
+                        'environment': {'server'},
+                    },
+                ),
+                TestGroupReport(
+                    name='test_param',
+                    category='parametrization',
+                    tags={
+                        'speed': {'slow'},
+                    },
+                    tags_index={
+                        'speed': {'slow'},
+                        'symbol': {'aaa', 'bbb'},
+                        'color': {'orange'},
+                        'environment': {'server'},
+                    },
+                    entries=[
+                        TestCaseReport(
+                            name='test_param__value_AAA',
+                            tags={
+                                'symbol': {'aaa'},
+                            },
+                            tags_index={
+                                'speed': {'slow'},
+                                'symbol': {'aaa'},
+                                'color': {'orange'},
+                                'environment': {'server'},
+                            }
+                        ),
+                        TestCaseReport(
+                            name='test_param__value_BBB',
+                            tags={
+                                'symbol': {'bbb'},
+                            },
+                            tags_index={
+                                'speed': {'slow'},
+                                'symbol': {'bbb'},
+                                'color': {'orange'},
+                                'environment': {'server'},
+                            }
+                        ),
+                    ]
+                ),
+                TestGroupReport(
+                    name='test_param_2',
+                    category='parametrization',
+                    tags={
+                        'speed': {'fast'},
+                    },
+                    tags_index={
+                        'speed': {'fast'},
+                        'color': {'orange'},
+                    },
+                    entries=[
+                        TestCaseReport(
+                            name='test_param_2__value_XXX',
+                            tags={},
+                            tags_index={
+                                'speed': {'fast'},
+                                'color': {'orange'},
+                            }
+                        ),
+                        TestCaseReport(
+                            name='test_param_2__value_YYY',
+                            tags={},
+                            tags_index={
+                                'speed': {'fast'},
+                                'color': {'orange'},
+                            }
+                        ),
+                    ]
+                )
+            ]
+        )
+    ]
+)
+
+
+@pytest.mark.parametrize(
+    'multitest_tags,expected_report',
+    (
+        ({}, report_for_multitest_without_tags),
+        (
+            {'color': 'orange', 'environment': 'server'},
+            report_for_multitest_with_tags
+        ),
+    )
+)
+def test_multitest_tagging(multitest_tags, expected_report):
 
     multitest = MultiTest(
-        name='MyMultitest', suites=[AlphaSuite(), BetaSuite()])
-
-    assert tagging.get_test_tags(multitest) == {
-        'color': frozenset({'blue', 'yellow', 'red', 'green'}),
-        'simple': frozenset({'bar', 'foo'})
-    }
-
-    assert tagging.get_suite_tags(AlphaSuite()) == {
-        'color': frozenset({'blue', 'red', 'green'}),
-        'simple': frozenset({'bar', 'foo'})
-    }
-
-    assert tagging.get_suite_tags(BetaSuite) == {
-        'color': frozenset({'yellow', 'red'}),
-        'simple': frozenset({'foo'})
-    }
+        name='MyMultitest',
+        suites=[AlphaSuite(), BetaSuite(), GammaSuite()],
+        tags=multitest_tags
+    )
 
     plan = Testplan(name='plan', parse_cmdline=False)
     plan.add(multitest)
 
-    plan.run()
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        plan.run()
 
-    test_report = plan.report
-    multitest_report = test_report[0]
-    suite_report_a, suite_report_b = multitest_report
-
-    assert test_report.tags_index == {
-        'color': frozenset({'green', 'red', 'blue', 'yellow'}),
-        'simple': frozenset({'foo', 'bar'})
-    }
-
-    assert suite_report_a.tags == {'color': frozenset({'red', 'blue'})}
-    assert suite_report_a.tags_index == {
-        'color': frozenset({'red', 'blue', 'green'}),
-        'simple': frozenset({'foo', 'bar'})
-    }
-
-    assert suite_report_b.tags == {'color': frozenset({'yellow'})}
-    assert suite_report_b.tags_index == {
-        'color': frozenset({'yellow', 'red'}),
-        'simple': frozenset({'foo'})
-    }
-
-    tc_report_a_0, tc_report_a_1, tc_report_a_2 = suite_report_a
-    tc_report_b_0, tc_report_b_1, tc_report_b_2 = suite_report_b
-
-    assert tc_report_a_0.tags == {}
-    assert tc_report_a_0.tags_index == {'color': frozenset({'red', 'blue'})}
-
-    assert tc_report_a_1.tags == {'simple': frozenset({'foo', 'bar'})}
-    assert tc_report_a_1.tags_index == {
-        'simple': frozenset({'foo', 'bar'}),
-        'color': frozenset({'red', 'blue'})
-    }
-
-    assert tc_report_a_2.tags == {'color': frozenset({'green'})}
-    assert tc_report_a_2.tags_index == {
-        'color': frozenset({'red', 'blue', 'green'})
-    }
-
-    assert tc_report_b_0.tags == {}
-    assert tc_report_b_0.tags_index == {'color': frozenset({'yellow'})}
-
-    assert tc_report_b_1.tags == {'simple': frozenset({'foo'})}
-    assert tc_report_b_1.tags_index == {
-        'simple': frozenset({'foo'}),
-        'color': frozenset({'yellow'})
-    }
-
-    assert tc_report_b_2.tags == {'color': frozenset({'red'})}
-    assert tc_report_b_2.tags_index == {'color': frozenset({'yellow', 'red'})}
+    check_report(
+        expected=TestReport(
+            name='plan',
+            entries=[expected_report]
+        ),
+        actual=plan.report
+    )

--- a/test/unit/testplan/report/test_testing.py
+++ b/test/unit/testplan/report/test_testing.py
@@ -15,7 +15,10 @@ DummyReportGroup = functools.partial(BaseReportGroup, name='dummy')
 
 
 def test_report_status_precedent():
-    """`precedent` should return the value with the highest precedence (the lowest index)."""
+    """
+    `precedent` should return the value with the
+    highest precedence (the lowest index).
+    """
     rule = ['alpha', 'beta', 'gamma']
 
     assert 'alpha' == Status.precedent(['alpha', 'beta'], rule=rule)
@@ -63,7 +66,10 @@ class TestBaseReportGroup(object):
         (
             ([Status.ERROR, Status.FAILED, Status.PASSED], Status.ERROR),
             ([Status.FAILED, Status.PASSED], Status.FAILED),
-            ([Status.INCOMPLETE, Status.PASSED, Status.SKIPPED], Status.INCOMPLETE),
+            (
+                [Status.INCOMPLETE, Status.PASSED, Status.SKIPPED],
+                Status.INCOMPLETE
+            ),
             ([Status.SKIPPED, Status.PASSED], Status.PASSED),
             ([Status.INCOMPLETE, Status.FAILED], Status.FAILED),
         )
@@ -71,20 +77,30 @@ class TestBaseReportGroup(object):
     def test_status(self, statuses, expected):
         """Should return the precedent status from children."""
 
-        reports = [DummyStatusReport(uid=idx, status=status) for idx, status in enumerate(statuses)]
+        reports = [
+            DummyStatusReport(uid=idx, status=status)
+            for idx, status in enumerate(statuses)
+        ]
         group = DummyReportGroup(entries=reports)
         assert group.status == expected
 
     def test_status_no_entries(self):
-        """Should return Status.PASSED `status_override` is None and report has no entries."""
+        """
+        Should return Status.PASSED `status_override`
+        is None and report has no entries.
+        """
         group = DummyReportGroup()
 
         assert group.status_override is None
         assert group.status == Status.PASSED
 
     def test_status_override(self):
-        """`status_override` of a group should take precedence over child statuses."""
-        group = DummyReportGroup(entries=[DummyStatusReport(status=Status.FAILED)])
+        """
+        `status_override` of a group should take
+        precedence over child statuses.
+        """
+        group = DummyReportGroup(
+            entries=[DummyStatusReport(status=Status.FAILED)])
 
         assert group.status == Status.FAILED
 
@@ -93,7 +109,10 @@ class TestBaseReportGroup(object):
         assert group.status == Status.PASSED
 
     def test_merge(self):
-        """Should merge children and set `status_override` using `report.status_override` precedence."""
+        """
+        Should merge children and set `status_override`
+        using `report.status_override` precedence.
+        """
         report_orig = DummyReportGroup(uid=0)
         report_clone = DummyReportGroup(uid=0)
 
@@ -103,7 +122,8 @@ class TestBaseReportGroup(object):
 
         with mock.patch.object(report_orig, 'merge_children'):
             report_orig.merge(report_clone)
-            report_orig.merge_children.assert_called_once_with(report_clone, strict=True)
+            report_orig.merge_children.assert_called_once_with(
+                report_clone, strict=True)
             assert report_orig.status_override == report_clone.status_override
 
     def test_merge_children_not_strict(self):
@@ -113,7 +133,8 @@ class TestBaseReportGroup(object):
         """
         child_clone_1 = DummyReport(uid=1)
         child_clone_2 = DummyReport(uid=2)
-        parent_clone = DummyReportGroup(uid=0, entries=[child_clone_1, child_clone_2])
+        parent_clone = DummyReportGroup(
+            uid=0, entries=[child_clone_1, child_clone_2])
 
         child_orig_1 = DummyReport(uid=1)
         parent_orig = DummyReportGroup(uid=0, entries=[child_orig_1])
@@ -159,7 +180,10 @@ class TestTestCaseReport(object):
         )
     )
     def test_status_override(self, entries, status_override):
-        """TestCaseReport `status_override` should take precedence over `status` logic."""
+        """
+        TestCaseReport `status_override` should
+        take precedence over `status` logic.
+        """
         rep = TestCaseReport(name='foo', entries=entries)
         rep.status_override = status_override
         assert rep.status == status_override
@@ -188,8 +212,8 @@ class TestTestCaseReport(object):
 @pytest.fixture
 def dummy_test_plan_report():
 
-    tag_data_1 = {'tagname': frozenset(['tag1', 'tag2'])}
-    tag_data_2 = {'other_tagname': frozenset(['tag4', 'tag5'])}
+    tag_data_1 = {'tagname': {'tag1', 'tag2'}}
+    tag_data_2 = {'other_tagname': {'tag4', 'tag5'}}
     all_tag_data = dict(tag_data_1, **tag_data_2)
 
     tc_1 = TestCaseReport(

--- a/testplan/common/utils/callable.py
+++ b/testplan/common/utils/callable.py
@@ -5,7 +5,9 @@ import functools
 
 
 WRAPPER_ASSIGNMENTS = functools.WRAPPER_ASSIGNMENTS + (
-    'tags', 'wrapper_of',
+    '__tags__',
+    '__tags_index__',
+    'wrapper_of',
     'summarize',
     'summarize_num_passing',
     'summarize_num_failing'

--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -22,23 +22,23 @@ def default_runpath(entity):
 
 @contextlib.contextmanager
 def change_directory(directory):
-  """
-  A context manager that changes working directory and returns to original on
-  exit.
+    """
+    A context manager that changes working directory and returns to original on
+    exit.
 
-  :param directory: Directory to change into.
-  :type directory: ``str``
-  """
-  old_directory = os.getcwd()
-  os.chdir(directory)
-  if 'PWD' in os.environ:
-      os.environ['PWD'] = directory
-  try:
-      yield
-  finally:
-      os.chdir(old_directory)
-      if 'PWD' in os.environ:
-          os.environ['PWD'] = old_directory
+    :param directory: Directory to change into.
+    :type directory: ``str``
+    """
+    old_directory = os.getcwd()
+    os.chdir(directory)
+    if 'PWD' in os.environ:
+        os.environ['PWD'] = directory
+    try:
+        yield
+    finally:
+        os.chdir(old_directory)
+        if 'PWD' in os.environ:
+            os.environ['PWD'] = old_directory
 
 
 def makedirs(path):

--- a/testplan/common/utils/testing.py
+++ b/testplan/common/utils/testing.py
@@ -213,7 +213,24 @@ def check_report(expected, actual, skip=None):
         act_value = getattr(actual, attr)
 
         if isinstance(act_value, (list, dict, tuple)):
-            check_iterable(exp_value, act_value)
+            try:
+                check_iterable(exp_value, act_value)
+            except AssertionError as err:
+                msg = (
+                    'Report name: {report_name}{linesep}'
+                    'Attribute: {attr}{linesep}'
+                ).format(
+                    linesep=os.linesep,
+                    attr=attr,
+                    report_name=actual.name,
+                )
+                raise AssertionError(
+                    '{linesep}{report_msg}{error_msg}'.format(
+                        linesep=os.linesep,
+                        report_msg=msg,
+                        error_msg=err.msg
+                    )
+                )
         else:
             msg = 'Mismatch: "{}", `{}` != `{}`'.format(
                 attr, exp_value, act_value)

--- a/testplan/examples/Multitest/Tagging and Filtering/Basic Filters/test_plan_command_line.py
+++ b/testplan/examples/Multitest/Tagging and Filtering/Basic Filters/test_plan_command_line.py
@@ -2,7 +2,7 @@
 """
 This example shows:
 
-* How the test cases and test suites can be tagged.
+* How the tests, test cases and test suites can be tagged.
 
 * How tests / suites/ testcases can be filtered by
   patterns and tags via command line options.
@@ -128,7 +128,12 @@ class Gamma(object):
 )
 def main(plan):
 
-    multi_test_1 = MultiTest(name='Primary', suites=[Alpha(), Beta()])
+    multi_test_1 = MultiTest(
+        name='Primary',
+        suites=[Alpha(), Beta()],
+        tags={'color': 'white'}
+    )
+
     multi_test_2 = MultiTest(name='Secondary', suites=[Gamma()])
     plan.add(multi_test_1)
     plan.add(multi_test_2)

--- a/testplan/examples/Multitest/Tagging and Filtering/Basic Filters/test_plan_programmatic.py
+++ b/testplan/examples/Multitest/Tagging and Filtering/Basic Filters/test_plan_programmatic.py
@@ -2,7 +2,7 @@
 """
 This example shows:
 
-* How the test cases and test suites can be tagged.
+* How test instances (e.g. multitest), test cases and test suites can be tagged.
 
 * How tests / suites/ testcases can be filtered
   by patterns and tags programmatically.
@@ -17,7 +17,8 @@ from testplan.report.testing.styles import Style
 from testplan.testing.filtering import Filter, Pattern, Tags, TagsAll
 
 
-# A suite with no tags, will be filtered out if we apply any tag based filters
+# A suite with no tags, can still inherit tag data
+# if it is added to a multitest with tags.
 @testsuite
 class Alpha(object):
 
@@ -107,9 +108,17 @@ tag_filter_4 = Tags({'simple': 'server', 'color': ('red', 'blue')})
 # Multi tag filtering, run all testcases tagged with `server` AND `client`.
 tag_filter_5 = TagsAll(('server', 'client'))
 
+# Run all tests that are tagged with `color` = `white`.
+# None of the suite classes and their testcases have such tag,
+# however in the plan declaration below we use a multitest level tag
+# for `multi_test_1`, which propagates `color` = `white` to the instances of
+# Alpha and Beta suites (and to their testcases). This only affects the
+# instances of the suites and the original classes' tag indices
+# remain unchanged.
+tag_filter_6 = Tags({'color': 'white'})
+
 # Replace the `test_filter` argument with the
 # filters declared above to see how they work.
-
 @test_plan(
     name='Tagging & Filtering (Programmatic)',
     test_filter=default_filter,
@@ -118,7 +127,11 @@ tag_filter_5 = TagsAll(('server', 'client'))
 )
 def main(plan):
 
-    multi_test_1 = MultiTest(name='Primary', suites=[Alpha(), Beta()])
+    multi_test_1 = MultiTest(
+        name='Primary',
+        suites=[Alpha(), Beta()],
+        tags={'color': 'white'}
+    )
     multi_test_2 = MultiTest(name='Secondary', suites=[Gamma()])
     plan.add(multi_test_1)
     plan.add(multi_test_2)

--- a/testplan/exporters/testing/base.py
+++ b/testplan/exporters/testing/base.py
@@ -25,13 +25,13 @@ class TagFilteredExporterConfig(ExporterConfig):
 
 class TagFilteredExporter(Exporter):
     """
-        This is a meta exporter that generates tag filtered clones
-        of the original test report and calls `export` operation on a new
-        instance of `exporter_class`.
+    This is a meta exporter that generates tag filtered clones
+    of the original test report and calls `export` operation on a new
+    instance of `exporter_class`.
 
-        Basically multiple sub-export operations will be
-        run for each generated clone report, however if the clone report
-        is empty the export operation will be skipped.
+    Basically multiple sub-export operations will be
+    run for each generated clone report, however if the clone report
+    is empty the export operation will be skipped.
     """
     ALL = 'all'
     ANY = 'any'
@@ -46,7 +46,9 @@ class TagFilteredExporter(Exporter):
         should be valid arguments in line with `exporter_class`'s config.
 
         :param tag_dict: Tag context for the current sub-export operation.
+        :type tag_dict: ``dict`` of ``set``
         :param filter_type: all / any
+        :type filter_type: ``str``
         :return: dict of keyword arguments
         """
         return {}
@@ -69,40 +71,37 @@ class TagFilteredExporter(Exporter):
 
     def get_filtered_source(self, source, tag_dict, filter_type):
         """
-            Create a clone of the original report and
-            filter it with the given filter type & tag context.
+        Create a clone of the original report and
+        filter it with the given filter type & tag context.
 
-            Also populate cloned report's meta
-            attribute with the tag label.
+        Also populate cloned report's meta
+        attribute with the tag label.
+
+        :param source: Original test report.
+        :type source: :py:class:`~testplan.report.testing.base.TestReport`
+        :param tag_dict: Tag context for the current filtered test report.
+        :type tag_dict: ``dict`` of ``set``
+        :param filter_type: all / any
+        :type filter_type: ``str``
         """
-
-        if filter_type == self.ANY:
-            filter_func = tagging.check_any_matching_tags
-        elif filter_type == self.ALL:
-            filter_func = tagging.check_all_matching_tags
-        else:
-            raise ValueError('Invalid filter_type: `{}`'.format(filter_type))
-
-        def _tag_filter(obj):
-            # Check against denormalized tag data
-            if not hasattr(obj, 'tags_index'):
-                return True  # include everything that doesn't have tags
-
-            return filter_func(
-                tag_arg_dict=tag_dict,
-                target_tag_dict=obj.tags_index)
-
-        result = source.filter(_tag_filter)
         tag_label = tagging.tag_label(tag_dict)
+        result = source.filter_by_tags(
+            tag_dict,
+            all_tags=filter_type == self.ALL
+        )
         result.meta['report_tags_{}'.format(filter_type)] = tag_label
         return result
 
     def get_skip_message(self, source, tag_dict, filter_type):
         """
         :param source: Cloned test report.
+        :type source: :py:class:`~testplan.report.testing.base.TestReport`
         :param tag_dict: Tag context for the current filtered test report.
+        :type tag_dict: ``dict`` of ``set``
         :param filter_type: all / any
+        :type filter_type: ``str``
         :return: String message to be displayed on skipped export operations.
+        :rtype: ``str``
         """
         return (
             'Empty report for tags: `{tag_label}`, filter_type:'
@@ -119,16 +118,21 @@ class TagFilteredExporter(Exporter):
         operation, if the clone report is not empty.
 
         :param source: Original test report.
+        :type source: :py:class:`~testplan.report.testing.base.TestReport`
         :param tag_dicts: List of tag dictionaries, a new export operation
                           will be run for each dict in the list.
+        :type tag_dicts: ``list`` of ``dict``
         :param filter_type: all / any, will be used for tag filtering strategy.
+        :type filter_type: ``str``
         :return: None
         """
+        if filter_type not in [self.ALL, self.ANY]:
+            raise ValueError('Invalid filter type: {}'.format(filter_type))
 
         for tag_dict in tag_dicts:
             clone = self.get_filtered_source(source, tag_dict, filter_type)
 
-            if clone:
+            if clone is not None:
                 params = self.get_params(tag_dict, filter_type)
                 exporter = self.get_exporter(**params)
                 exporter.export(clone)
@@ -146,6 +150,7 @@ class TagFilteredExporter(Exporter):
         Run export operation for exact (all) and any matching tag groups.
 
         :param source: Test report.
+        :type source: :py:class:`~testplan.report.testing.base.TestReport`
         :return: None
         """
         self.export_clones(

--- a/testplan/exporters/testing/base.py
+++ b/testplan/exporters/testing/base.py
@@ -87,6 +87,7 @@ class TagFilteredExporter(Exporter):
             # Check against denormalized tag data
             if not hasattr(obj, 'tags_index'):
                 return True  # include everything that doesn't have tags
+
             return filter_func(
                 tag_arg_dict=tag_dict,
                 target_tag_dict=obj.tags_index)

--- a/testplan/exporters/testing/pdf/__init__.py
+++ b/testplan/exporters/testing/pdf/__init__.py
@@ -61,8 +61,8 @@ def generate_path_for_tags(config, tag_dict, filter_type):
       >>> generate_pdf_path(
       ...   filter_type='all',
       ...   tag_arg_dict={
-      ...     'simple': frozenset(['foo', 'bar']),
-      ...     'hello': frozenset(['world', 'mars'])
+      ...     'simple': {'foo', 'bar'},
+      ...     'hello': {'world', 'mars'}
       ...   }
       ... )
 

--- a/testplan/report/testing/parser.py
+++ b/testplan/report/testing/parser.py
@@ -4,7 +4,7 @@ import argparse
 class ReportTagsAction(argparse.Action):
     """
         Argparse action for parsing multiple report tag
-        arguments, builds up a list of dictionary of frozensets.
+        arguments, builds up a list of dictionary of sets.
 
         In:
             --report-tags foo bar hello=world --report-tags one two color=red
@@ -13,12 +13,12 @@ class ReportTagsAction(argparse.Action):
 
             [
                 {
-                    'simple': frozenset(['foo', 'bar']),
-                    'hello': frozenset(['world'])
+                    'simple': {'foo', 'bar'},
+                    'hello': {'world'}
                 },
                 {
-                    'simple': frozenset(['one', 'two']),
-                    'color': frozenset(['red']),
+                    'simple': {'one', 'two'},
+                    'color': {'red'},
                 }
             ]
     """

--- a/testplan/report/testing/schemas.py
+++ b/testplan/report/testing/schemas.py
@@ -33,7 +33,7 @@ class IntervalSchema(Schema):
 
 
 class TagField(fields.Field):
-    """Field for serializing tag data, which is a ``dict`` of ``frozenset``."""
+    """Field for serializing tag data, which is a ``dict`` of ``set``."""
 
     def _serialize(self, value, attr, obj):
         return {
@@ -43,7 +43,7 @@ class TagField(fields.Field):
 
     def _deserialize(self, value, attr, data):
         return {
-            tag_name: frozenset(tag_values)
+            tag_name: set(tag_values)
             for tag_name, tag_values in value.items()
         }
 

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -212,6 +212,15 @@ class Test(Runnable):
                     )
                 )
 
+    def propagate_tag_indices(self):
+        """
+        Basic step for propagating tag indices of the test report tree.
+        This step may be necessary if the report
+        tree is created in parts and then added up.
+        """
+        if len(self.report):
+            self.report.propagate_tag_indices()
+
 
 class ProcessRunnerTestConfig(TestConfig):
     """
@@ -481,6 +490,7 @@ class ProcessRunnerTest(Test):
     def main_batch_steps(self):
         self._add_step(self.run_tests)
         self._add_step(self.update_test_report)
+        self._add_step(self.propagate_tag_indices)
         self._add_step(self.log_test_results)
 
     def aborting(self):

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -9,7 +9,7 @@ from schema import Or, Use
 from testplan import defaults
 from testplan.common.config import ConfigOption
 
-from testplan.testing import filtering, ordering
+from testplan.testing import filtering, ordering, tagging
 
 from testplan.common.entity import Runnable, RunnableResult, RunnableConfig
 from testplan.common.utils.process import subprocess_popen
@@ -42,7 +42,11 @@ class TestConfig(RunnableConfig):
             ConfigOption(
                 'stdout_style',
                 default=defaults.STDOUT_STYLE
-            ): test_styles.Style
+            ): test_styles.Style,
+            ConfigOption(
+                'tags',
+                default=None
+            ): Or(None, Use(tagging.validate_tag_value))
         }
         return self.inherit_schema(overrides, super(TestConfig, self))
 
@@ -90,11 +94,29 @@ class Test(Runnable):
     filter_levels = [filtering.FilterLevel.TEST]
 
     def __init__(self, **options):
-        self._test_context = None
         super(Test, self).__init__(**options)
+
+        self._test_context = None
+        self.result.report = TestGroupReport(
+            name=self.cfg.name,
+            category=self.__class__.__name__.lower(),
+            description=self.cfg.description,
+            tags=self.cfg.tags,
+            tags_index=self.get_tags_index(),
+        )
 
     def __str__(self):
         return '{}[{}]'.format(self.__class__.__name__, self.name)
+
+    def get_tags_index(self):
+        """
+        Return the tag index that will be used for filtering.
+        By default this is equal to the native tags for this object.
+
+        However subclasses may build larger tag indices
+        by collecting tags from their children for example.
+        """
+        return self.cfg.tags
 
     def get_filter_levels(self):
         if not self.filter_levels:
@@ -253,15 +275,9 @@ class ProcessRunnerTest(Test):
 
         self._test_context = None
         self._test_process = None  # will be set by `self.run_tests`
-        self._test_process_retcode = None # will be set by `self.run_tests`
+        self._test_process_retcode = None  # will be set by `self.run_tests`
         self._test_process_killed = False
         self._test_has_run = False
-
-        self.result.report = TestGroupReport(
-            name=self.cfg.name,
-            category=self.__class__.__name__,
-            description=self.cfg.description,
-        )
 
     @property
     def stderr(self):

--- a/testplan/testing/filtering.py
+++ b/testplan/testing/filtering.py
@@ -1,6 +1,7 @@
 """Filtering logic for Multitest, Suites and testcase methods (of Suites)"""
 import argparse
 import collections
+import operator
 import fnmatch
 
 from enum import Enum, unique
@@ -210,15 +211,16 @@ class BaseTagFilter(Filter):
 
     def filter_test(self, test):
         return self._check_tags(
-            obj=test, tag_getter=tagging.get_test_tags)
+            obj=test,
+            tag_getter=operator.methodcaller('get_tags_index'))
 
     def filter_suite(self, suite):
         return self._check_tags(
-            obj=suite, tag_getter=tagging.get_suite_tags)
+            obj=suite, tag_getter=operator.attrgetter('__tags_index__'))
 
     def filter_case(self, case):
         return self._check_tags(
-            obj=case, tag_getter=tagging.get_testcase_tags)
+            obj=case, tag_getter=operator.attrgetter('__tags_index__'))
 
 
 class Tags(BaseTagFilter):
@@ -325,12 +327,12 @@ class TagsAction(argparse.Action):
 
         [
             Tags({
-                'simple': frozenset({'foo', 'bar'}),
-                'hello': frozenset({'world'}),
+                'simple': {'foo', 'bar'},
+                'hello': {'world'},
             }),
             Tags({
-                'simple': frozenset({'baz'}),
-                'hello': frozenset({'mars'}),
+                'simple': {'baz'},
+                'hello': {'mars'},
             })
         ]
     """
@@ -355,12 +357,12 @@ class TagsAllAction(TagsAction):
 
         [
             TagsAll({
-                'simple': frozenset({'foo', 'bar'}),
-                'hello': frozenset({'world'}),
+                'simple': {'foo', 'bar'},
+                'hello': {'world'},
             }),
             TagsAll({
-                'simple': frozenset({'baz'}),
-                'hello': frozenset({'mars'}),
+                'simple': {'baz'},
+                'hello': {'mars'},
             })
         ]
     """
@@ -385,8 +387,8 @@ def parse_filter_args(parsed_args, arg_names):
         And(
             Pattern('my_pattern'),
             Or(
-                Tags({'simple': frozenset({'foo'})),
-                TagsAll({'simple': frozenset({'bar', 'baz'})),
+                Tags({'simple': {'foo'}}),
+                TagsAll({'simple': {'bar', 'baz'}}),
             )
         )
     """

--- a/testplan/testing/listing.py
+++ b/testplan/testing/listing.py
@@ -106,29 +106,28 @@ class ExpandedPatternLister(ExpandedNameLister):
     def format_instance(self, instance):
         return instance.name
 
+    def apply_tag_label(self, pattern, obj):
+        if obj.__tags__:
+            return '{}  --tags {}'.format(
+                pattern, tagging.tag_label(obj.__tags__))
+        return pattern
+
     def format_suite(self, instance, suite):
 
         if not isinstance(instance, MultiTest):
             return '{}:{}'.format(instance.name, suite)
 
         pattern = '{}:{}'.format(instance.name, suite.__class__.__name__)
-        tag_label = tagging.tag_label(
-            tagging.get_native_suite_tags(suite))
-        if tag_label:
-            return '{}  --tags {}'.format(pattern, tag_label)
-        return pattern
+        return self.apply_tag_label(pattern, suite)
 
     def format_testcase(self, instance, suite, testcase):
+
         if not isinstance(instance, MultiTest):
             return '{}:{}:{}'.format(instance.name, suite, testcase)
 
         pattern = '{}:{}:{}'.format(
             instance.name, suite.__class__.__name__, testcase.__name__)
-        tag_label = tagging.tag_label(
-            tagging.get_native_testcase_tags(testcase))
-        if tag_label:
-            return '{}  --tags {}'.format(pattern, tag_label)
-        return pattern
+        return self.apply_tag_label(pattern, testcase)
 
 
 class TrimMixin(object):

--- a/testplan/testing/tagging.py
+++ b/testplan/testing/tagging.py
@@ -3,7 +3,6 @@
 import re
 import six
 import argparse
-import warnings
 import functools
 import collections
 

--- a/testplan/testing/tagging.py
+++ b/testplan/testing/tagging.py
@@ -1,4 +1,4 @@
-"""TODO."""
+"""Generic Tagging logic."""
 
 import re
 import six
@@ -45,11 +45,6 @@ TAG_VALUE_UNMATCH_MSG = TAG_UNMATCH_TEMPLATE.format(attr_name='value')
 TAG_NAME_UNMATCH_MSG = TAG_UNMATCH_TEMPLATE.format(attr_name='name')
 
 
-def _prevent_tag_reassignment(obj, attr_name):
-    if hasattr(obj, attr_name):
-        raise AttributeError('{} already has tags set.'.format(obj))
-
-
 def _validate_string(value, regex, error_msg):
     if not isinstance(value, six.string_types):
         raise ValueError(
@@ -72,20 +67,27 @@ def validate_tag_value(tag_value):
     Validate a tag value, make sure it is of correct type.
     Return a tag dict for internal representation.
 
+    Sample input / output:
+
+    'foo' -> {'simple': {'foo'}
+    ('foo', 'bar') -> {'simple': {'foo', 'bar'}
+    {'color': 'red'} -> {'color': {'red'}
+    {'color': ('red', 'blue')} -> {'color': {'red', 'blue'}
+
     :param tag_value: User defined tag value.
     :type tag_value: ``string``, ``iterable`` of ``string`` or
                      a ``dict`` with ``string`` keys
                      and ``string`` or ``iterable`` of ``strings`` as values.
 
     :return: Internal representation of the tag context.
-    :rtype: ``dict`` of ``frozenset``
+    :rtype: ``dict`` of ``set``
     """
     def validate_value(value):
         """Make sure tag value is either a string or an iterable of strings."""
         if isinstance(value, six.string_types):
-            return frozenset([_validate_tag_value_string(value)])
+            return {_validate_tag_value_string(value)}
         elif isinstance(value, collections.Iterable):
-            return frozenset([_validate_tag_value_string(tag) for tag in value])
+            return {_validate_tag_value_string(tag) for tag in value}
         raise ValueError((
             'Invalid tag value: "{}", only strings, an iterable'
             ' of strings or dictionaries are allowed.'.format(value)))
@@ -98,139 +100,11 @@ def validate_tag_value(tag_value):
 
 def merge_tag_dicts(*tag_dicts):
     """Utility function for merging tag dicts for easy comparisons."""
-    result = collections.defaultdict(frozenset)
+    result = collections.defaultdict(set)
     for tag_dict in tag_dicts:
         for tag_name, tags_set in tag_dict.items():
             result[tag_name] = result[tag_name] | tags_set
     return dict(result)
-
-
-def get_native_testcase_tags(test_case):
-    """Return tags that are explicitly assigned to a test case method."""
-    return getattr(test_case, 'tags', {})
-
-
-def get_native_suite_tags(suite):
-    """Return tags that are explicitly assigned to a suite."""
-    return getattr(suite, '__TAGS__', {})
-
-
-def get_native_test_tags(test):
-    """Return tags that are explicitly assigned to a test."""
-    # Test instances don't have native tag support yet
-    # When we add support for this, get_test_tags,
-    # get_testcase_tags and get_suite_tags should also change.
-    return getattr(test, 'tags', {})
-
-
-def get_testcase_tags(test_case):
-    """A suite's tag also apply to a test case method."""
-    suite = test_case.im_class if six.PY2 else test_case.__self__.__class__
-    return merge_tag_dicts(
-        get_native_suite_tags(suite),
-        get_native_testcase_tags(test_case))
-
-
-def get_suite_tags(suite):
-    """Get all tag data from a suite, including merged testcase tags."""
-    tag_dicts = [get_native_suite_tags(suite)]
-    if hasattr(suite, 'get_testcase_methods'):
-        tag_dicts.extend([method.tags
-                          for _, method in suite.get_testcase_methods().items()
-                          if hasattr(method, 'tags')])
-    return merge_tag_dicts(*tag_dicts)
-
-
-def get_test_tags(test):
-    """Get all tag data from a test, including merged suite tags."""
-    # Currently only MultiTest has support for tag filtering
-
-    from testplan.testing.multitest import MultiTest
-    if not isinstance(test, MultiTest):
-        return {}
-
-    return merge_tag_dicts(*[get_suite_tags(suite) for suite in test.suites])
-
-
-def _check_duplicate_tag_names(suite):
-    """
-    Display warning if suite level tags are duplicates of method level
-    tags and vice versa.
-    """
-
-    suite_level_tags = get_native_testcase_tags(suite)
-    if suite_level_tags and hasattr(suite, 'get_testcase_methods'):
-        for tname, tmethod in suite.get_testcase_methods().items():
-            if hasattr(tmethod, 'tags'):
-                intersects = {
-                    tag_name: tags & tmethod.tags.get(tag_name, frozenset())
-                    for tag_name, tags in suite_level_tags.items()
-                    }
-                duplicates = {k: v for k, v in intersects.items() if v}
-
-                for tag_name, dupes in duplicates.items():
-                    tag_template = '{dupes}'\
-                        if tag_name == SIMPLE else '{tag_name} = {dupes}'
-                    msg = ('Duplicate tags found, Suite: {testsuite},'
-                           ' Method: {testsuite}.{method_name}, Tags: "%s".'
-                           ' Re-assigning suite level tags to testcases is a '
-                           'redundant operation.' % tag_template)
-                    msg = msg.format(
-                        tag_name=tag_name, dupes=', '.join(dupes),
-                        testsuite=suite.__name__, method_name=tname)
-                    warnings.warn(msg)
-
-
-def _check_duplicate_tag_values(tag_target, tag_dict):
-    """
-    Display warning if the user assigns same tag value for
-    different groups (which may cause confusion).
-
-    e.g. @testcase(tags={tag_name_1='foo', tag_name_2='foo'})
-    """
-    tag_dict_reversed = collections.defaultdict(set)
-    for tag_name, tag_values in tag_dict.items():
-        for value in tag_values:
-            tag_dict_reversed[value].add(tag_name)
-
-    dupes = {
-        tag_value: tag_names
-        for tag_value, tag_names in tag_dict_reversed.items()
-        if len(tag_names) > 1
-        }
-
-    for tag_value, tag_names in dupes.items():
-        msg = (
-            '{tag_target}: Duplicate tag value ("{tag_value}") is being used '
-            'for different tag names ("{tag_names}").'
-        ).format(
-            tag_target=tag_target,
-            tag_value=tag_value,
-            tag_names=', '.join(tag_names))
-        warnings.warn(msg)
-
-
-def attach_testcase_tags(test_case, tag_value):
-    """Assign a tag dict to a method."""
-    tag_dict = validate_tag_value(tag_value)
-    _prevent_tag_reassignment(test_case, 'tags')
-    _check_duplicate_tag_values(test_case, tag_dict)
-    test_case.tags = tag_dict
-    return test_case
-
-
-def attach_suite_tags(suite, tag_value):
-    """
-    Assign a tag dict to a testsuite class, display warnings
-    if testsuite level tags match method level tags.
-    """
-    tag_dict = validate_tag_value(tag_value)
-    _prevent_tag_reassignment(suite, '__TAGS__')
-    suite.__TAGS__ = tag_dict
-
-    _check_duplicate_tag_values(suite, tag_dict)
-    _check_duplicate_tag_names(suite)
-    return suite
 
 
 def tag_label(tag_dict):
@@ -269,7 +143,7 @@ def tag_label(tag_dict):
 
 def parse_tag_arguments(*tag_arguments):
     """
-    Parse command line tag arguments into a dictionary of frozensets.
+    Parse command line tag arguments into a dictionary of sets.
 
     For the call below:
 
@@ -280,11 +154,11 @@ def parse_tag_arguments(*tag_arguments):
     .. code-block:: python
 
       [
-        {'simple': frozenset(['foo'])},
-        {'simple', frozenset(['bar'])},
-        {'named_tag', frozenset(['one', 'two'])},
-        {'named_tag', frozenset(['three'])},
-        {'hello', frozenset(['world'])}
+        {'simple': {'foo'},
+        {'simple', {'bar'},
+        {'named_tag', {'one', 'two'},
+        {'named_tag', {'three'},
+        {'hello', {'world'}
       ]
 
     The repeated tag values will later on be grouped together via TagsAction.
@@ -294,12 +168,11 @@ def parse_tag_arguments(*tag_arguments):
         named_match = NAMED_TAG_REGEX.match(tag_argument)
 
         if simple_match:
-            return {SIMPLE: frozenset([simple_match.group('tag').strip()])}
+            return {SIMPLE: {simple_match.group('tag').strip()}}
         elif named_match:
             tagname = named_match.group('tag_name')
             tags = named_match.group('tags').split(',')
-            return {tagname.replace('-', '_'): frozenset([tag.strip()
-                                                          for tag in tags])}
+            return {tagname.replace('-', '_'): {tag.strip() for tag in tags}}
         else:
             raise argparse.ArgumentTypeError(
                 ('Invalid tag argument: "{}", Please use tag argument '
@@ -311,7 +184,7 @@ def parse_tag_arguments(*tag_arguments):
 
 def check_any_matching_tags(tag_arg_dict, target_tag_dict):
     """Return true if there is at least one match for a category."""
-    return any([bool(tags_set & target_tag_dict.get(tag_name, frozenset()))
+    return any([bool(tags_set & target_tag_dict.get(tag_name, set()))
                 for tag_name, tags_set in tag_arg_dict.items()])
 
 
@@ -320,61 +193,5 @@ def check_all_matching_tags(tag_arg_dict, target_tag_dict):
     Return True if all tag sets in `tag_arg_dict` is a subset of the
     matching categories in `target_tag_dict`.
     """
-    return all([tags_set.issubset(target_tag_dict.get(tag_name, frozenset()))
+    return all([tags_set.issubset(target_tag_dict.get(tag_name, set()))
                 for tag_name, tags_set in tag_arg_dict.items()])
-
-
-def _matcher(tag_getter, tag_arg_dict, match_func):
-    """Match function builder"""
-    def _match(obj):
-        return match_func(
-            target_tag_dict=tag_getter(obj),
-            tag_arg_dict=tag_arg_dict)
-    return _match
-
-
-class TagsAction(argparse.Action):
-    """
-    Returns 3 filter functions:
-      - test filter -> Applied at test class level (e.g. ``MultiTest``)
-      - suite filter -> Applied to a suite class
-                       (e.g. decorated with ``@testsuite``)
-      - testcase filter -> Applied to a testcase method of a suite
-                          (e.g. decorated with ``@testcase``)
-
-    A test will run only if all filter functions return True for their target.
-    """
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        # Merge tag values for the same tag names
-        matcher = functools.partial(
-            _matcher,
-            tag_arg_dict=merge_tag_dicts(*values),
-            match_func=self._get_match_function())
-
-        test_matcher = matcher(tag_getter=get_test_tags)
-        suite_matcher = matcher(tag_getter=get_suite_tags)
-        testcase_matcher = matcher(tag_getter=get_testcase_tags)
-
-        values = (test_matcher, suite_matcher, testcase_matcher)
-        setattr(namespace, self.dest, values)
-
-    def _get_match_function(self):  # pylint: disable=no-self-use
-        return check_any_matching_tags
-
-
-class TagsAllAction(TagsAction):
-    """
-    Similar to TagsAction, however ALL tags should match
-    instead of at least one.
-    """
-
-    def _get_match_function(self):  # pylint: disable=no-self-use
-        return check_all_matching_tags
-
-
-class TempTagsAction(argparse.Action):
-    """Temporary replacement for TagsAction & TagsAllAction"""
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, merge_tag_dicts(*values))


### PR DESCRIPTION
-  Logic for adding top (e.g. GTest, MultiTest) level tagging support to tests. 
- Tag data is now stored as dictionary of sets, instead of frozensets. We can afford to be more permissive as now it's possible to propagate tag indices via utility methods on the test reports.
- We now store native tags and denormalized tag indices on the suites / testcases separately.