### PR TITLE
Add pylintrc file and fix pylint errors

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,781 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=4
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=blacklisted-name,
+        invalid-name,
+        missing-docstring,
+        empty-docstring,
+        unneeded-not,
+        singleton-comparison,
+        misplaced-comparison-constant,
+        unidiomatic-typecheck,
+        consider-using-enumerate,
+        consider-iterating-dictionary,
+        bad-classmethod-argument,
+        bad-mcs-method-argument,
+        bad-mcs-classmethod-argument,
+        single-string-used-for-slots,
+        line-too-long,
+        too-many-lines,
+        trailing-whitespace,
+        missing-final-newline,
+        trailing-newlines,
+        multiple-statements,
+        superfluous-parens,
+        bad-whitespace,
+        mixed-line-endings,
+        unexpected-line-ending-format,
+        bad-continuation,
+        wrong-spelling-in-comment,
+        wrong-spelling-in-docstring,
+        invalid-characters-in-docstring,
+        multiple-imports,
+        wrong-import-order,
+        ungrouped-imports,
+        wrong-import-position,
+        old-style-class,
+        len-as-condition,
+        print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        invalid-unicode-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        c-extension-no-member,
+        literal-comparison,
+        no-self-use,
+        no-classmethod-decorator,
+        no-staticmethod-decorator,
+        cyclic-import,
+        duplicate-code,
+        too-many-ancestors,
+        too-many-instance-attributes,
+        too-few-public-methods,
+        too-many-public-methods,
+        too-many-return-statements,
+        too-many-branches,
+        too-many-arguments,
+        too-many-locals,
+        too-many-statements,
+        too-many-boolean-expressions,
+        consider-merging-isinstance,
+        too-many-nested-blocks,
+        simplifiable-if-statement,
+        redefined-argument-from-local,
+        no-else-return,
+        consider-using-ternary,
+        trailing-comma-tuple,
+        stop-iteration-return,
+        simplify-boolean-expression,
+        inconsistent-return-statements,
+        unreachable,
+        dangerous-default-value,
+        pointless-statement,
+        pointless-string-statement,
+        expression-not-assigned,
+        unnecessary-pass,
+        unnecessary-lambda,
+        duplicate-key,
+        deprecated-lambda,
+        assign-to-new-keyword,
+        useless-else-on-loop,
+        exec-used,
+        eval-used,
+        confusing-with-statement,
+        using-constant-test,
+        lost-exception,
+        assert-on-tuple,
+        attribute-defined-outside-init,
+        bad-staticmethod-argument,
+        protected-access,
+        arguments-differ,
+        signature-differs,
+        abstract-method,
+        super-init-not-called,
+        no-init,
+        non-parent-init-called,
+        useless-super-delegation,
+        unnecessary-semicolon,
+        bad-indentation,
+        mixed-indentation,
+        lowercase-l-suffix,
+        wildcard-import,
+        deprecated-module,
+        relative-import,
+        reimported,
+        import-self,
+        misplaced-future,
+        fixme,
+        invalid-encoded-data,
+        global-variable-undefined,
+        global-variable-not-assigned,
+        global-statement,
+        global-at-module-level,
+        unused-import,
+        unused-variable,
+        unused-argument,
+        unused-wildcard-import,
+        redefined-outer-name,
+        redefined-builtin,
+        redefine-in-handler,
+        undefined-loop-variable,
+        cell-var-from-loop,
+        bare-except,
+        broad-except,
+        duplicate-except,
+        nonstandard-exception,
+        binary-op-exception,
+        raising-format-tuple,
+        property-on-old-class,
+        keyword-arg-before-vararg,
+        logging-not-lazy,
+        logging-format-interpolation,
+        bad-format-string-key,
+        unused-format-string-key,
+        bad-format-string,
+        missing-format-argument-key,
+        unused-format-string-argument,
+        format-combined-specification,
+        missing-format-attribute,
+        invalid-format-index,
+        anomalous-backslash-in-string,
+        anomalous-unicode-escape-in-string,
+        bad-open-mode,
+        boolean-datetime,
+        redundant-unittest-assert,
+        deprecated-method,
+        bad-thread-instantiation,
+        shallow-copy-environ,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+
+        # Disable the no-member error as it works very poorly, including on many
+        # parts of the stdlib where members are generated programatically.
+        no-member
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=syntax-error,
+       unrecognized-inline-option,
+       bad-option-value,
+       init-is-generator,
+       return-in-init,
+       function-redefined,
+       not-in-loop,
+       return-outside-function,
+       yield-outside-function,
+       return-arg-in-generator,
+       nonexistent-operator,
+       duplicate-argument-name,
+       abstract-class-instantiated,
+       bad-reversed-sequence,
+       too-many-star-expressions,
+       invalid-star-assignment-target,
+       star-needs-assignment-target,
+       nonlocal-and-global,
+       continue-in-finally,
+       nonlocal-without-binding,
+       used-prior-global-declaration,
+       method-hidden,
+       access-member-before-definition,
+       no-method-argument,
+       no-self-argument,
+       invalid-slots-object,
+       assigning-non-slot,
+       invalid-slots,
+       inherit-non-class,
+       inconsistent-mro,
+       duplicate-bases,
+       non-iterator-returned,
+       unexpected-special-method-signature,
+       invalid-length-returned,
+       import-error,
+       relative-beyond-top-level,
+       used-before-assignment,
+       undefined-variable,
+       undefined-all-variable,
+       invalid-all-object,
+       no-name-in-module,
+       unbalanced-tuple-unpacking,
+       unpacking-non-sequence,
+       bad-except-order,
+       raising-bad-type,
+       bad-exception-context,
+       misplaced-bare-raise,
+       raising-non-exception,
+       notimplemented-raised,
+       catching-non-exception,
+       slots-on-old-class,
+       super-on-old-class,
+       bad-super-call,
+       missing-super-argument,
+       not-callable,
+       assignment-from-no-return,
+       no-value-for-parameter,
+       too-many-function-args,
+       unexpected-keyword-arg,
+       redundant-keyword-arg,
+       missing-kwoa,
+       invalid-sequence-index,
+       invalid-slice-index,
+       assignment-from-none,
+       not-context-manager,
+       invalid-unary-operand-type,
+       unsupported-binary-operation,
+       repeated-keyword,
+       not-an-iterable,
+       not-a-mapping,
+       unsupported-membership-test,
+       unsubscriptable-object,
+       unsupported-assignment-operation,
+       unsupported-delete-operation,
+       invalid-metaclass,
+       logging-unsupported-format,
+       logging-format-truncated,
+       logging-too-many-args,
+       logging-too-few-args,
+       bad-format-character,
+       truncated-format-string,
+       mixed-format-string,
+       format-needs-mapping,
+       missing-format-string-key,
+       too-many-format-args,
+       too-few-format-args,
+       bad-str-strip-call,
+       yield-inside-async-function,
+       not-async-context-manager,
+       fatal,
+       astroid-error,
+       parse-error,
+       method-check-failed
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=colorized
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,io,builtins
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=optparse
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/test/unit/testplan/test_plan_base.py
+++ b/test/unit/testplan/test_plan_base.py
@@ -64,7 +64,7 @@ class MyPool(LocalRunner):  # Start is async
         self.name = name
 
     def uid(self):
