### PR TITLE
Fix a bug that a generator is traversed many times

### DIFF
--- a/testplan/common/report/base.py
+++ b/testplan/common/report/base.py
@@ -142,7 +142,7 @@ class Report(object):
         """
         self._check_report(report)
         # Merge logs
-        log_ids = (rec['uid'] for rec in self.logs)
+        log_ids = [rec['uid'] for rec in self.logs]
         self.logs += [rec for rec in report.logs if rec['uid'] not in log_ids]
 
     def append(self, item):

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -408,7 +408,7 @@ class TestGroupReport(BaseReportGroup):
 
     def merge(self, report, strict=True):
         """Propagate tag indices after merge operations."""
-        super(BaseReportGroup, self).merge(report, strict=strict)
+        super(TestGroupReport, self).merge(report, strict=strict)
         self.propagate_tag_indices()
 
 

--- a/testplan/testing/multitest/entries/base.py
+++ b/testplan/testing/multitest/entries/base.py
@@ -252,7 +252,7 @@ class DictLog(BaseEntry):
     def __init__(self, dictionary, description=None):
         formatted_obj = fmt(dictionary)
         if len(formatted_obj) != 2 or formatted_obj[0] != 2:
-            raise ValueError('Require a formatted object of mapping type')
+            raise TypeError('Require a formatted object of mapping type')
         self.flattened_dict = flatten_formatted_object(formatted_obj)
 
         super(DictLog, self).__init__(description=description)
@@ -262,6 +262,6 @@ class FixLog(DictLog):
     """Log a fix message to the report."""
     def __init__(self, msg, description=None):
         if not msg or not isinstance(msg, dict):
-            raise ValueError('Invalid format of fix message')
+            raise TypeError('Invalid format of fix message')
 
         super(FixLog, self).__init__(msg, description=description)


### PR DESCRIPTION
* The issue is in method Report::merge(). A generator can be traversed
  only once, use `list` instead if we need to access it many times.

* By the way, change Exception type from `ValueError` to `TypeError`
  during Dictlog/Fixlog initlization when a invalid value of unwanted
  type is passed.