### PR TITLE
Exporter & test runner updates

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -879,7 +879,7 @@ in the ``parameters`` tuple below:
       #  is not that readable.
       @testcase(parameters=(2, 4, 6, 8))
       def is_even(self, env, result, value):
-          result.equal(value % 2)(0)
+          result.equal(value % 2, 0)
 
 
 .. _parametrization_combinatorial:
@@ -972,7 +972,7 @@ method has default values assigned to the parametrized arguments:
             {'a': 10, 'expected': 15},  # b=5
         ))
         def addition(self, env, result, a, b=5, expected=10):
-            result.equal(expected)(a + b)
+            result.equal(expected, a + b)
 
 
 .. _parametrization_custom_name_func:

--- a/test/functional/exporters/testing/test_xml.py
+++ b/test/functional/exporters/testing/test_xml.py
@@ -82,8 +82,6 @@ def test_xml_exporter(tmpdir):
                         name='test_membership',
                         time=re.compile('\d+\.?\d*')
                     ),
-                    XC(tag='system-out'),
-                    XC(tag='system-err')
                 ]
             ),
         ]
@@ -127,8 +125,6 @@ def test_xml_exporter(tmpdir):
                             )
                         ]
                     ),
-                    XC(tag='system-out'),
-                    XC(tag='system-err')
                 ]
             )
         ]

--- a/test/functional/testplan/testing/fixtures/base/failing/report.py
+++ b/test/functional/testplan/testing/fixtures/base/failing/report.py
@@ -1,23 +1,37 @@
 import re
-from testplan.report.testing import TestReport, TestGroupReport, Status
 
-my_test_report = TestGroupReport(
-    name='MyTest',
-    category='dummytest',
-    entries=[],
+from testplan.report.testing import (
+  TestReport, TestGroupReport,
+  TestCaseReport, Status
 )
 
-my_test_report.status_override = Status.ERROR
+testcase_report = TestCaseReport(
+    name='failure',
+    entries=[
+        {
+            'type': 'RawAssertion',
+            'description': 'Process failure details',
+            # 'content': ''
+        }
+    ]
+)
 
-my_test_report.logs = [
-    {'message': re.compile(
-        r'RuntimeError: Test process of'
-        r' DummyTest\[MyTest\] exited with nonzero status: 5\.')
-    }
-]
+testcase_report.status_override = Status.ERROR
+
 
 expected_report = TestReport(
     name='plan',
-    entries=[my_test_report]
+    entries=[
+        TestGroupReport(
+            name='MyTest',
+            category='dummytest',
+            entries=[
+                TestGroupReport(
+                    name='ProcessFailure',
+                    category='suite',
+                    entries=[testcase_report]
+                )
+            ]
+        )
+    ]
 )
-

--- a/test/functional/testplan/testing/fixtures/base/sleeping/report.py
+++ b/test/functional/testplan/testing/fixtures/base/sleeping/report.py
@@ -1,10 +1,34 @@
 import re
-from testplan.report.testing import TestReport, TestGroupReport, Status
+
+from testplan.report.testing import (
+  TestReport, TestGroupReport,
+  TestCaseReport, Status
+)
+
+testcase_report = TestCaseReport(
+    name='failure',
+    entries=[
+        {
+            'type': 'RawAssertion',
+            'description': 'Process failure details',
+            # 'content': ''
+        }
+    ]
+)
+
+testcase_report.status_override = Status.ERROR
+
 
 my_test_report = TestGroupReport(
     name='MyTest',
     category='dummytest',
-    entries=[],
+    entries=[
+        TestGroupReport(
+            name='ProcessFailure',
+            category='suite',
+            entries=[testcase_report]
+        )
+    ],
 )
 
 my_test_report.logs = [
@@ -13,10 +37,11 @@ my_test_report.logs = [
         r" running DummyTest\[MyTest\] after 1 seconds\.")}
 ]
 
+
 my_test_report.status_override = Status.ERROR
+
 
 expected_report = TestReport(
     name='plan',
     entries=[my_test_report]
 )
