### PR TITLE
MultiTest parts scheduling

### DIFF
--- a/doc/en/download/Execution Pools.rst
+++ b/doc/en/download/Execution Pools.rst
@@ -54,3 +54,20 @@ test_plan.py
 tasks.py
 +++++++++
 .. literalinclude:: ../../../testplan/examples/ExecutionPools/Remote/tasks.py
+
+.. _example_multiTest_parts:
+
+MultiTest parts scheduling
+--------------------------
+
+Required files:
+  - :download:`test_plan.py <../../../testplan/examples/ExecutionPools/Parts/test_plan.py>`
+  - :download:`tasks.py <../../../testplan/examples/ExecutionPools/Parts/tasks.py>`
+
+test_plan.py
+++++++++++++
+.. literalinclude:: ../../../testplan/examples/ExecutionPools/Parts/test_plan.py
+
+tasks.py
++++++++++
+.. literalinclude:: ../../../testplan/examples/ExecutionPools/Parts/tasks.py

--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -1249,7 +1249,6 @@ Testcases in the same group will be executed concurrently.
                                   suites=[SampleTest()],
                                   thread_pool_size=2))
 
-
 .. _multitest_drivers:
 
 Drivers

--- a/doc/en/pools.rst
+++ b/doc/en/pools.rst
@@ -259,3 +259,45 @@ failures and their behaviour is a part of
 
            # Add the pool to the plan.
            pool_uid = plan.add_resource(pool)
+
+.. _Multitest_parts_scheduling:
+
+MultiTest parts scheduling
+--------------------------
+
+A Task that returns a MultiTest can be scheduled in parts in one or more pools.
+Each MultiTest will have its own environment and will run a subtotal of testcases
+based on which part of the total number of parts it is. So each MultiTest part will
+produce its own report entry, these entries can be merged before exported.
+
+To split a MultiTest task into several parts, we can provide a tuple of 2 elements
+as a parameter, the first element indicates the sequence number of part, and the
+second one is the number of parts in total. For the tuple (M, N), make sure that
+N > 1 and 0 <= M < N, where M and N are both integers.
+
+.. code-block:: python
+
+    from testplan.runners.pools import ThreadPool
+
+    @test_plan(name='ThreadPoolPlan', merge_scheduled_parts=False)
+    def main(plan):
+        # Add a thread pool of 3 workers.
+        # Also you can use process pool or remote pool instead.
+        pool = ThreadPool(name='MyPool', size=3)
+        plan.add_resource(pool)
+
+        # Schedule 10 tasks to the thread pool.
+        # A parameter `part_tuple` is provided to indicate which part it is.
+        for idx in range(10):
+            task = Task(target='make_multitest',
+                        module='tasks',
+                        kwargs={'part_tuple': (i, 10)})
+            plan.schedule(task, resource='MyPool')
+
+If you set merge_scheduled_parts=True, please be sure that all parts of a MultiTest
+will be executed, for example, if a MultiTest is split into 3 parts, then 3 tasks
+containing MultiTest part should be scheduled, with the parameter tuple (0, 3),
+(1, 3) and (2, 3) for each task, also note that a MultiTest can only be schedule
+once, or there will be error during merging reports.
+
+See a downloadable example of :ref:`MultiTest parts scheduling <example_multiTest_parts>`.