-        return self.name or super(DummyTest, self).uid()
+        return self.name or super(MyPool, self).uid()
 
     def _execute(self, uid):
         func = self._input[uid]
@@ -144,11 +144,11 @@ def test_testplan_decorator():
     from testplan import test_plan
 
     @test_plan(name='MyPlan', port=800, parse_cmdline=False)
-    def main(plan):
+    def main1(plan):
         plan.add(DummyTest(name='bob'))
         return 123
 
-    res = main()
+    res = main1()  # pylint: disable=no-value-for-parameter
     assert isinstance(res, TestplanResult)
     assert res.decorated_value == 123
     assert res.run is True
@@ -157,7 +157,7 @@ def test_testplan_decorator():
     with argv_overridden('--pdf', pdf_path):
         with log_propagation_disabled(TESTPLAN_LOGGER):
             @test_plan(name='MyPlan', port=800)
-            def main(plan, parser):
+            def main2(plan, parser):
                     args = parser.parse_args()
 
                     assert args.verbose is False
@@ -165,7 +165,7 @@ def test_testplan_decorator():
                     assert plan.cfg.pdf_path == pdf_path
                     plan.add(DummyTest(name='bob'))
 
-            res = main()
+            res = main2()  # pylint:disable=assignment-from-no-return,no-value-for-parameter
             assert isinstance(res, TestplanResult)
             assert res.decorated_value is None
             assert res.run is True

--- a/test/unit/testplan/testing/multitest/entries/test_assertions.py
+++ b/test/unit/testplan/testing/multitest/entries/test_assertions.py
@@ -267,7 +267,7 @@ class BaseRegexTest(object):
         self, regexp, string, expected_match_indexes,
         expected, flags=0, *args, **kwargs
     ):
