### PR TITLE
Catch BaseException in worker thread

### DIFF
--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -276,7 +276,7 @@ class Worker(Resource):
                 result = target()
             else:
                 result = target.run()
-        except Exception as exc:
+        except BaseException as exc:
             task_result = TaskResult(
                 task=task, result=None, status=False,
                 reason=format_trace(inspect.trace(), exc))


### PR DESCRIPTION
To repro issue: add sys.exit() call to any testcase scheduled to a thread pool. Testplan hangs indefinitely.

Possibly we should monitor worker thread health to avoid hanging, but for now the simple fix is to just catch BaseException so that the thread does not exit even if SystemExit is raised from user code.