### PR TITLE
Diff assertion in table namespace

### DIFF
--- a/doc/en/assertions.rst
+++ b/doc/en/assertions.rst
@@ -1018,6 +1018,66 @@ values and supports regex / custom comparators as well.
 
           ...
 
+:py:meth:`result.table.diff <testplan.testing.multitest.result.TableNamespace.diff>`
+--------------------------------------------------------------------------------------
+
+Find differences of two tables, uses equality for each table cell for plain
+values and supports regex / custom comparators as well.
+
+    .. code-block:: python
+
+      from testplan.common.utils import comparison
+
+      @testcase
+      def sample_testcase(self, env, result):
+
+          # Table in list of lists format
+          actual_table = [
+              ['name', 'age'],
+              ['Bob', 32],
+              ['Susan', 24],
+              ['Rick', 67]
+          ]
+
+        # Compare table with itself, plain comparison for each cell
+        result.table.diff(actual_table, actual_table)
+
+        # Another table with regexes & custom comparators
+        expected_table = [
+            ['name', 'age'],
+            [
+                re.compile(r'\w{3}'),
+                comparison.Greater(35) & comparison.Less(40)
+            ],
+            ['Susan', 24],
+            [comparison.In(['David', 'Helen']), 67]
+        ]
+
+        result.table.diff(
+            actual_table, expected_table,
+            description='Table diff with custom comparators'
+        )
+
+
+    Sample output:
+
+    .. code-block:: bash
+
+      $ test_plan.py --verbose
+          ...
+          Table Diff - Pass
+          Table diff with custom comparators - Fail
+            File: .../test_plan.py
+            Line: 95
+            +-----+-----------------------------------+-------------------------------+
+            | row | name                              | age                           |
+            +-----+-----------------------------------+-------------------------------+
+            | 0   | Bob == REGEX('\w{3}')             | 32 != (VAL > 35 and VAL < 40) |
+            | 2   | Rick != VAL in ['David', 'Helen'] | 67 == 67                      |
+            +-----+-----------------------------------+-------------------------------+
+
+          ...
+
 :py:meth:`result.table.log <testplan.testing.multitest.result.TableNamespace.log>`
 ----------------------------------------------------------------------------------
 