-

--- a/test/functional/testplan/testing/multitest/test_parametrization.py
+++ b/test/functional/testplan/testing/multitest/test_parametrization.py
@@ -429,7 +429,7 @@ def test_docstring_func(docstring_func, expected_docstring):
 
         @testcase(
             parameters=(
-                    ('foo', 'bar'),
+                ('foo', 'bar'),
             ),
             name_func=lambda func_name, kwargs: 'dummy_name',
             docstring_func=docstring_func,
@@ -457,11 +457,6 @@ def test_parametrization_tagging():
         )
         def dummy_test(self, env, result, color):
             pass
-
-    all_tags_index = {
-        'simple': {'foo', 'alpha'},
-        'color': {'red', 'blue', 'green'}
-    }
 
     parametrization_group = TestGroupReport(
         name='dummy_test',

--- a/test/functional/testplan/testing/multitest/test_pre_post_steps.py
+++ b/test/functional/testplan/testing/multitest/test_pre_post_steps.py
@@ -1,0 +1,95 @@
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+from testplan.testing.multitest.base import Categories
+
+from testplan import Testplan
+from testplan.common.utils.testing import (
+    check_report, log_propagation_disabled
+)
+from testplan.report.testing import TestReport, TestGroupReport, TestCaseReport
+from testplan.logger import TESTPLAN_LOGGER
+
+
+@testsuite
+class MySuite(object):
+
+    @testcase
+    def test_one(self, env, result):
+        pass
+
+
+def check_func_1(env, result):
+    result.equal(1, 1, description='sample assertion')
+
+
+def check_func_2(env):
+    pass
+
+
+def check_func_3(env):
+    pass
+
+
+def check_func_4(env, result):
+    result.equal(1, 2, description='failing assertion')
+
+
+expected_report = TestReport(
+    name='plan',
+    entries=[
+        TestGroupReport(
+            name='MyMultitest',
+            category=Categories.MULTITEST,
+            entries=[
+                TestGroupReport(
+                    name='MySuite',
+                    category=Categories.SUITE,
+                    entries=[
+                        TestCaseReport(name='test_one')
+                    ]
+                ),
+                TestGroupReport(
+                    name='Pre/Post Step Checks',
+                    category=Categories.SUITE,
+                    entries=[
+                        TestCaseReport(
+                            name='before_start - check_func_1',
+                            entries=[{
+                                'type': 'Equal',
+                                'passed': True,
+                            }]
+                        ),
+                        TestCaseReport(name='after_start - check_func_2'),
+                        TestCaseReport(name='before_stop - check_func_3'),
+                        TestCaseReport(
+                            name='after_stop - check_func_4',
+                            entries=[{
+                                'type': 'Equal',
+                                'passed': False
+                            }]
+                        ),
+                    ]
+                )
+            ]
+        )
+    ]
+)
+
+
+def test_pre_post_steps():
+
+    multitest = MultiTest(
+        name='MyMultitest',
+        suites=[MySuite()],
+        before_start=check_func_1,
+        after_start=check_func_2,
+        before_stop=check_func_3,
+        after_stop=check_func_4
+    )
+
+    plan = Testplan(name='plan', parse_cmdline=False)
+    plan.add(multitest)
+
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        plan.run()
+
+    check_report(expected_report, plan.report)

--- a/testplan/common/utils/process.py
+++ b/testplan/common/utils/process.py
@@ -50,7 +50,7 @@ def kill_process(proc, timeout=5, signal_=None, output=None):
         try:
             child.send_signal(signal.SIGTERM)
         except Exception as exc:
-            _log (
+            _log(
                 msg='While terminating child proc - {}'.format(exc),
                 warn=True
             )
@@ -119,7 +119,7 @@ def subprocess_popen(
 
 
 def enforce_timeout(process, timeout=1, callback=None, output=None):
-    _log= functools.partial(_log_proc, output=output)
+    _log = functools.partial(_log_proc, output=output)
 
     def _inner():
         begin = time.time()

--- a/testplan/exporters/testing/xml/__init__.py
+++ b/testplan/exporters/testing/xml/__init__.py
@@ -8,8 +8,6 @@ import shutil
 from lxml import etree
 from lxml.builder import E
 
-from schema import Schema, Or
-
 from testplan import defaults
 from testplan.logger import TESTPLAN_LOGGER
 from testplan.common.utils.path import unique_name
@@ -24,46 +22,71 @@ from testplan.testing.multitest.base import Categories, Status
 from ..base import Exporter
 
 
-class MultiTestRenderer(object):
-    # TODO: Handle force passed
+class BaseRenderer(object):
+    """
+    Basic renderer, will render a test group report with the following structure:
+
+    TestGroupReport(name=..., category='<test-category>')
+        TestGroupReport(name=..., category='suite')
+            TestCaseReport(name=...)  (failing)
+                RawAssertion (dict form)
+            TestCaseReport(name=...) (passing)
+            TestCaseReport(name=...) (passing)
+    """
 
     def render(self, source):
-        return self.render_multitest(source)
+        """
+        Top level rendering logic, renders each suite
+        separately & groups them within `testsuites` tag.
+        """
+        testsuites = []
+        num_tests = 0
+        num_failures = 0
+        num_errors = 0
 
-    def render_multitest(self, multitest_report):
+        for index, suite_report in enumerate(source):
+            num_tests += suite_report.counts.total
+            num_errors += suite_report.counts.error
+            num_failures += suite_report.counts.failed
+            suite_elem = self.render_testsuite(index, source, suite_report)
+            testsuites.append(suite_elem)
+
         return E.testsuites(
-            *[self.render_testsuite(index, multitest_report, suite_report)
-                for index, suite_report in enumerate(multitest_report)])
+            *testsuites,
+            tests=str(num_tests),
+            errors=str(num_errors),
+            failures=str(num_failures))
 
-    def render_testsuite(self, index, multitest_report, testsuite_report):
+    def get_testcase_reports(self, testsuite_report):
+        """
+        Get testcases from a suite report, normally this is more or less
+        equal to all children of the suite report, however certain test
+        runners (e.g. MultiTest) may have nested data that needs to be flattened.
+        """
         testcase_reports = []
         for child in testsuite_report:
             if isinstance(child, TestCaseReport):
                 testcase_reports.append(child)
-            elif isinstance(child, TestGroupReport) and\
-                    child.category == Categories.PARAMETRIZATION:
-                testcase_reports.extend(child.entries)
             else:
                 raise TypeError('Unsupported report type: {}'.format(child))
+        return testcase_reports
 
+    def render_testsuite(self, index, test_report, testsuite_report):
+        """Render a single testsuite with its testcases within a `testsuite` tag."""
         cases = [
             self.render_testcase(
-                multitest_report,
+                test_report,
                 testsuite_report,
                 testcase_report
             )
-            for testcase_report in testcase_reports]
-
-        # junit.xsd mandates system-out and system err
-        cases.append(etree.Element("system-out"))
-        cases.append(etree.Element("system-err"))
+            for testcase_report in self.get_testcase_reports(testsuite_report)]
 
         return E.testsuite(
             *cases,
             hostname=socket.gethostname(),
             id=str(index),
             package='{}:{}'.format(
-                multitest_report.name, testsuite_report.name),
+                test_report.name, testsuite_report.name),
             name=testsuite_report.name,
             errors=str(testsuite_report.counts.error),
             failures=str(testsuite_report.counts.failed),
@@ -71,8 +94,9 @@ class MultiTestRenderer(object):
         )
 
     def render_testcase(
-        self, multitest_report, testsuite_report, testcase_report
+        self, test_report, testsuite_report, testcase_report
     ):
