### PR TITLE
Multitest update re. pre/post start/stop functions

### DIFF
--- a/testplan/common/config/base.py
+++ b/testplan/common/config/base.py
@@ -13,9 +13,9 @@ from testplan.common.utils.interface import check_signature
 ABSENT = Optional._MARKER
 
 
-def validate_func(args_list):
+def validate_func(*arg_names):
     """Validate given function signature."""
-    return lambda x: callable(x) and check_signature(x, args_list)
+    return lambda x: callable(x) and check_signature(x, list(arg_names))
 
 
 class DefaultValueWrapper(object):

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -401,7 +401,7 @@ class Pool(Executor):
         :return: True if Task should be rescheduled else False.
         :rtype: ``bool``
         """
-        validate_func(['pool', 'task_result'])(check_reschedule)
+        validate_func('pool', 'task_result')(check_reschedule)
         self.should_reschedule = check_reschedule
 
     def _loop(self):


### PR DESCRIPTION
* `before_start`, `after_start`.  `before_stop`, `after_stop`
  functions can now either accept single `env` argument or
  both `env` and `result` arguments. Within these functions
  it is now possible to apply assertion logic via `result` object.

* Added new utility wrapper method for running pre/post start/stop
  functions exception tracebacks are also recorded on the test report.