### PR TITLE
Multi-thread testcase execution

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -1210,6 +1210,46 @@ implement custom decorators, please make sure you use
         def addition(self, env, result, a, b):
             ...
 
+.. _parallezation:
+
+Testcase Parallel Execution
+---------------------------
+
+It is possible to run testcases in parallel with a thread pool. This feature
+can be used to accelerate a group of testcases that spend a lot of time on IO
+or waiting. Due to Python global interpreter lock, the feature is not going to
+help CPU-bounded tasks, it also requires testcase written in a thread-safe way.
+
+To enable this feature, instantiate MultiTest with a non-zero ``thread_pool_size``
+and define ``execution_group`` for testcases you would like to run in parallel.
+Testcases in the same group will be executed concurrently.
+
+.. code-block:: python
+
+    @testsuite
+    class SampleTest(object):
+
+        @testcase(execution_group='first')
+        def test_g1_1(kwargs):
+            ...
+
+        @testcase(execution_group='second')
+        def test_g2_1(kwargs):
+            ...
+
+        @testcase(execution_group='first')
+        def test_g1_2(kwargs):
+            ...
+
+        @testcase(execution_group='second')
+        def test_g2_2(kwargs):
+            ...
+
+        my_multitest = MultiTest((name='Testcase Parallezation',
+                                  suites=[SampleTest()],
+                                  thread_pool_size=2))
+
+
 .. _multitest_drivers:
 
 Drivers

--- a/test/functional/testplan/testing/multitest/test_execution_groups.py
+++ b/test/functional/testplan/testing/multitest/test_execution_groups.py
@@ -1,0 +1,126 @@
+import time
+from collections import OrderedDict
+
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+
+from testplan import Testplan
+from testplan.common.utils.testing import log_propagation_disabled
+from testplan.report.testing import TestGroupReport
+from testplan.logger import TESTPLAN_LOGGER
+
+EXECUTION_PERIOD = 0.001
+
+
+@testsuite
+class MySuite(object):
+
+    @testcase
+    def test_case_0_0(self, env, result):
+        time.sleep(EXECUTION_PERIOD)
+
+    @testcase(execution_group='group_1')
+    def test_case_1_0(self, env, result):
+        time.sleep(EXECUTION_PERIOD)
+
+    @testcase(execution_group='group_2')
+    def test_case_2_0(self, env, result):
+        time.sleep(EXECUTION_PERIOD)
+
+    @testcase
+    def test_case_0_1(self, env, result):
+        time.sleep(EXECUTION_PERIOD)
+
+    @testcase(execution_group='group_1')
+    def test_case_1_1(self, env, result):
+        time.sleep(EXECUTION_PERIOD)
+
+    @testcase(execution_group='group_2')
+    def test_case_2_1(self, env, result):
+        time.sleep(EXECUTION_PERIOD)
+
+    @testcase
+    def test_case_0_2(self, env, result):
+        time.sleep(EXECUTION_PERIOD)
+
+    @testcase(execution_group='group_1')
+    def test_case_1_2(self, env, result):
+        time.sleep(EXECUTION_PERIOD)
+
+    @testcase(execution_group='group_2')
+    def test_case_2_2(self, env, result):
+        time.sleep(EXECUTION_PERIOD)
+
+    @testcase(
+        parameters=(
+            ('x', 1),
+            ('y', 2),
+            ('z', 3)
+        ),
+        execution_group='group_3'
+    )
+    def test_case_3(self, env, result, a, b):
+        time.sleep(EXECUTION_PERIOD)
+
+
+def get_testcase_execution_time(
+        report,
+        suite_name='MySuite',
+        multitest_name='MyMultitest',
+):
+    for multitest_report in report.entries:
+        testcase_execution_time = OrderedDict()
+
+        if multitest_report.name != multitest_name:
+            continue
+
+        for suite_report in multitest_report.entries:
+            if suite_report.name != suite_name:
+                continue
+
+            for entry in suite_report.entries:
+                if isinstance(entry, TestGroupReport):
+                    testcase_execution_time.update({
+                        testcase_report.name: testcase_report.timer['run']
+                        for testcase_report in entry
+                    })
+                else:
+                    testcase_execution_time[entry.name] = entry.timer['run']
+
+        return testcase_execution_time
+
+
+def test_execution_order():
+
+    multitest = MultiTest(
+        name='MyMultitest',
+        suites=[MySuite()],
+        thread_pool_size=2
+    )
+
+    plan = Testplan(name='plan', parse_cmdline=False)
+    plan.add(multitest)
+
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        plan.run()
+
+    result = get_testcase_execution_time(plan.report)
+
+    group_1_start = min(result[item].start
+                        for item in result if item.startswith('test_case_1'))
+    group_2_start = min(result[item].start
+                        for item in result if item.startswith('test_case_2'))
+    group_3_start = min(result[item].start
+                        for item in result if item.startswith('test_case_3'))
+    group_0_end = max(result[item].end
+                      for item in result if item.startswith('test_case_0'))
+    group_1_end = max(result[item].end
+                      for item in result if item.startswith('test_case_1'))
+    group_2_end = max(result[item].end
+                      for item in result if item.startswith('test_case_2'))
+
+    assert result['test_case_0_0'].start < result['test_case_0_0'].end <= \
+           result['test_case_0_1'].start < result['test_case_0_1'].end <= \
+           result['test_case_0_2'].start < result['test_case_0_2'].end
+    assert group_0_end <= group_1_start
+    assert group_1_end <= group_2_start
+    assert group_2_end <= group_3_start

