### PR TITLE
Add isclose assertion for testing approximate equality

### DIFF
--- a/doc/en/assertions.rst
+++ b/doc/en/assertions.rst
@@ -253,6 +253,28 @@ Comparison assertion, checks if ``reference`` is greater than or equal the ``val
           ...
 
 
+:py:meth:`result.isclose <testplan.testing.multitest.result.Result.isclose>`
+----------------------------------------------------------------------------
+
+Checks if ``first`` is close to ``second`` without requiring them to be exactly equal.
+
+    .. code-block:: python
+
+      @testcase
+      def sample_testcase(self, env, result):
+          result.isclose(100, 101, rel_tol=0.01, abs_tol=0.0, description='Approximate equality example')
+
+    Sample output:
+
+    .. code-block:: bash
+
+      $ test_plan.py --verbose
+          ...
+          Approximate equality example - Pass
+            100 ~= 101 (rel_tol: 0.01, abs_tol: 0.0)
+          ...
+
+
 :py:meth:`result.contain <testplan.testing.multitest.result.Result.contain>`
 ----------------------------------------------------------------------------
 

--- a/test/functional/testplan/runners/fixtures/assertions_failing/report.py
+++ b/test/functional/testplan/runners/fixtures/assertions_failing/report.py
@@ -127,6 +127,27 @@ expected_report = TestReport(
                             ]
                         ),
                         TestCaseReport(
+                            name='test_approximate_equality',
+                            entries=[
+                                {
+                                    'first': 95,
+                                    'second': 100,
+                                    'rel_tol': 0,
+                                    'abs_tol': 5,
+                                    'type': 'IsClose',
+                                    'passed': True
+                                },
+                                {
+                                    'first': 99,
+                                    'second': 101,
+                                    'rel_tol': 0,
+                                    'abs_tol': 1,
+                                    'type': 'IsClose',
+                                    'passed': False
+                                },
+                            ]
+                        ),
+                        TestCaseReport(
                             name='test_membership',
                             entries=[
                                 {

--- a/test/functional/testplan/runners/fixtures/assertions_failing/suites.py
+++ b/test/functional/testplan/runners/fixtures/assertions_failing/suites.py
@@ -38,6 +38,11 @@ class MySuite(object):
         result.greater_equal(2, 1)
 
     @testcase
+    def test_approximate_equality(self, env, result):
+        result.isclose(95, 100, 0, 5)
+        result.isclose(99, 101, 0, 1)
+
+    @testcase
     def test_membership(self, env, result):
         result.contain(1, [1, 2, 3])
         result.not_contain('foo', 'bar')

--- a/test/functional/testplan/runners/fixtures/assertions_passing/report.py
+++ b/test/functional/testplan/runners/fixtures/assertions_passing/report.py
@@ -71,6 +71,19 @@ expected_report = TestReport(
                             ]
                         ),
                         TestCaseReport(
+                            name='test_approximate_equality',
+                            entries=[
+                                {
+                                    'first': 95,
+                                    'second': 100,
+                                    'rel_tol': 0,
+                                    'abs_tol': 5,
+                                    'type': 'IsClose',
+                                    'passed': True
+                                }
+                            ]
+                        ),
+                        TestCaseReport(
                             name='test_membership',
                             entries=[
                                 {

--- a/test/functional/testplan/runners/fixtures/assertions_passing/suites.py
+++ b/test/functional/testplan/runners/fixtures/assertions_passing/suites.py
@@ -27,6 +27,10 @@ class MySuite(object):
         result.greater_equal(2, 1)
 
     @testcase
+    def test_approximate_equality(self, env, result):
+        result.isclose(95, 100, 0, 5)
+
+    @testcase
     def test_membership(self, env, result):
         result.contain(1, [1, 2, 3])
         result.not_contain('foo', 'bar')

--- a/testplan/examples/Assertions/Basic/test_plan.py
+++ b/testplan/examples/Assertions/Basic/test_plan.py
@@ -45,6 +45,11 @@ class SampleSuite(object):
         result.le(10, 15)
         result.ge(15, 10)
 
+        # We can test if 2 numbers are close to each other within
+        # the relative tolerance or a minimum absolute tolerance level
+        result.isclose(100, 95, 0.1, 0.0)
+        result.isclose(100, 95, 0.01, 0.0)
+
         # `result` also has a `log` method that can be used
         # for adding extra information on the output
         result.log(

--- a/testplan/exporters/testing/pdf/renderers/entries/assertions.py
+++ b/testplan/exporters/testing/pdf/renderers/entries/assertions.py
@@ -111,6 +111,30 @@ class FunctionAssertionRenderer(AssertionRenderer):
 
 
 @registry.bind(
+    assertions.IsClose
+)
+class ApproximateEqualityAssertionRenderer(AssertionRenderer):
+    """
+    Assertion renderer for serialized assertion entries:
+      * IsClose
+    """
+
+    def get_detail(self, source, depth, row_idx):
+        return RowData(
+            content=[
+                '{first} {label} {second}'
+                ' (rel_tol: {rel_tol}, abs_tol: {abs_tol})'.format(**source),
+                '', '', '',
+            ],
+            style=default_assertion_style(
+                passed=source['passed'],
+                depth=depth + 1
+            ),
+            start=row_idx,
+        )
+
+
+@registry.bind(
     assertions.RegexMatch,
     assertions.RegexSearch,
 )

--- a/testplan/testing/multitest/entries/schemas/assertions.py
+++ b/testplan/testing/multitest/entries/schemas/assertions.py
@@ -41,6 +41,18 @@ class FuncAssertionSchema(AssertionSchema):
 
 
 @registry.bind(
+    asr.IsClose
+)
+class ApproximateEqualitySchema(AssertionSchema):
+
+    first = custom_fields.NativeOrPretty()
+    second = custom_fields.NativeOrPretty()
+    rel_tol = custom_fields.NativeOrPretty()
+    abs_tol = custom_fields.NativeOrPretty()
+    label = fields.String()
+
+
+@registry.bind(
     asr.IsTrue,
     asr.IsFalse
 )

--- a/testplan/testing/multitest/entries/stdout/assertions.py
+++ b/testplan/testing/multitest/entries/stdout/assertions.py
@@ -69,6 +69,26 @@ class FunctionAssertionRenderer(AssertionRenderer):
 
 
 @registry.bind(
+    assertions.IsClose
+)
+class ApproximateEqualityAssertionRenderer(AssertionRenderer):
+
+    def get_assertion_details(self, entry):
+        """
+            Use a format like `99 ~= 100 (with rel_tol=0.1, abs_tol=0.0)`,
+            highlighting failing comparisons in red.
+        """
+        msg = '{} {} {} (rel_tol: {}, abs_tol: {})'.format(
+            entry.first,
+            entry.label,
+            entry.second,
+            entry.rel_tol,
+            entry.abs_tol
+        )
+        return msg if entry else Color.red(msg)
+
+
+@registry.bind(
     assertions.RegexMatch,
     assertions.RegexSearch,
 )

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -1342,6 +1342,32 @@ class Result(object):
     ge = greater_equal
 
     @bind_entry
+    def isclose(
+        self, first, second, rel_tol=1e-09, abs_tol=0.0,
+        description=None, category=None
+    ):
+        """
+        Checks if ``first`` and ``second`` are approximately equal.
+
+        .. code-block:: python
+
+            result.isclose(99.99, 100, 0.001, 0.0, 'Custom description')
+
+        :param first: The first item to be compared for approximate equality.
+        :type first: ``numbers.Number``
+        :param second: The second item to be compared for approximate equality.
+        :type second: ``numbers.Number``
+        :param rel_tol: The relative tolerance.
+        :type rel_tol: ``numbers.Real``
+        :param abs_tol: The minimum absolute tolerance level.
+        :type abs_tol: ``numbers.Real``
+        :return: Assertion pass status
+        :rtype: ``bool``
+        """
+        return assertions.IsClose(
+            first, second, rel_tol, abs_tol, description=description, category=category)
+
+    @bind_entry
     def contain(self, member, container, description=None, category=None):
         """
         Checks if ``member in container``.


### PR DESCRIPTION
* A new assertion `isclose` is added to result that allows user to
  check if 2 numbers are approximate equal. Either the relative
  tolerance or a minimum absolute tolerance level can be specified.
  Please refer to PEP 485, we implement it in a similar way.