### PR TITLE
Change the behavior of config options

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -282,7 +282,7 @@ An example implementation of custom test lister can be seen
   For filtering / ordering / listing operations, programmatic declarations will
   take precedence over command line arguments, meaning command line arguments
   will **NOT** take on effect if there is an explicit
-  ``test-filter``/``test_sorter``/``test_lister`` argument in the ``@test_plan``
+  ``test_filter``/``test_sorter``/``test_lister`` argument in the ``@test_plan``
   declaration.
 
 

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -277,8 +277,9 @@ class EntityConfig(Config):
     def get_options(cls):
         """Config options for base Entity class."""
         return {
-            ConfigOption('runpath', default=None):
-                Or(None, str, lambda x: callable(x)),
+            ConfigOption(
+                'runpath', default=None,
+                low_precedence=True): Or(None, str, lambda x: callable(x)),
             ConfigOption('initial_context', default={}): dict,
             ConfigOption('path_cleanup', default=None): Or(None, bool),
             ConfigOption('status_wait_timeout', default=3600): int,

--- a/testplan/exporters/testing/base.py
+++ b/testplan/exporters/testing/base.py
@@ -15,10 +15,10 @@ class TagFilteredExporterConfig(ExporterConfig):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption('report_tags', default=[]):
-                [Use(tagging.validate_tag_value)],
-            ConfigOption('report_tags_all', default=[]):
-                [Use(tagging.validate_tag_value)]
+            ConfigOption('report_tags', default=[],
+                low_precedence=True): [Use(tagging.validate_tag_value)],
+            ConfigOption('report_tags_all', default=[],
+                low_precedence=True): [Use(tagging.validate_tag_value)]
         }
 
 

--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -28,7 +28,11 @@ class JSONExporterConfig(ExporterConfig):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption('json_path', default=defaults.JSON_PATH): str
+            ConfigOption(
+                'json_path',
+                default=defaults.JSON_PATH,
+                low_precedence=True
+            ): str
         }
 
 

--- a/testplan/exporters/testing/pdf/__init__.py
+++ b/testplan/exporters/testing/pdf/__init__.py
@@ -147,7 +147,9 @@ class BasePDFExporterConfig(ExporterConfig):
     def get_options(cls):
         return {
             ConfigOption('timestamp', default=None): Or(str, None),
-            ConfigOption('pdf_style', default=defaults.PDF_STYLE): Style,
+            ConfigOption(
+                'pdf_style', default=defaults.PDF_STYLE,
+                low_precedence=True): Style,
         }
 
 
@@ -157,7 +159,11 @@ class PDFExporterConfig(BasePDFExporterConfig):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption('pdf_path', default=defaults.PDF_PATH): str
+            ConfigOption(
+                'pdf_path',
+                default=defaults.PDF_PATH,
+                low_precedence=True
+            ): str
         }
 
 
@@ -169,7 +175,11 @@ class TagFilteredPDFExporterConfig(
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption('report_dir', default=defaults.REPORT_DIR): str
+            ConfigOption(
+                'report_dir',
+                default=defaults.REPORT_DIR,
+                low_precedence=True
+            ): str
         }
 
 

--- a/testplan/exporters/testing/xml/__init__.py
+++ b/testplan/exporters/testing/xml/__init__.py
@@ -197,7 +197,11 @@ class XMLExporterConfig(ExporterConfig):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption('xml_dir', default=defaults.XML_DIR): str
+            ConfigOption(
+                'xml_dir',
+                default=defaults.XML_DIR,
+                low_precedence=True
+            ): str
         }
 
 