-        assertion = self.assertion_class(
+        assertion = self.assertion_class(  # pylint: disable=not-callable
             regexp=regexp, string=string, flags=flags, *args, **kwargs)
         pattern = regexp if isinstance(
             regexp, six.string_types) else regexp.pattern

--- a/test/unit/testplan/testing/multitest/test_result.py
+++ b/test/unit/testplan/testing/multitest/test_result.py
@@ -40,7 +40,7 @@ def test_assertion_orders():
     expected = ['AssertionFirst1', 'AssertionFirst2', 'AssertionSecond',
                 'AssertionMain1', 'AssertionMain2', 'Report passed so far.']
     assertions = (entry for entry in mtest.report.flatten()
-        if isinstance(entry, dict) and entry['meta_type'] == 'assertion')
+        if isinstance(entry, dict) and entry['meta_type'] == 'assertion')  # pylint: disable=invalid-sequence-index
 
     for idx, entry in enumerate(assertions):
         assert entry['description'] == expected[idx]

--- a/testplan/__init__.py
+++ b/testplan/__init__.py
@@ -10,7 +10,7 @@ if TESTPLAN_DEPENDENCIES_PATH in os.environ:
     print('Importing testplan dependencies from: {}'.format(
         os.environ[TESTPLAN_DEPENDENCIES_PATH]))
     sys.path.insert(0, os.environ[TESTPLAN_DEPENDENCIES_PATH])
-    import dependencies
+    import dependencies  # pylint: disable=import-error
     sys.path.remove(os.environ[TESTPLAN_DEPENDENCIES_PATH])
 
 from .base import Testplan, TestplanConfig, TestplanResult, test_plan

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -686,7 +686,8 @@ class Runnable(Entity):
         """Executes the defined steps and populates the result object."""
         try:
             if self.cfg.interactive is True:
-                raise
+                raise RuntimeError(
+                    'Cannot run batch execution in interactive mode.')
             else:
                 self._run_batch_steps()
         except Exception as exc:

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -94,7 +94,7 @@ class OperatorCallable(Callable):
         self.reference = reference
 
     def __call__(self, value):
-        return self.func(value, self.reference)
+        return self.func(value, self.reference)  # pylint: disable=not-callable
 
     def __repr__(self):
         return '{}({})'.format(self.__class__.__name__, repr(self.reference))

--- a/testplan/common/utils/table.py
+++ b/testplan/common/utils/table.py
@@ -55,7 +55,7 @@ class TableEntry(object):
             assert isinstance(self.table[0], list)
             return self.table[0]
 
-    @classmethod
+    @staticmethod
     def consolidate_columns(list_of_dict, placeholder='ABSENT'):
         """
         In some cases the raw DB results may return a

--- a/testplan/exporters/testing/base.py
+++ b/testplan/exporters/testing/base.py
@@ -64,7 +64,7 @@ class TagFilteredExporter(Exporter):
         if not self.exporter_class:
             raise AttributeError('`exporter_class` not set.')
 
-        exporter = self.exporter_class(**params)
+        exporter = self.exporter_class(**params)  # pylint: disable=not-callable
         exporter.cfg.parent = self.cfg
         return exporter
 

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -513,9 +513,10 @@ class Pool(Executor):
                 if self.should_reschedule(self, task_result):
                     if self.task_assign_cnt[uid] >= self.cfg.task_retries_limit:
                         self.logger.test_info(
-                            'Will not reschedule {} again as it '
-                            'reached max retries'.format(
-                                self._input[uid], self.cfg.task_retries_limit))
+                            'Will not reschedule %(input)s again as it '
+                            'reached max retries %(retries)d',
+                            {'input': self._input[uid],
+                             'retries': self.cfg.task_retries_limit})
                     else:
                         self.logger.test_info(
                             'Rescheduling {} due to '

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -156,7 +156,7 @@ class ChildLoop(object):
         log_file = os.path.join(self.runpath, '{}_stdout'.format(self._metadata['index']))
         self.logger.info('stdout file = %(file)s (log level = %(lvl)s)',
                          {'file': log_file, 'lvl': self.logger.level})
-        self.logger.info('stderr file = %s'.format(stderr_file))
+        self.logger.info('stderr file = %s', stderr_file)
         self.logger.info(
             'Closing stdin, stdout and stderr file descriptors...')
 
@@ -365,7 +365,7 @@ def child_logic(args):
             self._runpath = self.cfg.runpath
 
         def starting(self):
-            super(Pool, self).starting()
+            super(Pool, self).starting()  # pylint: disable=bad-super-call
             self.make_runpath_dirs()
 
             self._metadata['runpath'] = self.runpath

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -378,11 +378,6 @@ class ProcessRunnerTest(Test):
                     timeout=format_duration(self.cfg.timeout),
                 ))
 
-    # DEFAULT
-    def get_proc_env(self):
-        return self.cfg.proc_env
-
-    # HOBBBES TEST
     def get_proc_env(self):
         self._json_ouput = os.path.join(self.runpath, 'output.json')
         self.logger.debug('Json output: {}'.format(self._json_ouput))

--- a/testplan/testing/filtering.py
+++ b/testplan/testing/filtering.py
@@ -137,7 +137,7 @@ class MetaFilter(BaseFilter):
         return self._composed_filter
 
     def filter(self, test, suite, case):
-        return self.composed_filter(test, suite, case)
+        return self.composed_filter(test, suite, case)  # pylint: disable=not-callable
 
 
 class Or(MetaFilter):

--- a/testplan/testing/multitest/driver/http/server.py
+++ b/testplan/testing/multitest/driver/http/server.py
@@ -254,7 +254,7 @@ class HTTPServer(Driver):
         """
         try:
             return self.requests.get(False)
