### PR TITLE
Avoid race condition in ProcessRunnerTest

### DIFF
--- a/testplan/common/utils/process.py
+++ b/testplan/common/utils/process.py
@@ -133,10 +133,12 @@ def enforce_timeout(process, timeout=1, callback=None, output=None):
                 _log(msg='Killing binary after'
                          ' reaching timeout value {}s'.format(timeout))
 
-                kill_process(process, output=output)
+                try:
+                    if callback:
+                        callback()
 
-                if callback:
-                    callback()
+                finally:
+                    kill_process(process, output=output)
                 break
             else:
                 delay = next(intervals)

--- a/testplan/common/utils/testing.py
+++ b/testplan/common/utils/testing.py
@@ -210,7 +210,7 @@ def check_report(expected, actual, skip=None):
     skip = skip or []
     attrs = [
         attr for attr in expected._get_comparison_attrs()
-        if attr not in ['entries', 'uid', 'timer'] + skip
+        if attr not in ['entries', 'uid', 'timer', 'logs'] + skip
     ]
 
     for attr in attrs:


### PR DESCRIPTION
When running a process test with a timeout, call the callback
function before killing the process. This avoids creating a
race condition with the main thread that is wait()-ing for
the process to terminate.

The above race condition was causing intermittent failures in the
functional/testplan/testing/test_base.py test - it now passes
consistently.

Also add "logs" to the list of attrs ignored when testing reports.
We should not be testing logs as this breaks when enabling Debug
logging!