--- a/testplan/runnable.py
+++ b/testplan/runnable.py
@@ -96,8 +96,8 @@ class TestRunnerConfig(RunnableConfig):
         return {
             'name': str,
             ConfigOption('logger_level', default=TEST_INFO): int,
-            ConfigOption('runpath', default=default_runpath):
-                Or(None, str, lambda x: callable(x)),
+            ConfigOption(
+                'runpath', default=default_runpath): Or(None, str, lambda x: callable(x)),
             ConfigOption('path_cleanup', default=True): bool,
             ConfigOption('all_tasks_local', default=False): bool,
             ConfigOption('shuffle', default=[]): list,  # list of string choices
@@ -106,30 +106,38 @@ class TestRunnerConfig(RunnableConfig):
             ConfigOption(
                 'exporters', default=None): Use(get_exporters),
             ConfigOption(
-                'stdout_style',
-                default=defaults.STDOUT_STYLE): Style,
-            ConfigOption('report_dir', default=defaults.REPORT_DIR): str,
-            ConfigOption('xml_dir', default=None): Or(str, None),
-            ConfigOption('pdf_path', default=None): Or(str, None),
-            ConfigOption('json_path', default=None): Or(str, None),
+                'stdout_style', default=defaults.STDOUT_STYLE,
+                low_precedence=True): Style,
             ConfigOption(
-                'pdf_style',
-                default=defaults.PDF_STYLE): Style,
-            ConfigOption('report_tags', default=[]):
-                [Use(tagging.validate_tag_value)],
-            ConfigOption('report_tags_all', default=[]):
-                [Use(tagging.validate_tag_value)],
+                'report_dir', default=defaults.REPORT_DIR,
+                low_precedence=True): str,
+            ConfigOption(
+                'xml_dir', default=None,
+                low_precedence=True): Or(str, None),
+            ConfigOption(
+                'pdf_path', default=None,
+                low_precedence=True): Or(str, None),
+            ConfigOption(
+                'json_path', default=None,
+                low_precedence=True): Or(str, None),
+            ConfigOption(
+                'pdf_style', default=defaults.PDF_STYLE,
+                low_precedence=True): Style,
+            ConfigOption('report_tags', default=[],
+                low_precedence=True): [Use(tagging.validate_tag_value)],
+            ConfigOption('report_tags_all', default=[],
+                low_precedence=True): [Use(tagging.validate_tag_value)],
             ConfigOption('browse', default=False): bool,
             ConfigOption(
-                'test_filter', default=filtering.Filter()):
-                filtering.BaseFilter,
+                'test_filter', default=filtering.Filter(),
+                low_precedence=True): filtering.BaseFilter,
             ConfigOption(
-                'test_sorter', default=ordering.NoopSorter()):
-                ordering.BaseSorter,
+                'test_sorter', default=ordering.NoopSorter(),
+                low_precedence=True): ordering.BaseSorter,
             # Test lister is None by default, otherwise Testplan would
             # list tests, not run them
-            ConfigOption('test_lister', default=None):
-                Or(None, listing.BaseLister)
+            ConfigOption('test_lister', default=None,
+                low_precedence=True): Or(None, listing.BaseLister)
         }
 
 

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -29,15 +29,18 @@ class TestConfig(RunnableConfig):
             ConfigOption('description', default=None): str,
             ConfigOption(
                 'test_filter',
-                default=filtering.Filter()
+                default=filtering.Filter(),
+                low_precedence=True
             ): filtering.BaseFilter,
             ConfigOption(
                 'test_sorter',
-                default=ordering.NoopSorter()
+                default=ordering.NoopSorter(),
+                low_precedence=True
             ): ordering.BaseSorter,
             ConfigOption(
                 'stdout_style',
-                default=defaults.STDOUT_STYLE
+                default=defaults.STDOUT_STYLE,
+                low_precedence=True
             ): test_styles.Style,
             ConfigOption(
                 'tags',


### PR DESCRIPTION
* There is a parent-child relation in the configuration options of
  entities. When an option is not present in a child, then look up
  in the parent. Some options have default values. If a user doesn't
  specify an option in the entity constructor then the default value
  will be used. Currently if an option is not explicitly specified by
  user then the default value defined in parent will be used. We want
  to change this behavior that its default value takes precedence, but
  provide a parameter which sometimes can be used to makes clear that
  default value in parent is prefered.