--- a/test/functional/testplan/testing/multitest/test_multitest_parts.py
+++ b/test/functional/testplan/testing/multitest/test_multitest_parts.py
@@ -1,0 +1,183 @@
+import os
+
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+
+from testplan import Testplan
+from testplan.runners.pools import ThreadPool
+from testplan.runners.pools.tasks import Task
+from testplan.report.testing import Status
+from testplan.common.utils.testing import log_propagation_disabled
+from testplan.logger import TESTPLAN_LOGGER
+
+
+@testsuite
+class Suite1(object):
+    """A test suite with parameterized testcases."""
+    @testcase(
+        parameters=tuple(range(10))
+    )
+    def test_true(self, env, result, val):
+        result.true(val, description='Check if value is true')
+
+
+@testsuite
+class Suite2(object):
+    """A test suite with parameterized testcases."""
+    @testcase(
+        parameters=(
+            False,
+            True,
+            None,
+        )
+    )
+    def test_false(self, env, result, val):
+        result.false(val, description='Check if value is false')
+
+
+def get_mtest(part_tuple=None):
+    test = MultiTest(name='MTest',
+                     suites=[Suite1(), Suite2()],
+                     part=part_tuple)
+    return test
+
+'''
+def test_multi_parts_not_merged():
+    """Execute MultiTest parts but do not merge report."""
+    plan = Testplan(name='plan', parse_cmdline=False,
+                    merge_scheduled_parts=False)
+    pool = ThreadPool(name='MyPool', size=2)
+    plan.add_resource(pool)
+
+    for idx in range(3):
+        task = Task(target=get_mtest(part_tuple=(idx, 3)))
+        plan.schedule(task, resource='MyPool')
+
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        assert plan.run().run is True
+
+    assert len(plan.report.entries) == 3
+    assert plan.report.entries[0].name == 'MTest - part(1/3)'
+    assert plan.report.entries[1].name == 'MTest - part(2/3)'
+    assert plan.report.entries[2].name == 'MTest - part(3/3)'
+    assert len(plan.report.entries[0].entries) == 2  # 2 suites
+    assert plan.report.entries[0].entries[0].name == 'Suite1'
+    assert plan.report.entries[0].entries[1].name == 'Suite2'
+    assert len(plan.report.entries[0].entries[0].entries) == 1  # param group
+    assert plan.report.entries[0].entries[0].entries[0].name == 'test_true'
+    assert len(plan.report.entries[0].entries[1].entries) == 1  # param group
+    assert plan.report.entries[0].entries[1].entries[0].name == 'test_false'
+    assert len(plan.report.entries[0].entries[0].entries[0].entries) == 4
+    assert len(plan.report.entries[0].entries[1].entries[0].entries) == 1
+
+
+def test_multi_parts_merged():
+    """Execute MultiTest parts and merge report."""
+    plan = Testplan(name='plan', parse_cmdline=False,
+                    merge_scheduled_parts=True)
+    pool = ThreadPool(name='MyPool', size=2)
+    plan.add_resource(pool)
+
+    for idx in range(3):
+        task = Task(target=get_mtest(part_tuple=(idx, 3)))
+        plan.schedule(task, resource='MyPool')
+
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        assert plan.run().run is True
+
+    assert len(plan.report.entries) == 1
+    assert plan.report.entries[0].name == 'MTest'
+    assert len(plan.report.entries[0].entries) == 2  # 2 suites
+    assert plan.report.entries[0].entries[0].name == 'Suite1'
+    assert plan.report.entries[0].entries[1].name == 'Suite2'
+    assert len(plan.report.entries[0].entries[0].entries) == 1  # param group
+    assert plan.report.entries[0].entries[0].entries[0].name == 'test_true'
+    assert len(plan.report.entries[0].entries[1].entries) == 1  # param group
+    assert plan.report.entries[0].entries[1].entries[0].name == 'test_false'
+    assert len(plan.report.entries[0].entries[0].entries[0].entries) == 10
+    assert len(plan.report.entries[0].entries[1].entries[0].entries) == 3
+
+
+def test_multi_parts_invalid_parameter_1():
+    """
+    Execute MultiTest parts with invalid parameters that a part of
+    MultiTest has been scheduled twice.
+    """
+    plan = Testplan(name='plan', parse_cmdline=False,
+                    merge_scheduled_parts=True)
+    pool = ThreadPool(name='MyPool', size=2)
+    plan.add_resource(pool)
+
+    for idx in range(3):
+        task = Task(target=get_mtest(part_tuple=(idx, 3)))
+        plan.schedule(task, resource='MyPool')
+    plan.schedule(Task(target=get_mtest(part_tuple=(1, 3))),
+                  resource='MyPool')
+
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        assert plan.run().run is False
+
+    assert len(plan.report.entries) == 1
+    assert len(plan.report.entries[0].entries) == 2
+    assert plan.report.status == Status.ERROR  # Testplan result
+    assert plan.report.entries[0].status == Status.ERROR  # Multitest
+    assert plan.report.entries[0].entries[0].status == Status.FAILED  # Suite1
+    assert plan.report.entries[0].entries[1].status == Status.FAILED  # Suite2
+    assert 'invalid parameter of part provided' in \
+           plan.report.entries[0].logs[0]['message']
+
+
+def test_multi_parts_invalid_parameter_2():
+    """
+    Execute MultiTest parts with invalid parameters that a MultiTest
+    has been scheduled twice.
+    """
+    plan = Testplan(name='plan', parse_cmdline=False,
+                    merge_scheduled_parts=True)
+    pool = ThreadPool(name='MyPool', size=2)
+    plan.add_resource(pool)
+
+    for idx in range(3):
+        task = Task(target=get_mtest(part_tuple=(idx, 3)))
+        plan.schedule(task, resource='MyPool')
+    for idx in range(2):
+        task = Task(target=get_mtest(part_tuple=(idx, 2)))
+        plan.schedule(task, resource='MyPool')
+
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        assert plan.run().run is False
+
+    assert len(plan.report.entries) == 1
+    assert len(plan.report.entries[0].entries) == 2
+    assert plan.report.status == Status.ERROR  # Testplan result
+    assert plan.report.entries[0].status == Status.ERROR  # Multitest
+    assert plan.report.entries[0].entries[0].status == Status.FAILED  # Suite1
+    assert plan.report.entries[0].entries[1].status == Status.FAILED  # Suite2
+    assert 'invalid parameter of part provided' in \
+           plan.report.entries[0].logs[0]['message']
+'''
+
+def test_multi_parts_missing_parts():
+    """
+    Execute MultiTest parts with invalid parameters that not all
+    parts of a MultiTest has been scheduled.
+    """
+    plan = Testplan(name='plan', parse_cmdline=False,
+                    merge_scheduled_parts=True)
+    pool = ThreadPool(name='MyPool', size=2)
+    plan.add_resource(pool)
+
+    for idx in range(1, 3):
+        task = Task(target=get_mtest(part_tuple=(idx, 3)))
+        plan.schedule(task, resource='MyPool')
+
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        assert plan.run().run is False
+
+    assert len(plan.report.entries) == 1
+    assert len(plan.report.entries[0].entries) == 2
+    assert plan.report.status == Status.ERROR  # Testplan result
+    assert plan.report.entries[0].status == Status.ERROR  # Multitest
+    assert plan.report.entries[0].entries[0].status == Status.PASSED  # Suite1
+    assert plan.report.entries[0].entries[1].status == Status.FAILED  # Suite2
+    assert 'not all MultiTest parts had been scheduled' in \
+           plan.report.entries[0].logs[0]['message']

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -703,6 +703,10 @@ class Runnable(Entity):
         return all(not isinstance(val, Exception) and val is not False
                    for val in self._result.step_results.values())
 