+        """Render a testcase with errors & failures within a `testcase` tag."""
         # the xsd for junit only allows errors OR failures not both
         if testcase_report.status == Status.ERROR:
             details = self.render_testcase_errors(testcase_report)
@@ -85,23 +109,29 @@ class MultiTestRenderer(object):
             *details,
             name=testcase_report.name,
             classname="{}:{}:{}".format(
-                multitest_report.name,
+                test_report.name,
                 testsuite_report.name,
                 testcase_report.name
             ),
             time=str(testcase_report.timer['run'].elapsed)
-                if 'run' in testcase_report.timer else '0'
+            if 'run' in testcase_report.timer else '0'
         )
 
     def render_testcase_errors(self, testcase_report):
-        # This is retrieved from the log data created by report.logger
+        """Create an `error` tag that holds error information via testcase report's logs."""
         return [
             E.error(message=log['message'])
             for log in testcase_report.logs if log['levelname'] == 'ERROR'
         ]
 
     def render_testcase_failures(self, testcase_report):
+        """
+        Entries of a testcase report are in dict form, which may
+        also be nested in case there are groups/summaries.
 
+        This method flattens the enty data and iterates over failing
+        assertions to create `failure` tags with element tree.
+        """
         # Depth does not matter, we just need entries in flat form
         flat_dicts = list(zip(*testcase_report.flattened_entries(depth=0)))[1]
 
