### PR TITLE
Use platform-specific runpath locations

### DIFF
--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -203,3 +203,22 @@ def unique_name(name, names):
         base, ext = os.path.splitext(orig_name)
         name = "{base}{suffix}{ext}".format(base=base, suffix=suffix, ext=ext)
     return name
+
+
+def to_posix_path(from_path):
+    """
+    :param: File path, in local OS format.
+    :return: POSIX-formatted path.
+    """
+    return '/'.join(from_path.split(os.sep))
+
+
+def is_subdir(child, parent):
+    """
+    Check whether "parent" is a sub-directory of "child".
+
+    :param child: Child path.
+    :param parent: Parent directory to check against.
+    :return: True if child is a sub-directory of the parent.
+    """
+    return child.startswith(parent)

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -307,6 +307,8 @@ class RemoteChildLoop(ChildLoop):
             self._setup_metadata.workspace_paths.local
         os.environ['TESTPLAN_REMOTE_WORKSPACE'] = \
             self._setup_metadata.workspace_paths.remote
+        if self._setup_metadata.push_dir:
+            os.environ['TESTPLAN_PUSH_DIR'] = self._setup_metadata.push_dir
 
         if self._setup_metadata.setup_script:
             if subprocess.call(self._setup_metadata.setup_script,


### PR DESCRIPTION
New rules for the default runpath:

- On POSIX, try to create a runpath under /var/tmp if it exists
- Otherwise, create runpath under a platform-specific temporary location as returned by tempfile.gettempdir()

In addition, add new configuration option for RemotePool: "push_relative_dir". When set, instead of trying to re-create the full absolute path of pushed files on the remote host, they are pushed to a path under `_remote_testplan_path` with the relative structure up to the root conserved:

E.g. from Windows you could push "C:\path\to\file" with root "C:\path". This will be created under the testplan path as "/testplan_path/to/file". This enables the remote example to still work on Windows, as otherwise we likely will not have write permissions to create the full path on the remote. The /testplan_path root is made available to testsuites via the new TESTPLAN_PUSH_DIR environment variable.

The default behaviour of re-creating the full path on the remote is retained if the new config option is not set.