-        except Queue.Empty:
+        except queue.Empty:
             return None
 
     def starting(self):

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -47,7 +47,7 @@ __all__ = [
     'ExceptionRaised',
     'EqualSlices',
     'EqualExcludeSlices',
-    'Diff',
+    'LineDiff',
     'ColumnContain',
     'TableMatch',
     'TableDiff',
@@ -132,7 +132,7 @@ class FuncAssertion(Assertion):
             description=description, category=category)
 
     def evaluate(self):
-        return self.func(self.first, self.second)
+        return self.func(self.first, self.second)  # pylint: disable=not-callable
 
 
 class Equal(FuncAssertion):

--- a/testplan/testing/ordering.py
+++ b/testplan/testing/ordering.py
@@ -42,7 +42,8 @@ class SortType(Enum):
             if SortType.ALL.value in values and len(values) > 1:
                 raise ValueError(
                     'Passing extra shuffle types along with'
-                    ' `all` is a redundant operation.'.format(values))
+                    ' `all` is a redundant operation. values = {}'
+                    .format(values))
             return values
         return validate_single(value)
 

--- a/testplan/vendor/tempita/__init__.py
+++ b/testplan/vendor/tempita/__init__.py
@@ -319,7 +319,7 @@ class Template(object):
             if PY3:
                 raise(e)
             else:
-                raise (exc_info[1], e, exc_info[2])
+                raise (exc_info[1], e, exc_info[2])  # pylint: disable=raising-bad-type
 
     def _exec(self, code, ns, pos):
         # __traceback_hide__ = True
@@ -335,7 +335,7 @@ class Template(object):
             if PY3:
                 raise(e)
             else:
-                raise (exc_info[1], e, exc_info[2])
+                raise (exc_info[1], e, exc_info[2])  # pylint: disable=raising-bad-type
 
     def _repr(self, value, pos):
         # __traceback_hide__ = True
@@ -358,7 +358,7 @@ class Template(object):
             if PY3:
                 raise(e)
             else:
-                raise (exc_info[1], e, exc_info[2])
+                raise (exc_info[1], e, exc_info[2])  # pylint: disable=raising-bad-type
         else:
             if self._unicode and isinstance(value, bytes):
                 if not self.default_encoding:

--- a/testplan/vendor/tempita/compat3.py
+++ b/testplan/vendor/tempita/compat3.py
@@ -16,7 +16,7 @@ if sys.version_info[0] < 3:
         return d.iteritems(**kw)
 
     b = bytes = str
-    basestring_ = basestring
+    basestring_ = basestring  # pylint: disable=undefined-variable
 
 else:
 
@@ -37,7 +37,7 @@ text = str
 
 def is_unicode(obj):
     if sys.version_info[0] < 3:
-        return isinstance(obj, unicode)
+        return isinstance(obj, unicode)  # pylint: disable=undefined-variable
     else:
         return isinstance(obj, str)
 
@@ -49,7 +49,7 @@ def coerce_text(v):
         else:
             attr = '__str__'
         if hasattr(v, attr):
-            return unicode(v)
+            return unicode(v)  # pylint: disable=undefined-variable
         else:
             return bytes(v)
     return v


### PR DESCRIPTION
Currently only include Error-level messages in Pylint. Both
testplan/ and test/ directories give no errors when run using
the pylintrc file.

Fix up the source code and tests to give no pylint errors when
run. Some had to be locally disabled because of dynamic effects
not spotted by pylint, but there were also a few actual bugs
spotted and fixed.

In future we can move some more of the other warnings from
the disabled to enabled sections in the pylintrc and fix/locally
disable the messages they produce.