### PR TITLE
Fix several possible issues in running test

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -617,15 +617,16 @@ class Runnable(Entity):
             time.sleep(self.cfg.active_loop_sleep)
 
     def _run_batch_steps(self):
+        self._add_step(self.setup)
         self.pre_resource_steps()
-
         self._add_step(self.resources.start)
 
         self.main_batch_steps()
 
         self._add_step(self.resources.stop, reversed=True)
-
         self.post_resource_steps()
+        self._add_step(self.teardown)
+
         self._run()
 
     def _execute_step(self, step, *args, **kwargs):
@@ -684,12 +685,10 @@ class Runnable(Entity):
     def run(self):
         """Executes the defined steps and populates the result object."""
         try:
-            self._add_step(self.setup)
             if self.cfg.interactive is True:
                 raise
             else:
                 self._run_batch_steps()
-            self._add_step(self.teardown)
         except Exception as exc:
             self._result.run = exc
             self.logger.error(format_trace(inspect.trace(), exc))

--- a/testplan/runners/base.py
+++ b/testplan/runners/base.py
@@ -5,6 +5,7 @@ import threading
 from collections import OrderedDict
 
 from testplan.common.entity import Resource, ResourceConfig
+from testplan.common.utils.thread import interruptible_join
 
 
 class ExecutorConfig(ResourceConfig):
@@ -72,6 +73,8 @@ class Executor(Resource):
 
     def stopping(self):
         """Stop the executor."""
+        if self._loop_handler:
+            interruptible_join(self._loop_handler)
 
     def pausing(self):
         """Pause the executor."""

--- a/testplan/runners/local.py
+++ b/testplan/runners/local.py
@@ -2,8 +2,6 @@
 
 import time
 
-from testplan.common.utils.thread import interruptible_join
-
 from .base import Executor
 
 class LocalRunner(Executor):
@@ -42,6 +40,3 @@ class LocalRunner(Executor):
     def aborting(self):
         """Suppressing not implemented debug log from parent class."""
 
-    def stopping(self):
-        """Stopping the LocalRunner."""
-        interruptible_join(self._loop_handler)

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -652,6 +652,7 @@ class Pool(Executor):
         """Stop connections and workers."""
         self._conn.close()
         self._workers.stop()
+        super(Pool, self).stopping()
 
     def abort_dependencies(self):
         """Empty generator to override parent implementation."""

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -239,7 +239,9 @@ class MultiTest(Test):
                             tags=next_suite.__tags__,
                         )
                         self.report.append(testsuite_report)
-                        self._run_suite(next_suite, testcases, testsuite_report)
+                        with testsuite_report.logged_exceptions():
+                            self._run_suite(
+                                next_suite, testcases, testsuite_report)
                 time.sleep(self.cfg.active_loop_sleep)
 
     def _run_suite(self, testsuite, testcases, testsuite_report):
@@ -370,7 +372,8 @@ class MultiTest(Test):
             method_report = TestCaseReport(method)
             report.append(method_report)
             case_result = self.cfg.result(stdout_style=self.stdout_style)
-            attr(self.resources, case_result)
+            with method_report.logged_exceptions():
+                attr(self.resources, case_result)
             method_report.extend(case_result.serialized_entries)
 
     def _wrap_run_step(self, func, label):


### PR DESCRIPTION
* In base class Runnable, 'teardown' is added into execution list
  after all other functions finished and will have no change to be
  executed, so, remove 'setup' and 'teardown' into '_run_batch_steps'
  before '_run'.

* If exception raised in 'setup' during running suite, in the final
  report the suite would be FAIL but the status of setup (same level
  as testcase) is PASS, because the setup report has no failed entry.
  So, add ExceptionLogger (context manager) around 'setup' & 'teardown'
  to catch the exception. Similarly, if any exception occurs during
  running suite but before testcase execution, the suite report will
  have no entry, thus the status is PASS -- that's not right. Should
  also add ExceptionLogger around self._run_suite().

* There are several Executors in testplan -- The LocalRunner and Pool.
  Separate Executor thread will be created to execute task, and after
  task finished the Executor thread should be joined. Should do this
  in a in a uniform manner, although these threads have been set daemon
  and won't lead to exception or program hang.