@@ -114,15 +144,55 @@ class MultiTestRenderer(object):
             not entry['type'] in ('Group', 'Summary')
         ]
 
-        return [
-            E.failure(
+        failures = []
+        for entry in failed_assertions:
+            failure = E.failure(
                 message=entry['description'] or entry['type'],
                 type='assertion'
-            ) for entry in failed_assertions]
+            )
+            if entry['type'] == 'RawAssertion':
+                failure.text = etree.CDATA(entry['content'])
+            failures.append(failure)
+
+        return failures
+
+
+class MultiTestRenderer(BaseRenderer):
+    """
+    Source report represents a MultiTest with the following structure:
+
+    TestGroupReport(name=..., category='multitest')
+        TestGroupReport(name=..., category='suite')
+            TestCaseReport(name=...)
+                Assertion entry (dict)
+                Assertion entry (dict)
+            TestGroupReport(name='...', category='parametrization')
+                TestCaseReport(name=...)
+                    Assertion entry (dict)
+                    Assertion entry (dict)
+                TestCaseReport(name=...)
+                    Assertion entry (dict)
+                    Assertion entry (dict)
+
+    Final XML will have flattened testcase data from parametrization groups.
+    """
+
+    def get_testcase_reports(self, testsuite_report):
+        """Multitest suites may have additional nested in case of parametrization."""
+        testcase_reports = []
+        for child in testsuite_report:
+            if isinstance(child, TestCaseReport):
+                testcase_reports.append(child)
+            elif isinstance(child, TestGroupReport) and\
+                    child.category == Categories.PARAMETRIZATION:
+                testcase_reports.extend(child.entries)
+            else:
+                raise TypeError('Unsupported report type: {}'.format(child))
+        return testcase_reports
 
 
 class XMLExporterConfig(ExporterConfig):
-    """TODO"""
+    """Config for XML exporter"""
 
     @classmethod
     def get_options(cls):
@@ -133,18 +203,18 @@ class XMLExporterConfig(ExporterConfig):
 
 class XMLExporter(Exporter):
     """
-        Produces one XML file per each child of
-        TestPlanReport (e.g. Multitest reports)
+    Produces one XML file per each child of
+    TestPlanReport (e.g. Multitest reports)
     """
 
     CONFIG = XMLExporterConfig
 
-    # TODO: Add more renderers here when we support them (e.g. GTest etc)
     renderer_map = {
         Categories.MULTITEST: MultiTestRenderer,
     }
 
     def export(self, source):
+        """Create multiple XML files in the given directory for each top level test group report."""
         xml_dir = self.cfg.xml_dir
 
         if os.path.exists(xml_dir):
@@ -155,15 +225,26 @@ class XMLExporter(Exporter):
         files = set(os.listdir(xml_dir))
 
         for child_report in source:
-            renderer = self.renderer_map[child_report.category]()
-            element = etree.ElementTree(renderer.render(child_report))
             filename = '{}.xml'.format(slugify(child_report.name))
             filename = unique_name(filename, files)
             files.add(filename)
