### PR TITLE
Add example for parallel MultiTest usage

### DIFF
--- a/testplan/examples/Multitest/Parallel/parallel_tasks.py
+++ b/testplan/examples/Multitest/Parallel/parallel_tasks.py
@@ -1,0 +1,79 @@
+"""Example test suite to demonstrate grouped parallel MultiTest execution."""
+import time
+
+from testplan.testing.multitest import MultiTest
+from testplan.testing.multitest.suite import testsuite, testcase
+import resource_manager
+
+@testsuite
+class SampleTest(object):
+    """
+    Example test suite. The test cases are split into two different execution
+    groups. Only tests from the same group will be executed in parallel with
+    each other - the groups overall are executed serially. To demonstrate
+    this, each test acquires one of two resources that cannot both be acquired
+    in parallel.
+
+    You will find that modifying a single test from the "first" group to acquire
+    the "second" resource (or vice-versa) will cause the test to fail.
+    """
+
+    def __init__(self):
+        self._test_g2_1_done = False
+
+    @testcase(execution_group='first')
+    def test_g1_1(self, env, result):
+        """Wait for test_g1_2 to also acquire the first resource."""
+        with env.resources['first'] as res:
+            result.true(res.active)
+            while res.refcount < 2:
+                result.log('Waiting for test_g1_2...')
+                time.sleep(1)
+
+    @testcase(execution_group='second')
+    def test_g2_1(self, env, result):
+        """Assert that no other test holds the second resource."""
+        with env.resources['second'] as res:
+            result.true(res.active)
+            result.equal(res.refcount, 1)
+        self._test_g2_1_done = True
+
+    @testcase(execution_group='first')
+    def test_g1_2(self, env, result):
+        """
+        Sleep before acquiring the first resource. Wait for test_g1_1 to
+        release it first.
+        """
+        time.sleep(2.5)
+
+        with env.resources['first'] as res:
+            result.true(res.active)
+            result.equal(res.refcount, 2)
+            while res.refcount == 2:
+                result.log('Waiting for test_g1_1...')
+                time.sleep(1)
+
+    @testcase(execution_group='second')
+    def test_g2_2(self, env, result):
+        """Wait for test_g2_1 to release the resource before acquiring it."""
+        while not self._test_g2_1_done:
+            result.log('Waiting for test_g2_1 to finish...')
+            time.sleep(1)
+
+        with env.resources['second'] as res:
+            result.true(res.active)
+            result.equal(res.refcount, 1)
+
+
+def make_multitest():
+    """
+    Callable target to build a MultiTest. The `thread_pool_size` argument
+    instructs Testplan to create a thread pool for running the MultiTest
+    testcases.
+    """
+    return MultiTest(
+        name='Testcase Parallezation',
+        suites=[SampleTest()],
+        thread_pool_size=2,
+        environment=[
+            resource_manager.ExclusiveResourceManager(name='resources')])

--- a/testplan/examples/Multitest/Parallel/resource_manager.py
+++ b/testplan/examples/Multitest/Parallel/resource_manager.py
@@ -1,0 +1,85 @@
+"""
+Example of a custom driver, that manages several resources. Only a single
+resource may be "acquired" at a time, however that same resource may be
+acquired multiple times. The manager enforces this logic.
+"""
+import collections
+import functools
+
+from testplan.testing.multitest import driver
+
+
+class ExclusiveResourceManager(driver.Driver):
+    """
+    Driver which manages several resources. Only one resource may be active at a
+    time.
+
+    This is only a contrived example to demonstrate the grouping of parallel
+    tests execution - not a suggested pattern for managing resources.
+    """
+
+    RESOURCE_NAMES = ('first', 'second')
+
+    def __init__(self, **kwargs):
+        self._refcounts = collections.Counter()
+        self._resources = {}
+        for name in self.RESOURCE_NAMES:
+            self.add_resource(name)
+
+        super(ExclusiveResourceManager, self).__init__(**kwargs)
+
+    def __getitem__(self, item):
+        """Provide access to the resources."""
+        return self._resources[item]
+
+    def add_resource(self, name):
+        """Add a named resource."""
+        self._resources[name] = _AcquirableResource(
+            acquire_callback=functools.partial(self._acquire, name),
+            release_callback=functools.partial(self._release, name),
+            refcount_callback=lambda: self._refcounts[name])
+
+    def _acquire(self, resource_name):
+        """
+        Check that no other resources are in use. Increment the usage refcount.
+        """
+        if not all(count == 0
+                   for key, count in self._refcounts.items()
+                   if key != resource_name):
+            raise RuntimeError(
+                'Cannot acquire resource {} when other resources are in use.'
+                    .format(resource_name))
+        self._refcounts[resource_name] += 1
+
+    def _release(self, resource_name):
+        """Decrement the usage refcount."""
+        assert self._refcounts[resource_name] > 0
+        self._refcounts[resource_name] -= 1
+
+
+class _AcquirableResource(object):
+    """A resource which may be acquired via a `with` context."""
+
+    def __init__(self, acquire_callback, release_callback, refcount_callback):
+        self._acquire_callback = acquire_callback
+        self._release_callback = release_callback
+        self._refcount_callback = refcount_callback
+
+    def __enter__(self):
+        """Report back that this resource has been acquired."""
+        self._acquire_callback()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Report back that this resource has been released."""
+        self._release_callback()
+
+    @property
+    def active(self):
+        """:return: whether the resource has been acquired."""
+        return self.refcount > 0
+
+    @property
+    def refcount(self):
+        """:return: the number of active references to this resource."""
+        return self._refcount_callback()

--- a/testplan/examples/Multitest/Parallel/test_plan.py
+++ b/testplan/examples/Multitest/Parallel/test_plan.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""
+Example script to demonstrate parallel test execution of a MultiTest.
+"""
+import sys
+
+from testplan import test_plan
+from testplan.report.testing.styles import Style, StyleEnum
+
+OUTPUT_STYLE = Style(StyleEnum.ASSERTION_DETAIL, StyleEnum.ASSERTION_DETAIL)
+
+
+@test_plan(name='ParallelMultiTest',
+           pdf_path='report.pdf',
+           stdout_style=OUTPUT_STYLE,
+           pdf_style=OUTPUT_STYLE)
+def main(plan):
+    """
+    Testplan decorated main function. Adds a single parallel MultiTest to the
+    test plan.
+
+    :param plan: Plan to add MultiTest to.
+    :return: Results of tests.
+    """
+    plan.schedule(target='make_multitest', module='parallel_tasks')
+
+
+if __name__ == '__main__':
+    sys.exit(main().exit_code)

--- a/testplan/testing/multitest/driver/__init__.py
+++ b/testplan/testing/multitest/driver/__init__.py
@@ -1,1 +1,2 @@
 """Drivers modules."""
+from .base import Driver


### PR DESCRIPTION
New example demonstrates parallel execution of tests without
explicitly adding a Thread pool, by use of the thread_pool_size
argument to MultiTest.

Includes small fix to LocalRunner to handle being passed a Task
as input instead of a Runnable.