+    def dry_run(self):
+        """A testing process that creates result for each step."""
+        raise NotImplementedError
+
 
 class FailedAction(object):
     """

--- a/testplan/common/report/base.py
+++ b/testplan/common/report/base.py
@@ -169,6 +169,13 @@ class Report(object):
 
         return report_obj
 
+    def reset_uid(self, uid=None):
+        """
+        Reset uid of the report, it can be useful when need to generate
+        a standard UUID instead of the current one.
+        """
+        self.uid = uuid.uuid4() if uid is None else uid
+
     def flattened_entries(self, depth):
         """
         Utility function that is used by `TestGroupReport.flatten`.
@@ -258,7 +265,7 @@ class ReportGroup(Report):
 
         if item.uid in self._index:
             raise ValueError(
-                'Child report with `uid` `{uid}`'
+                'Child report with `uid`: {uid}'
                 ' already exists in {self}'.format(uid=item.uid, self=self))
 
         self._index[item.uid] = item
@@ -288,6 +295,17 @@ class ReportGroup(Report):
             report_obj.build_index(recursive=True)
 
         return report_obj
+
+    def reset_uid(self, uid=None):
+        """
+        Reset uid of the report and all of its children, it can be useful
+        when need to generate standard UUIDs instead of the current ones.
+        """
+        self.uid = uuid.uuid4() if uid is None else uid
+        for entry in self:
+            if isinstance(entry, (Report, ReportGroup)):
+                entry.reset_uid()
+        self.build_index()
 
     def flatten(self, depths=False):
         """

--- a/testplan/examples/ExecutionPools/Parts/tasks.py
+++ b/testplan/examples/ExecutionPools/Parts/tasks.py
@@ -1,0 +1,47 @@
+"""Tests to be executed in multi-parts and task will be schedule in a pool."""
+
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+
+@testsuite
+class Suite1(object):
+    """A test suite with several normal testcases."""
+    @testcase
+    def test_equal(self, env, result):
+        result.equal('foo', 'foo', description='Equality example')
+
+    @testcase
+    def test_not_equal(self, env, result):
+        result.not_equal('foo', 'bar',  description='Inequality example')
+
+    @testcase
+    def test_less(self, env, result):
+        result.less(2, 12, description='Less comparison example')
+
+    @testcase
+    def test_greater(self, env, result):
+        result.greater(10, 5, description='Greater comparison example')
+
+    @testcase
+    def test_approximate_equal(self, env, result):
+        result.isclose(100, 101, rel_tol=0.01, abs_tol=0.0,
+                       description='Approximate equality example')
+
+
+@testsuite
+class Suite2(object):
+    """A test suite with parameterized testcases."""
+    @testcase(
+        parameters=tuple(range(6))
+    )
+    def test_bool(self, env, result, val):
+        if val > 0:
+            result.true(val, description='Check if value is true')
+        else:
+            result.false(val, description='Check if value is false')
+
+
+def make_multitest(part_tuple=None):
+    test = MultiTest(name='MultitestParts',
+                     suites=[Suite1(), Suite2()],
+                     part=part_tuple)
+    return test

--- a/testplan/examples/ExecutionPools/Parts/test_plan.py
+++ b/testplan/examples/ExecutionPools/Parts/test_plan.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""
+This example is to demonstrate parallel test execution with parts in a pool.
+"""
+
+import sys
+
+from testplan import test_plan, Task
+from testplan.parser import TestplanParser
+from testplan.runners.pools import ThreadPool
+from testplan.report.testing.styles import Style, StyleEnum
+
+OUTPUT_STYLE = Style(StyleEnum.ASSERTION_DETAIL, StyleEnum.ASSERTION_DETAIL)
+
+
+class CustomParser(TestplanParser):
+    """Inheriting base parser."""
+
+    def add_arguments(self, parser):
+        """Defining custom arguments for this Testplan."""
+        parser.add_argument('--parts-num',
+                            action='store', type=int, default=3,
+                            help='Number of parts to be split.')
+        parser.add_argument('--pool-size',
+                            action='store', type=int, default=3,
+                            help='How many thread workers assigned to pool.')
+
+
+# Using a custom parser to support `--tasks-num` and `--pool-size` command
+# line arguments so that users can experiment with thread pool test execution.
+
+# Hard-coding `pdf_path`, 'stdout_style' and 'pdf_style' so that the
+# downloadable example gives meaningful and presentable output.
+# NOTE: this programmatic arguments passing approach will cause Testplan
+# to ignore any command line arguments related to that functionality.
+@test_plan(name='MultiTestPartsExecution',
+           parser=CustomParser,
+           pdf_path='report.pdf',
+           stdout_style=OUTPUT_STYLE,
+           pdf_style=OUTPUT_STYLE,
+           merge_scheduled_parts=False)
+def main(plan):
+    """
+    Testplan decorated main function to add and execute MultiTests.
+
+    :return: Testplan result object.
+    :rtype:  ``testplan.base.TestplanResult``
+    """
+    # Add a thread pool test execution resource to the plan of given size.
+    # Also you can use process pool or remote pool instead.
+    pool = ThreadPool(name='MyPool', size=plan.args.pool_size)
+    plan.add_resource(pool)
+
+    # Add a given number of similar tests to the thread pool
+    # to be executed in parallel.
+    for idx in range(plan.args.parts_num):
+        task = Task(target='make_multitest',
+                    module='tasks',
+                    kwargs={'part_tuple': (idx, plan.args.parts_num)})
+        plan.schedule(task, resource='MyPool')
+
+
+if __name__ == '__main__':
+    res = main()
+    print('Exiting code: {}'.format(res.exit_code))
+    sys.exit(res.exit_code)

