### PR TITLE
Fix some issues about driver

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -148,10 +148,10 @@ class Environment(object):
 
         # Wait resources status to be STARTED.
         for resource in self._resources.values():
-            if resource.cfg.async_start is False:
-                continue
             if resource in self.start_exceptions:
                 break
+            if resource.cfg.async_start is False:
+                continue
             else:
                 resource.wait(resource.STATUS.STARTED)
 

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -193,7 +193,7 @@ class App(Driver):
         except Exception:
             TESTPLAN_LOGGER.error(
                 'Error while App[%s] driver executed command: %s',
-                self.cfg.name, ' '.join(cmd))
+                self.cfg.name, cmd if self.cfg.shell else ' '.join(cmd))
             raise
 
     def stopping(self):

--- a/testplan/testing/multitest/driver/fix/client.py
+++ b/testplan/testing/multitest/driver/fix/client.py
@@ -104,7 +104,7 @@ class FixClient(Driver):
 
     @property
     def logpath(self):
-        """Fix server logfile in runpath."""
+        """Fix client logfile in runpath."""
         return os.path.join(self.runpath, self._logname)
 
     @property


### PR DESCRIPTION
* If a driver fails to start (exception raised), then other drivers
  following it won't be started, then no need to wait those drivers
  to change status to STARTED, or unwanted exception will be raised
  if the following drivers has no 'async_start' attribute.

* Command of an App driver can be stored in list or string, should
  always give the corrent output in log.

* A small typo error.