### PR TITLE
Poll resource health when running tests.

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -855,6 +855,14 @@ class Resource(Entity):
         self.stop()
         self.wait(self.STATUS.STOPPED)
 
+    @property
+    def is_alive(self):
+        """
+        Called to periodically poll the resource health. Default implementation
+        assumes the resource is always healthy.
+        """
+        return True
+
 
 class RunnableManagerStatus(EntityConfig):
     """
@@ -977,4 +985,3 @@ class RunnableManager(Entity):
     def aborting(self):
         """Suppressing not implemented debug log by parent class."""
         pass
-

--- a/testplan/runnable.py
+++ b/testplan/runnable.py
@@ -401,6 +401,13 @@ class TestRunner(Runnable):
                 if resource.ongoing:
                     # Maybe print periodically ongoing resource
                     ongoing = True
+
+                # Poll the resource's health - if it has unexpectedly died
+                # then abort the entire test to avoid hanging.
+                if not resource.is_alive:
+                    self.abort()
+                    self.result.test_report.status_override = Status.ERROR
+
             if ongoing is False:
                 break
             time.sleep(self.cfg.active_loop_sleep)

--- a/testplan/runners/base.py
+++ b/testplan/runners/base.py
@@ -88,3 +88,8 @@ class Executor(Resource):
         """Abort items running before aborting self."""
         for uid in self.ongoing:
             yield self._input[uid]
+
+    @property
+    def is_alive(self):
+        """Poll the loop handler thread to check it is running as expected."""
+        return self._loop_handler.is_alive()

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -241,6 +241,11 @@ class Worker(Resource):
         """Aborting logic, will not wait running tasks."""
         self._transport.active = False
 
+    @property
+    def is_alive(self):
+        """Poll the loop handler thread to check it is running as expected."""
+        return self._loop_handler.is_alive()
+
     def _loop(self, transport):
         message = Message(**self.metadata)
 


### PR DESCRIPTION
When the main thread is awaiting test completion, it
now also polls each resource's health via the new is_alive
Resource property. Main intended use is to catch when unhandled
Exceptions have killed loop threads used by test Executors,
to prevent Testplan hanging indefinitely.