### PR TITLE
Changes for remote pool backwards compatibility

### DIFF
--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -28,7 +28,6 @@ def parse_cmdline():
     parser.add_argument('--log-level', action="store", default=0, type=int)
     parser.add_argument('--remote-pool-type', action="store", default='thread')
     parser.add_argument('--remote-pool-size', action="store", default=1)
-    parser.add_argument('--ng-alpha', action="store_true")
 
     return parser.parse_args()
 

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -89,8 +89,7 @@ class ProcessWorker(Worker):
                '--testplan', os.path.join(os.path.dirname(testplan.__file__),
                                           '..'),
                '--type', 'process_worker',
-               '--log-level', TESTPLAN_LOGGER.getEffectiveLevel(),
-               '--ng-alpha']
+               '--log-level', TESTPLAN_LOGGER.getEffectiveLevel()]
         if os.environ.get(testplan.TESTPLAN_DEPENDENCIES_PATH):
             cmd.extend(
                 ['--testplan-deps', fix_home_prefix(
@@ -125,8 +124,9 @@ class ProcessWorker(Worker):
                 return
             sleep_interval *= 2
         if self._handler.poll() is not None:
-            raise RuntimeError('{} process exited: {}'.format(
-                self, self._handler.poll()))
+            raise RuntimeError(
+                '{proc} process exited: {rc} (logfile = {log})'.format(
+                    proc=self, rc=self._handler.returncode, log=self.outfile))
         raise RuntimeError(
             'Could not match starting pattern in {}'.format(self.outfile))
 

--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -210,8 +210,7 @@ class RemoteWorker(ProcessWorker):
 
     def _prepare_remote(self):
         """Transfer local data to remote host."""
-        import testplan.runners.pools.child as child
-        self._child_paths['local'] = module_abspath(child, self._user)
+        self._child_paths['local'] = self._child_path()
         self._working_dirs = {'local': pwd()}
         self._workspace_paths['local'] = self.cfg.workspace
 


### PR DESCRIPTION
- Use ._child_path() method to get child path instead of finding
  it directly, so that we can override the child script.
- Include logfile in Exception message for quicker debugging of
  worker failures.
- Remove references to "ng-alpha" from open source repo.