--- a/testplan/report/testing/schemas.py
+++ b/testplan/report/testing/schemas.py
@@ -77,6 +77,7 @@ class TestCaseReportSchema(ReportSchema):
     entries = fields.List(fields.Raw())
 
     status = fields.String(dump_only=True)
+    suite_related = fields.Bool()
     timer = TimerField()
     tags = TagField()
 
@@ -102,6 +103,7 @@ class TestGroupReportSchema(TestCaseReportSchema):
 
     source_class = TestGroupReport
     category = fields.String(allow_none=True)
+    part = fields.List(fields.Integer, allow_none=True)
 
     entries = custom_fields.GenericNested(
         schema_context={

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -46,7 +46,12 @@ class TestConfig(RunnableConfig):
             ConfigOption(
                 'tags',
                 default=None
-            ): Or(None, Use(tagging.validate_tag_value))
+            ): Or(None, Use(tagging.validate_tag_value)),
+            ConfigOption(
+                'part',
+                default=None)
+            : Or(None, And((int,), lambda tp:
+                len(tp) == 2 and 0 <= tp[0] < tp[1] and tp[1] > 1))
         }
 
 
@@ -98,9 +103,11 @@ class Test(Runnable):
         self._test_context = None
         self.result.report = TestGroupReport(
             name=self.cfg.name,
-            category=self.__class__.__name__.lower(),
             description=self.cfg.description,
+            category=self.__class__.__name__.lower(),
+            uid=self.uid(),
             tags=self.cfg.tags,
+            part=self.cfg.part,
         )
 
     def __str__(self):


### PR DESCRIPTION
* A Task that returns a MultiTest can be scheduled in parts in one or
  more pools. Each MultiTest will have its own environment and will run
  a subtotal of testcases based on which part of the total number of
  parts it is. Each MultiTest part will produce its own report entry.
  ISSUE: should the testcase reports be re-ordered after merging?