### PR TITLE
HTTPClient:

### DIFF
--- a/testplan/examples/Transports/HTTP/http_basic.py
+++ b/testplan/examples/Transports/HTTP/http_basic.py
@@ -45,7 +45,8 @@ class HTTPTestsuite(object):
 
         # We are verifying the JSON sent back is the same as the one sent by the
         # HTTPServer.
-        result.equal(response.json(), json_content, 'JSON response from server')
+        result.dict.match(response.json(), json_content,
+                          'JSON response from server')
 
 
 def get_multitest(name):


### PR DESCRIPTION
* Can use HTTPS or HTTP protocol on HTTPClient now.
* Port argument defaults to 80 for HTTP protocol and 443 for HTTPS protocol.
* Changed the JSON assertion from result.equal to result.dictmatch, better to
  show off range of assertions.