### PR TITLE
Conversion changes:

### DIFF
--- a/testplan/__init__.py
+++ b/testplan/__init__.py
@@ -11,7 +11,7 @@ if TESTPLAN_DEPENDENCIES_PATH in os.environ:
         os.environ[TESTPLAN_DEPENDENCIES_PATH]))
     sys.path.insert(0, os.environ[TESTPLAN_DEPENDENCIES_PATH])
     import dependencies
-    sys.path.pop(0)
+    sys.path.remove(os.environ[TESTPLAN_DEPENDENCIES_PATH])
 
 from .base import Testplan, TestplanConfig, TestplanResult, test_plan
 from .runners.pools.tasks import Task, TaskResult

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -24,6 +24,7 @@ def parse_cmdline():
     parser.add_argument('--log-level', action="store", default=0, type=int)
     parser.add_argument('--remote-pool-type', action="store", default='thread')
     parser.add_argument('--remote-pool-size', action="store", default=1)
+    parser.add_argument('--ng-alpha', action="store_true")
 
     return parser.parse_args()
 

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -85,7 +85,8 @@ class ProcessWorker(Worker):
                '--testplan', os.path.join(os.path.dirname(testplan.__file__),
                                           '..'),
                '--type', 'process_worker',
-               '--log-level', TESTPLAN_LOGGER.getEffectiveLevel()]
+               '--log-level', TESTPLAN_LOGGER.getEffectiveLevel(),
+               '--ng-alpha']
         if os.environ.get(testplan.TESTPLAN_DEPENDENCIES_PATH):
             cmd.extend(
                 ['--testplan-deps',


### PR DESCRIPTION
* Explicitly remove Testplan dependices path from sys PATH rather than removing
  the first entry.
* Send --ng-alpha flag to child workers to enable conversion changes.