### PR TITLE
Fetch error log of failed driver

### DIFF
--- a/test/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/test/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -1,14 +1,16 @@
 """TODO."""
 
 import os
+import re
 
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 
 from testplan import Testplan
 from testplan.common.entity.base import Environment, ResourceStatus
 from testplan.common.utils.context import context
-from testplan.common.utils.path import default_runpath
+from testplan.common.utils.path import StdFiles, default_runpath
 from testplan.common.utils.testing import log_propagation_disabled
+from testplan.testing.multitest.driver.base import Driver
 from testplan.testing.multitest.driver.tcp import TCPServer, TCPClient
 
 from testplan.logger import TESTPLAN_LOGGER
@@ -135,3 +137,94 @@ def test_multitest_drivers_in_testplan():
         assert client.runpath == os.path.join(mtest.runpath, client.uid())
         assert server.status.tag == ResourceStatus.STOPPED
         assert client.status.tag == ResourceStatus.STOPPED
+
+
+@testsuite
+class EmptySuite(object):
+
+    @testcase
+    def test_empty(self, env, result):
+        pass
+
+
+class BaseDriver(Driver):
+    """Base class of vulnerable driver which can raise exception."""
+    @property
+    def logpath(self):
+        if self.cfg.logfile:
+            return os.path.join(self.runpath, self.cfg.logfile)
+        return self.outpath
+
+    @property
+    def outpath(self):
+        return self.std.out_path
+
+    @property
+    def errpath(self):
+        return self.std.err_path
+
+    def starting(self):
+        super(BaseDriver, self).starting()
+        self.std = StdFiles(self.runpath)
+
+    def stopping(self):
+        super(BaseDriver, self).stopping()
+        self.std.close()
+
+
+class VulnerableDriver1(BaseDriver):
+    """This driver raises exception during startup."""
+    def starting(self):
+        super(VulnerableDriver1, self).starting()
+        self.std.err.write('Error found{}'.format(os.linesep))
+        self.std.err.flush()
+        raise Exception('Startup error')
+
+
+class VulnerableDriver2(BaseDriver):
+    """This driver raises exception during shutdown."""
+    def stopping(self):
+        """Trigger driver stop."""
+        super(VulnerableDriver2, self).stopping()
+        with open(self.logpath, 'w') as log_handle:
+            for idx in range(1000):
+                log_handle.write('This is line {}\n'.format(idx))
+        raise Exception('Shutdown error')
+
+
+def test_multitest_driver_failure():
+    """If driver fails to start or stop, the error log could be fetched."""
+    plan1 = Testplan(name='MyPlan1', parse_cmdline=False)
+    plan1.add(MultiTest(
+        name='Mtest1',
+        suites=[MySuite()],
+        environment=[VulnerableDriver1(name='vulnerable_driver_1',
+                                       report_errors_from_logs=True)]))
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        plan1.run()
+
+    plan2 = Testplan(name='MyPlan2', parse_cmdline=False)
+    plan2.add(MultiTest(
+        name='Mtest2',
+        suites=[MySuite()],
+        environment=[VulnerableDriver2(name='vulnerable_driver_2',
+                                       logfile='logfile',
+                                       report_errors_from_logs=True,
+                                       error_logs_max_lines=10)]))
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        plan2.run()
+
+    res1, res2 = plan1.result, plan2.result
+    assert res1.run is True and res2.run is True
+
+    report1, report2 = res1.report, res2.report
+    assert 'Exception: Startup error' in report1.entries[0].logs[0]['message']
+    assert 'Exception: Shutdown error' in report2.entries[0].logs[0]['message']
+
+    text1 = report1.entries[0].logs[1]['message'].split(os.linesep)
+    text2 = report2.entries[0].logs[1]['message'].split(os.linesep)
+    assert re.match(r'.*Information from log file:.+stderr.*', text1[0])
+    assert re.match(r'.*Error found.*', text1[1])
+    assert re.match(r'.*Information from log file:.+logfile.*', text2[0])
+    for idx, line in enumerate(text2[1:]):
+        assert re.match(r'.*This is line 99{}.*'.format(idx), line)

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -1,5 +1,6 @@
 """Multitest main test execution framework."""
 
+import os
 import inspect
 import collections
 import functools
@@ -694,6 +695,15 @@ class MultiTest(Test):
             for msg in exceptions.values():
                 self.result.report.logger.error(msg)
             self.result.report.status_override = Status.ERROR
+
+        if step == self.resources.stop:
+            drivers = set(self.resources.start_exceptions.keys())
+            drivers.update(self.resources.stop_exceptions.keys())
+            for driver in drivers:
+                if driver.cfg.report_errors_from_logs:
+                    error_log = os.linesep.join(driver.fetch_error_log())
+                    if error_log:
+                        self.result.report.logger.error(error_log)
 
     def pre_resource_steps(self):
         """Runnable steps to be executed before environment starts."""


### PR DESCRIPTION
* When error occurs during environment startup or shutdown, user may
  want to know what happened about the Multitest drivers. Currently in
  our report only stack trace information is retained, so it will be
  helpful for user if we can fetch error log from the failed drivers
  and attach it to report. Especially this feature provides convenience
  when the test is executed in remote.