### PR TITLE
Always specify testplan package for remote host

### DIFF
--- a/test/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/test/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -80,17 +80,10 @@ def schedule_tests_to_pool(name, pool, **pool_cfg):
     plan.add_resource(pool)
 
     this_file = fix_home_prefix(os.path.dirname(os.path.abspath(__file__)))
-    if pool_cfg.get('workspace'):  # Remote pool
-        ws = pool_cfg['workspace']
-        wd = fix_home_prefix(os.getcwd())
-        common = os.path.commonprefix(
-            [pool_cfg['workspace'], wd])
 
-        # Relative path tp the same file but from the remote workspace.
-        path = '/'.join(os.path.join(
-            os.path.relpath(common, wd),
-            os.path.relpath(this_file, ws)
-        ).split(os.sep))
+    workspace = pool_cfg.get('workspace')
+    if workspace:
+        path = os.path.relpath(this_file, workspace)
     else:
         path = this_file
 

--- a/test/functional/testplan/runners/pools/test_pool_remote.py
+++ b/test/functional/testplan/runners/pools/test_pool_remote.py
@@ -32,11 +32,7 @@ def strip_host(source, target, **kwargs):
 )
 def test_pool_basic():
     """Basic test scheduling."""
-    import testplan
-    workspace = os.path.abspath(
-        os.path.join(
-            os.path.dirname(module_abspath(testplan)),
-            '..', '..', '..'))
+    workspace = os.path.dirname(__file__)
 
     for remote_pool_type in ('thread', 'process'):
         schedule_tests_to_pool(

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -28,7 +28,6 @@ def parse_cmdline():
     parser.add_argument('--log-level', action="store", default=0, type=int)
     parser.add_argument('--remote-pool-type', action="store", default='thread')
     parser.add_argument('--remote-pool-size', action="store", default=1)
-    parser.add_argument('--ng-alpha', action="store_true")
 
     return parser.parse_args()
 
@@ -53,6 +52,7 @@ class ZMQTransport(object):
         self._sock = self._context.socket(zmq.REQ)
         self._sock.connect("tcp://{}".format(address))
         self.active = True
+        self.logger = logging.getLogger(self.__class__.__name__)
 
     def send(self, message):
         """
@@ -150,14 +150,22 @@ class ChildLoop(object):
     def _setup_logfiles(self):
         if not os.path.exists(self.runpath):
             os.makedirs(self.runpath)
+
+        stderr_file = os.path.join(self.runpath, '{}_stderr'.format(self._metadata['index']))
+        log_file = os.path.join(self.runpath, '{}_stdout'.format(self._metadata['index']))
+        self.logger.info('stdout file = %(file)s (log level = %(lvl)s)',
+                         {'file': log_file, 'lvl': self.logger.level})
+        self.logger.info('stderr file = %s'.format(stderr_file))
+        self.logger.info(
+            'Closing stdin, stdout and stderr file descriptors...')
+
+        # This closes stdin, stdout and stderr for this process.
         for fdesc in range(3):
             os.close(fdesc)
         mode = 'w' if platform.python_version().startswith('3') else 'wb'
 
-        sys.stderr = open(os.path.join(
-            self.runpath, '{}_stderr'.format(self._metadata['index'])), mode)
-        fhandler = logging.FileHandler(os.path.join(
-                self.runpath, '{}_stdout'.format(self._metadata['index'])))
+        sys.stderr = open(stderr_file, mode)
+        fhandler = logging.FileHandler(log_file)
         fhandler.setLevel(self.logger.level)
         self.logger.addHandler = fhandler
 
@@ -282,7 +290,7 @@ class RemoteChildLoop(ChildLoop):
     Child loop for remote workers.
     This involved exchange of metadata for additional functionality.
     """
-    def __int__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super(RemoteChildLoop, self).__init__(*args, **kwargs)
         self._setup_metadata = None
 
@@ -295,9 +303,9 @@ class RemoteChildLoop(ChildLoop):
             for key, value in self._setup_metadata.env.items():
                 os.environ[key] = value
         os.environ['TESTPLAN_LOCAL_WORKSPACE'] = \
-            self._setup_metadata.workspace_paths['local']
+            self._setup_metadata.workspace_paths.local
         os.environ['TESTPLAN_REMOTE_WORKSPACE'] = \
-            self._setup_metadata.workspace_paths['remote']
+            self._setup_metadata.workspace_paths.remote
 
         if self._setup_metadata.setup_script:
             if subprocess.call(self._setup_metadata.setup_script,
@@ -315,8 +323,8 @@ class RemoteChildLoop(ChildLoop):
             # Only delete the source workspace if it was transferred.
             if self._setup_metadata.workspace_pushed is True:
                 self.logger.test_info('Removing workspace: {}'.format(
-                    self._setup_metadata.workspace_paths['remote']))
-                shutil.rmtree(self._setup_metadata.workspace_paths['remote'],
+                    self._setup_metadata.workspace_paths.remote))
+                shutil.rmtree(self._setup_metadata.workspace_paths.remote,
                               ignore_errors=True)
         super(RemoteChildLoop, self).exit_loop()
 
@@ -418,15 +426,25 @@ if __name__ == '__main__':
     ARGS = parse_cmdline()
     if ARGS.wd:
         os.chdir(ARGS.wd)
+        sys.path.append('.')
 
-    sys.path.append(ARGS.testplan)
+    # We expect the testplan path to be the full /path/to/testplan directory, so
+    # add the parent /path/to dir to the sys.path so that the testplan package
+    # can be imported.
+    #
+    # We prepend the path instead of appending here in case there is another
+    # testplan installed on the sys path already, to ensure the expected version
+    # is used.
+    if ARGS.testplan:
+        sys.path.insert(
+            0, os.path.abspath(os.path.join(ARGS.testplan, os.pardir)))
     if ARGS.testplan_deps:
         sys.path.append(ARGS.testplan_deps)
     try:
         import dependencies
         # This will also import dependencies from $TESTPLAN_DEPENDENCIES_PATH
     except ImportError:
-        pass
+        dependencies = None
 
     import testplan
     if ARGS.testplan_deps:

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -89,8 +89,7 @@ class ProcessWorker(Worker):
                '--testplan', os.path.join(os.path.dirname(testplan.__file__),
                                           '..'),
                '--type', 'process_worker',
-               '--log-level', TESTPLAN_LOGGER.getEffectiveLevel(),
-               '--ng-alpha']
+               '--log-level', TESTPLAN_LOGGER.getEffectiveLevel()]
         if os.environ.get(testplan.TESTPLAN_DEPENDENCIES_PATH):
             cmd.extend(
                 ['--testplan-deps', fix_home_prefix(
@@ -109,7 +108,7 @@ class ProcessWorker(Worker):
                 [str(a) for a in cmd],
                 stdout=out, stderr=out, stdin=subprocess.PIPE
             )
-
+        self.logger.debug('Started child process - output at %s', self.outfile)
         self._handler.stdin.write(bytes('y\n'.encode('utf-8')))
 
     def _wait_started(self, timeout=None):
@@ -125,8 +124,8 @@ class ProcessWorker(Worker):
                 return
             sleep_interval *= 2
         if self._handler.poll() is not None:
-            raise RuntimeError('{} process exited: {}'.format(
-                self, self._handler.poll()))
+            raise RuntimeError('{self} process exited: {rc}. See output at {out}'.format(
+                self=self, rc=self._handler.returncode, out=self.outfile))
         raise RuntimeError(
             'Could not match starting pattern in {}'.format(self.outfile))
 


### PR DESCRIPTION
Plus some other tweaks and refactoring of how local and remote workspaces, working directories and dependencies are managed for the RemotePool. Doesn't require testplan to be within the current workspace - the workspace should correspond to what we are testing.