-
             file_path = os.path.join(self.cfg.xml_dir, filename)
-            element.write(file_path, pretty_print=True)
+
+            # If a report has XML string attribute it was mostly generated via parsing
+            # a JUnit compatible XML file already, meaning we don't need to re-generate
+            # the XML contents, but can directly write the contents to a file instead.
+            if hasattr(child_report, 'xml_string'):
+                with open(file_path, 'w') as xml_target:
+                    xml_target.write(child_report.xml_string)
+            else:
+                renderer = self.renderer_map.get(child_report.category, BaseRenderer)()
+                element = etree.ElementTree(renderer.render(child_report))
+                element.write(
+                    file_path,
+                    pretty_print=True,
+                    xml_declaration=True,
+                    encoding='UTF-8'
+                )
 
         TESTPLAN_LOGGER.exporter_info(
             '%s XML files created at: %s', len(source), xml_dir)
-

--- a/testplan/report/__init__.py
+++ b/testplan/report/__init__.py
@@ -1,3 +1,8 @@
 """TODO."""
 from .testing import (
-    TestReport, TestGroupReport, TestCaseReport, styles as test_styles)
+    TestReport,
+    TestGroupReport,
+    TestCaseReport,
+    Status,
+    styles as test_styles
+)

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -86,7 +86,14 @@ class Status(object):
         return min(stats, key=lambda stat: rule.index(stat))
 
 
-TestCount = collections.namedtuple('TestCount', Status.STATUS_PRECEDENCE)
+_TestCount = collections.namedtuple('_TestCount', Status.STATUS_PRECEDENCE)
+
+
+class TestCount(_TestCount):
+
+    @property
+    def total(self):
+        return sum(getattr(self, attrname) for attrname in self._fields)
 
 
 class ExceptionLogger(ExceptionLoggerBase):

--- a/testplan/testing/cpp/gtest.py
+++ b/testplan/testing/cpp/gtest.py
@@ -157,7 +157,7 @@ class GTest(ProcessRunnerTest):
         return result
 
     def parse_test_context(self, test_list_output):
-        """Parse GTest test output from report.xml"""
+        """Parse GTest test listing from stdout"""
         # Sample Test Declaration:
         #
         #     TEST(SquareRootTest, PositiveNos) {
@@ -199,3 +199,13 @@ class GTest(ProcessRunnerTest):
             else:
                 result[-1][1].append(line.strip())
         return result
+
+    def update_test_report(self):
+        """
+        Attach XML report contents to the report, which can be
+        used by XML exporters, but will be discarded by serializers.
+        """
+        super(GTest, self).update_test_report()
+
+        with open(self.report_path) as report_xml:
+            self.result.report.xml_string = report_xml.read()

--- a/testplan/testing/multitest/entries/base.py
+++ b/testplan/testing/multitest/entries/base.py
@@ -78,6 +78,11 @@ class BaseEntry(object):
 
     __nonzero__ = __bool__
 
+    def serialize(self):
+        """Shortcut method for serialization via schemas"""
+        from .schemas.base import registry
+        return registry.serialize(self)
+
 
 class Group(object):
 

--- a/testplan/testing/multitest/entries/schemas/__init__.py
+++ b/testplan/testing/multitest/entries/schemas/__init__.py
@@ -3,10 +3,5 @@
 """
 
 from .. import assertions as asr
-# from .. import logs
-# from .. import graphs
-
 from . import assertions as asr_schemas
-# from . import log_schemas
-# from . import graph_schemas
 from . import base


### PR DESCRIPTION
* Better XUnit conventions support for
  XML exporter. The exporter will also
  use the original XML string if it is
  available on the generated report objects.

* `ProcessRunnerTest` now generates a suite
  and testcase report with failure details
  if the process crashes. This report structure is
  better compatible with XUnit conventions.

* pre/post start/stop results are now grouped under
  a suite report.

* Added shortcut method (`BaseEntry.serialize`)
  for serializing testcase entries.

* Small fixes re. docs & utility functions.