--- a/test/unit/testplan/testing/multitest/test_suite.py
+++ b/test/unit/testplan/testing/multitest/test_suite.py
@@ -59,6 +59,28 @@ class MySuite3(object):
         pass
 
 
+@testsuite
+class MySuite4(object):
+    @testcase(execution_group='group_0')
+    def case1(self, env, result):
+        pass
+
+    @testcase(execution_group='group_1')
+    def case2(self, env, result):
+        pass
+
+    @testcase(execution_group='group_0')
+    def case3(self, env, result):
+        pass
+
+    @testcase(execution_group='group_1')
+    def case4(self, env, result):
+        pass
+
+    @testcase(parameters=(1, 2, 3), execution_group='group_parallel')
+    def case(self, env, result, param):
+        pass
+
 def test_basic_suites():
     mysuite = MySuite1()
 
@@ -69,16 +91,6 @@ def test_basic_suites():
     for method in get_testcase_methods(MySuite1):
         assert method.__name__ in cases
         assert callable(method)
-
-    for method in mysuite.get_testcases():
-        assert method.__name__ in cases
-        assert callable(method)
-
-
-def test_basic_parametrization():
-    mysuite = MySuite3()
-    cases = ('case__param_1', 'case__param_2', 'case__param_3')
-    assert tuple(mysuite.__testcases__) == cases
 
     for method in mysuite.get_testcases():
         assert method.__name__ in cases
@@ -98,6 +110,26 @@ def test_basic_suite_tags():
         assert method.__tags__ == case_dict[method.__name__]
         assert method.__tags_index__ == tagging.merge_tag_dicts(
             case_dict[method.__name__], mysuite.__tags__)
+
+
+def test_basic_parametrization():
+    mysuite = MySuite3()
+    cases = ('case__param_1', 'case__param_2', 'case__param_3')
+    assert tuple(mysuite.__testcases__) == cases
+
+    for method in mysuite.get_testcases():
+        assert method.__name__ in cases
+        assert callable(method)
+
+
+def test_basic_execution_group():
+    mysuite = MySuite4()
+
+    for i, method in enumerate(mysuite.get_testcases()):
+        if method.__name__.startswith('case__'):
+            assert method.execution_group == 'group_parallel'
+        else:
+            assert method.execution_group == 'group_{}'.format(i%2)
 
 
 def incorrect_case_signature1():

--- a/testplan/testing/multitest/parametrization.py
+++ b/testplan/testing/multitest/parametrization.py
@@ -335,7 +335,8 @@ def generate_functions(
     summarize,
     num_passing,
     num_failing,
-    key_combs_limit
+    key_combs_limit,
+    execution_group
 ):
     """
     Generate test cases using the given parameter context, use the name_func
@@ -375,9 +376,12 @@ def generate_functions(
     :param num_failing: Max number of failing assertions
                        for testcase level assertion summary.
     :type num_failing: ``int``
-    :param key_combs_limit: Max number of failed key combinations on
-      fix/dict summaries that contain assertion details.
+    :param key_combs_limit: Max number of failed key combinations on fix/dict
+                            summaries that contain assertion details.
     :type key_combs_limit: ``int``
+    :param execution_group: Name of execution group in which the testcases
+                            can be executed in parallel.
+    :type execution_group: ``str``
     :return: List of functions that is testcase compliant
              (accepts ``self``, ``env``, ``result`` as arguments) and have
              unique names.
@@ -412,6 +416,7 @@ def generate_functions(
         func.summarize_num_passing = num_passing
         func.summarize_num_failing = num_failing
         func.summarize_key_combs_limit = key_combs_limit
+        func.execution_group = execution_group
 
     _ensure_unique_names(functions)
 

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -361,7 +361,8 @@ def _testcase_meta(
     summarize=False,
     num_passing=defaults.SUMMARY_NUM_PASSING,
     num_failing=defaults.SUMMARY_NUM_FAILING,
-    key_combs_limit=defaults.SUMMARY_KEY_COMB_LIMIT
+    key_combs_limit=defaults.SUMMARY_KEY_COMB_LIMIT,
+    execution_group=None
 ):
     """
     Wrapper function that allows us to call :py:func:`@testcase <testcase>`
@@ -388,7 +389,8 @@ def _testcase_meta(
                 summarize=summarize,
                 num_passing=num_passing,
                 num_failing=num_failing,
-                key_combs_limit=key_combs_limit
+                key_combs_limit=key_combs_limit,
+                execution_group=execution_group
             )
 
             # Register generated functions as test_cases
@@ -418,6 +420,7 @@ def _testcase_meta(
             function.summarize_num_passing = num_passing
             function.summarize_num_failing = num_failing
             function.summarize_key_combs_limit = key_combs_limit
+            function.execution_group = execution_group
             function.__tags_index__ = copy.deepcopy(tag_dict)
 
             return _testcase(function)


### PR DESCRIPTION
* In a test suite, testcases that do not affect each other could be
  put in the same execution group, and then they can run in parallel
  with multi-threading. Parametrized testcase also supported.

* Fix a bug that if setup() fails in a suite, the status of suite will
  not be logged even 'display_suite' in 'stdout style' is set True.
  Should put log_suite_status() directly after _run_suite().