--- a/test/functional/testplan/runners/fixtures/assertions_failing/report.py
+++ b/test/functional/testplan/runners/fixtures/assertions_failing/report.py
@@ -763,6 +763,134 @@ expected_report = TestReport(
                                             {'value': 10}, {}, {}
                                         ),
                                         (
+                                            1,
+                                            ['bbb', 2],
+                                            {}, {}, {}
+                                        ),
+                                        (
+                                            2,
+                                            ['ccc', 3],
+                                            {'value': 30}, {}, {}
+                                        ),
+                                    ]
+                                },
+                            ],
+                        ),
+                        TestCaseReport(
+                            name='test_table_diff',
+                            entries=[
+                                {
+                                    'type': 'TableDiff',
+                                    'description': 'basic table diff',
+                                    'columns': ['name', 'value'],
+                                    'include_columns': None,
+                                    'exclude_columns': None,
+                                    'message': None,
+                                    'passed': True,
+                                    'data': []
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'passed': True,
+                                    'data': []
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'passed': True,
+                                    'data': []
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'columns': ['name', 'value'],
+                                    'passed': False,
+                                    'data': [
+                                        (
+                                            3,
+                                            ['ddd', 4],
+                                            # diff populated
+                                            {'name': 'xxx'}, {}, {}
+                                        ),
+                                    ]
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'passed': False,
+                                    'data': [
+                                        (
+                                            3,
+                                            ['ddd', 4],
+                                            {'name': always_false.__name__},
+                                            {}, {}
+                                        ),
+                                    ]
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'passed': False,
+                                    'data': [
+                                        (
+                                            3,
+                                            ['ddd', 4],
+                                            {'name': 'REGEX(zzz)'},
+                                            {}, {}
+                                        ),
+                                    ]
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'passed': False,
+                                    'data': check_row_comparison_data([
+                                        (
+                                            3,
+                                            ['ddd', 4],
+                                            {},
+                                            # Check traceback msg
+                                            {'name': lambda v: ERROR_MSG in v},
+                                            {}
+                                        ),
+                                    ])
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'columns': ['name'],
+                                    'include_columns': ['name'],
+                                    'passed': True,
+                                    'data': []
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'columns': ['name', 'value', 'is_finished'],
+                                    'include_columns': ['name'],
+                                    'passed': True,
+                                    'data': []
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'columns': ['name'],
+                                    'exclude_columns': ['value', 'is_finished'],
+                                    'passed': True,
+                                    'data': []
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'columns': ['name', 'value', 'is_finished'],
+                                    'exclude_columns': ['value', 'is_finished'],
+                                    'passed': True,
+                                    'data': []
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'columns': ['name', 'value'],
+                                    'include_columns': ['name', 'value'],
+                                    'fail_limit': 2,
+                                    'passed': False,
+                                    'data': [
+                                        (
+                                            0,
+                                            ['aaa', 1],
+                                            {'value': 10}, {}, {}
+                                        ),
+                                        (
                                             2,
                                             ['ccc', 3],
                                             {'value': 30}, {}, {}

--- a/test/functional/testplan/runners/fixtures/assertions_failing/suites.py
+++ b/test/functional/testplan/runners/fixtures/assertions_failing/suites.py
@@ -257,7 +257,95 @@ class MySuite(object):
             expected=[
                 ['name', 'value'],
                 ['aaa', 10],  # mismatch -> included
-                ['bbb', 2],   # match & fail_limit != None -> excluded
+                ['bbb', 2],   # match & fail_limit < 2 -> included
+                ['ccc', 30],  # mismatch -> included
+                ['ddd', 40],  # mismatch & fail_limit = 2 -> excluded
+            ],
+            include_columns=['name', 'value'],
+            fail_limit=2,
+        )
+
+    @testcase
+    def test_table_diff(self, env, result):
+        table = [
+            ['name', 'value'],
+            ['aaa', 1],
+            ['bbb', 2],
+            ['ccc', 3],
+            ['ddd', 4],
+        ]
+
+        result.table.diff(
+            actual=table,
+            expected=table,
+            description='basic table diff')
+
+        result.table.diff(
+            actual=table,
+            expected=table[:-1] + [[always_true, 4]])
+
+        result.table.diff(
+            actual=table,
+            expected=table[:-1] + [[re.compile(r'd+'), 4]])
+
+        result.table.diff(
+            actual=table,
+            expected=table[:-1] + [['xxx', 4]])
+
+        result.table.diff(
+            actual=table,
+            expected=table[:-1] + [[always_false, 4]])
+
+        result.table.diff(
+            actual=table,
+            expected=table[:-1] + [[re.compile(r'zzz'), 4]])
+
+        result.table.diff(
+            actual=table,
+            expected=table[:-1] + [[error_func, 4]])
+
+        table_2 = [
+            ['name', 'value', 'is_finished'],
+            ['aaa', 10, True],
+            ['bbb', 20, False],
+            ['ccc', 30, True],
+            ['ddd', 40, False],
+        ]
+
+        result.table.diff(
+            actual=table_2,
+            expected=table,
+            include_columns=['name'],
+            report_all=False
+        )
+
+        result.table.diff(
+            actual=table_2,
+            expected=table,
+            include_columns=['name'],
+            report_all=True,
+        )
+
+        result.table.diff(
+            actual=table_2,
+            expected=table,
+            exclude_columns=['value', 'is_finished'],
+            report_all=False,
+        )
+
+        result.table.diff(
+            actual=table_2,
+            expected=table,
+            exclude_columns=['value', 'is_finished'],
+            report_all=True,
+        )
+
+        result.table.diff(
+            actual=table,
+            expected=[
+                ['name', 'value'],
+                ['aaa', 10],  # mismatch -> included
+                ['bbb', 2],   # match & fail_limit < 2 -> included
                 ['ccc', 30],  # mismatch -> included
                 ['ddd', 40],  # mismatch & fail_limit = 2 -> excluded
             ],

--- a/test/functional/testplan/runners/fixtures/assertions_passing/report.py
+++ b/test/functional/testplan/runners/fixtures/assertions_passing/report.py
@@ -495,6 +495,59 @@ expected_report = TestReport(
                             ],
                         ),
                         TestCaseReport(
+                            name='test_table_diff',
+                            entries=[
+                                {
+                                    'type': 'TableDiff',
+                                    'description': 'basic table diff',
+                                    'columns': ['name', 'value'],
+                                    'include_columns': None,
+                                    'exclude_columns': None,
+                                    'message': None,
+                                    'passed': True,
+                                    'data': []
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'passed': True,
+                                    'data': []
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'passed': True,
+                                    'data': []
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'columns': ['name'],
+                                    'include_columns': ['name'],
+                                    'passed': True,
+                                    'data': []
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'columns': ['name', 'value', 'is_finished'],
+                                    'include_columns': ['name'],
+                                    'passed': True,
+                                    'data': []
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'columns': ['name'],
+                                    'exclude_columns': ['value', 'is_finished'],
+                                    'passed': True,
+                                    'data': []
+                                },
+                                {
+                                    'type': 'TableDiff',
+                                    'columns': ['name', 'value', 'is_finished'],
+                                    'exclude_columns': ['value', 'is_finished'],
+                                    'passed': True,
+                                    'data': []
+                                },
+                            ],
+                        ),
+                        TestCaseReport(
                             name='test_table_log',
                             entries=[
                                 {

--- a/test/functional/testplan/runners/fixtures/assertions_passing/suites.py
+++ b/test/functional/testplan/runners/fixtures/assertions_passing/suites.py
@@ -197,6 +197,65 @@ class MySuite(object):
         )
 
     @testcase
+    def test_table_diff(self, env, result):
+        table = [
+            ['name', 'value'],
+            ['aaa', 1],
+            ['bbb', 2],
+            ['ccc', 3],
+            ['ddd', 4],
+        ]
+
+        result.table.diff(
+            actual=table,
+            expected=table,
+            description='basic table diff')
+
+        result.table.diff(
+            actual=table,
+            expected=table[:-1] + [[always_true, 4]])
+
+        result.table.diff(
+            actual=table,
+            expected=table[:-1] + [[re.compile(r'd+'), 4]])
+
+        table_2 = [
+            ['name', 'value', 'is_finished'],
+            ['aaa', 10, True],
+            ['bbb', 20, False],
+            ['ccc', 30, True],
+            ['ddd', 40, False],
+        ]
+
+        result.table.diff(
+            actual=table_2,
+            expected=table,
+            include_columns=['name'],
+            report_all=False
+        )
+
+        result.table.diff(
+            actual=table_2,
+            expected=table,
+            include_columns=['name'],
+            report_all=True,
+        )
+
+        result.table.diff(
+            actual=table_2,
+            expected=table,
+            exclude_columns=['value', 'is_finished'],
+            report_all=False,
+        )
+
+        result.table.diff(
+            actual=table_2,
+            expected=table,
+            exclude_columns=['value', 'is_finished'],
+            report_all=True,
+        )
+
+    @testcase
     def test_table_log(self, env, result):
         table = [
             ['name', 'value'],

--- a/testplan/common/utils/table.py
+++ b/testplan/common/utils/table.py
@@ -16,7 +16,7 @@ class TableEntry(object):
 
     def _check_table(self, table):
         """Make the original table argument is a valid."""
-        error_msg = '`table` must a list of' \
+        error_msg = '`table` must be a list of' \
                     ' lists or list of dicts: {}'.format(table)
 
         if not isinstance(table, (list, tuple)):

--- a/testplan/examples/Assertions/Basic/test_plan.py
+++ b/testplan/examples/Assertions/Basic/test_plan.py
@@ -294,6 +294,21 @@ class SampleSuite(object):
             description='Table Match: list of dict vs list of list'
         )
 
+        result.table.diff(
+            list_of_lists, list_of_lists,
+            description='Table Diff: list of list vs list of list'
+        )
+
+        result.table.diff(
+            list_of_dicts, list_of_dicts,
+            description='Table Diff: list of dict vs list of dict'
+        )
+
+        result.table.diff(
+            list_of_dicts, list_of_lists,
+            description='Table Diff: list of dict vs list of list'
+        )
+
         # For table match, Testplan allows use of custom comparators
         # (callables & regex) instead of plain value matching
 
@@ -323,8 +338,14 @@ class SampleSuite(object):
             description='Table Match: simple comparators'
         )
 
+        result.table.diff(
+            actual_table, expected_table,
+            description='Table Diff: simple comparators'
+        )
+
         # Equivalent assertion as above, using Testplan's custom comparators
         # These utilities produce more readable output
+
         expected_table_2 = [
             ['name', 'age'],
             [
@@ -338,6 +359,11 @@ class SampleSuite(object):
         result.table.match(
             actual_table, expected_table_2,
             description='Table Match: readable comparators'
+        )
+
+        result.table.diff(
+            actual_table, expected_table_2,
+            description='Table Diff: readable comparators'
         )
 
         # While comparing tables with large number of columns
@@ -357,10 +383,23 @@ class SampleSuite(object):
             description='Table Match: Trimmed columns'
         )
 
-        # While comparing tables with large number of rows
-        # we can 'trim' some rows and display a limited number of failures only
+        result.table.diff(
+            table_with_many_columns,
+            table_with_many_columns,
+            include_columns=['column_1', 'column_2'],
+            report_all=False,
+            description='Table Diff: Trimmed columns'
+        )
 
-        matching_rows = [
+        # While comparing tables with large number of rows
+        # we can stop comparing if the number of failed rows exceeds the limit
+
+        matching_rows_1 = [
+            {'amount': idx * 10, 'product_id': random.randint(1000, 5000)}
+            for idx in range(5)
+        ]
+
+        matching_rows_2 = [
             {'amount': idx * 10, 'product_id': random.randint(1000, 5000)}
             for idx in range(500)
         ]
@@ -377,16 +416,25 @@ class SampleSuite(object):
             {'amount': 20, 'product_id': 5432},
         ]
 
-        table_a = matching_rows + row_diff_a + matching_rows
-        table_b = matching_rows + row_diff_b + matching_rows
+        table_a = matching_rows_1 + row_diff_a + matching_rows_2
+        table_b = matching_rows_1 + row_diff_b + matching_rows_2
 
-        # Only display mismatching rows, with a maximum limit of 2 rows
+        # We can 'trim' some rows and display at most 2 rows of failures
         result.table.match(
             table_a,
             table_b,
             fail_limit=2,
             report_all=False,
             description='Table Match: Trimmed rows'
+        )
+
+        # Only display mismatching rows, with a maximum limit of 2 rows
+        result.table.diff(
+            table_a,
+            table_b,
+            fail_limit=2,
+            report_all=False,
+            description='Table Diff: Trimmed rows'
         )
 
         # result.table.column_contain can be used for checking if all of the

--- a/testplan/exporters/testing/pdf/renderers/entries/assertions.py
+++ b/testplan/exporters/testing/pdf/renderers/entries/assertions.py
@@ -680,7 +680,10 @@ class XMLCheckRenderer(AssertionRenderer):
             return msg_row
 
 
-@registry.bind(assertions.TableMatch)
+@registry.bind(
+    assertions.TableMatch,
+    assertions.TableDiff
+)
 class TableMatchRenderer(AssertionRenderer):
     """
     Renders serialized tabular data in ReportLab table format.
@@ -772,19 +775,20 @@ class TableMatchRenderer(AssertionRenderer):
             colour_matrix.append(colour_row)
 
         max_width = const.PAGE_WIDTH - (depth * const.INDENT)
-        display_index = source['fail_limit'] > 0
         table = create_table(
             table=raw_table,
             columns=source['columns'],
             row_indices=row_indices,
-            display_index=display_index,
+            display_index=source['report_fails_only'],
             max_width=max_width,
             style=table_style,
             colour_matrix=colour_matrix
-        )
+        ) if raw_table else None
 
         if source['message']:
-            error_style = row_style + [RowStyle(textcolor=colors.red)]
+            error_style = row_style + [RowStyle(
+                font=(const.FONT, const.FONT_SIZE_SMALL),
+                textcolor=colors.black if source['passed'] else colors.red)]
             error = RowData(
                 content=source['message'],
                 start=row_idx,
@@ -795,9 +799,10 @@ class TableMatchRenderer(AssertionRenderer):
                 content=table,
                 start=error.end,
                 style=row_style
-            )
+            ) if table else error
         else:
-            return RowData(content=table, start=row_idx, style=row_style)
+            return RowData(content=table, start=row_idx, style=row_style) \
+                if table else None
 
 
 @registry.bind(assertions.ColumnContain)

--- a/testplan/exporters/testing/pdf/renderers/entries/base.py
+++ b/testplan/exporters/testing/pdf/renderers/entries/base.py
@@ -129,8 +129,8 @@ class LogRenderer(SerializedEntryRenderer):
                 isinstance(source['message'], six.string_types):
             return header
 
-        log_msg = str(source['message']) if \
-            isinstance(source['message'], six.string_types) else \
+        log_msg = str(source['message']) \
+            if isinstance(source['message'], six.string_types) else \
             pprint.pformat(source['message'], depth=6)
         log_para = Paragraph(
             text='<br />\n'.join(log_msg.split('\n')),

--- a/testplan/testing/multitest/entries/schemas/assertions.py
+++ b/testplan/testing/multitest/entries/schemas/assertions.py
@@ -156,7 +156,10 @@ class ColumnContainSchema(AssertionSchema):
     data = fields.List(custom_fields.ColumnContainComparisonField())
 
 
-@registry.bind(asr.TableMatch)
+@registry.bind(
+    asr.TableMatch,
+    asr.TableDiff
+)
 class TableMatchSchema(AssertionSchema):
 
     strict = fields.Boolean()
@@ -170,6 +173,7 @@ class TableMatchSchema(AssertionSchema):
     exclude_columns = fields.List(fields.String(), allow_none=True)
     message = fields.String(allow_none=True)
     fail_limit = fields.Integer()
+    report_fails_only = fields.Bool()
 
 
 @registry.bind(asr.XMLCheck)

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -514,9 +514,7 @@ class TableNamespace(AssertionNamespace):
         :param fail_limit: Max number of failures before aborting
                            the comparison run. Useful for large
                            tables, when we want to stop after we have N rows
-                           that fail the comparison. The result will contain
-                           only failing comparisons if this argument
-                           is a positive integer.
+                           that fail the comparison.
         :type fail_limit: ``int``
         :param description: Text description for the assertion.
         :type description: ``str``
@@ -529,6 +527,86 @@ class TableNamespace(AssertionNamespace):
             table=actual, expected_table=expected,
             include_columns=include_columns, exclude_columns=exclude_columns,
             report_all=report_all, fail_limit=fail_limit,
+            description=description, category=category,
+        )
+
+    @bind_entry
+    def diff(
+        self, actual, expected,
+        description=None, category=None,
+        include_columns=None, exclude_columns=None,
+        report_all=True, fail_limit=0,
+    ):
+        """
+        Find differences of two tables, uses equality for each table cell
+        for plain values and supports regex / custom comparators as well.
+        The result will contain only failing comparisons.
+
+        If the columns of the two tables are not the same,
+        either ``include_columns`` or ``exclude_columns`` arguments
+        must be used to have column uniformity.
+
+        .. code-block:: python
+
+            result.table.diff(
+                actual=[
+                    ['name', 'age'],
+                    ['Bob', 32],
+                    ['Susan', 24],
+                ],
+                expected=[
+                    ['name', 'age'],
+                    ['Bob', 33],
+                    ['David', 24],
+                ]
+            )
+
+            result.table.diff(
+                actual=[
+                    ['name', 'age'],
+                    ['Bob', 32],
+                    ['Susan', 24],
+                ],
+                expected=[
+                    ['name', 'age'],
+                    [re.compile(r'^B\w+'), 33],
+                    ['David', lambda age: 20 < age < 50],
+                ]
+            )
+
+        :param actual: Tabular data
+        :type actual: ``list`` of ``list`` or ``list`` of ``dict``.
+        :param expected: Tabular data, which can contain custom comparators.
+        :type expected: ``list`` of ``list`` or ``list`` of ``dict``.
+        :param include_columns: List of columns to include
+                                in the comparison. Cannot be used
+                                with ``exclude_columns``.
+        :type include_columns: ``list`` of ``str``
+        :param exclude_columns: List of columns to exclude
+                                from the comparison. Cannot be used
+                                with ``include_columns``.
+        :type exclude_columns: ``list`` of ``str``
+        :param report_all: Boolean flag for configuring output.
+                           If True then all columns of the original
+                           table will be displayed.
+        :type report_all: ``bool``
+        :param fail_limit: Max number of failures before aborting
+                           the comparison run. Useful for large
+                           tables, when we want to stop after we have N rows
+                           that fail the comparison.
+        :type fail_limit: ``int``
+        :param description: Text description for the assertion.
+        :type description: ``str``
+        :param category: Custom category that will be used for summarization.
+        :type category: ``str``
+        :return: Assertion pass status
+        :rtype: ``bool``
+        """
+        return assertions.TableDiff(
+            table=actual, expected_table=expected,
+            include_columns=include_columns, exclude_columns=exclude_columns,
+            report_all=report_all, fail_limit=fail_limit,
+            report_fail_only=True,
             description=description, category=category,
         )
 


### PR DESCRIPTION
* Implement result.table.diff() assertion, it's much similar like
  result.table.match() while only failing comparisoms are kept.
* Fix an issue in table match assertion that when the tables to be
  compared are both empty, console output is ugly, and pdf exporter
  raises exception.
* Change pdf output for table match and table diff: if there is error
  or warning message, set normal font-size, and if status is PASSED (
  i.e. compare empty tables) then the font color should not be red.