### PR TITLE
Driver support for unit test

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -1364,6 +1364,32 @@ applications.
 Users are strongly encouraged to follow this practice rather than hardcode host
 names and port numbers in their test setups.
 
+Work with unit test
+-------------------
+Drivers can also be useful while working with other unit testing frameworks like
+like GTest or Hobbes Test. Testplan will export environment variables for newly
+started test process. Have a look at the following code:
+
+.. code-block:: python
+
+    plan.add(GTest(
+        name='My GTest',
+        driver=BINARY_PATH,
+        environment=[
+            TCPServer(name='my server'),
+            TCPClient(name='client-101',
+                host=context('server', '{{host}}'),
+                port=context('server', '{{port}}')
+            )
+        ]
+    )
+
+In your unit test process, you can find an environment variable named
+'DRIVER_MY_SERVER_ATTR_HOST', likewise, 'DRIVER_CLIENT_101_ATTR_PORT' is also
+available. It is easy to understand that the string is formatted in uppercase,
+like 'DRIVER_<uid of driver>_ATTR_<attribute name>', while hyphens and spaces
+are replaced by underscores.
+
 .. _multitest_builtin_drivers:
 
 Built-in drivers

--- a/test/functional/testplan/testing/fixtures/base/passing/test_env.sh
+++ b/test/functional/testplan/testing/fixtures/base/passing/test_env.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+if [ "$PROC_ENV1" != "abc" ]; then
+  echo "Unexpected value of variable PROC_ENV1"
+  exit 6
+fi
+if [ "$PROC_ENV2" != "123" ]; then
+  echo "Unexpected value of variable PROC_ENV2"
+  exit 7
+fi
+if [ "$DRIVER_MY_EXECUTABLE_ATTR_FOOBAR" != "foo bar" ]; then
+  echo "Unexpected value of variable $DRIVER_MY_EXECUTABLE_ATTR_FOOBAR"
+  exit 8
+fi
+if [ "$DRIVER_MY_EXECUTABLE_ATTR_MYVALUE" != "hello" ]; then
+  echo "Unexpected value of variable $DRIVER_MY_EXECUTABLE_ATTR_VALUE"
+  exit 9
+fi
+exit 0

--- a/test/functional/testplan/testing/test_base.py
+++ b/test/functional/testplan/testing/test_base.py
@@ -4,13 +4,34 @@ import platform
 import pytest
 
 from testplan.testing.base import ProcessRunnerTest
+from testplan.testing.multitest.driver.base import Driver, DriverConfig
 
 from testplan import Testplan
+from testplan.common.config import ConfigOption
 from testplan.common.utils.testing import log_propagation_disabled, check_report
 
 from testplan.logger import TESTPLAN_LOGGER
 
 from .fixtures import base
+
+
+class MyDriverConfig(DriverConfig):
+    @classmethod
+    def get_options(cls):
+        return {
+            ConfigOption('my_val', default=''): str
+        }
+
+class MyDriver(Driver):
+    CONFIG = MyDriverConfig
+
+    @property
+    def foobar(self):
+        return 'foo bar'
+
+    @property
+    def myvalue(self):
+        return self.cfg.my_val
 
 
 class DummyTest(ProcessRunnerTest):
@@ -39,6 +60,14 @@ fixture_root = os.path.join(os.path.dirname(__file__), 'fixtures', 'base')
             os.path.join(fixture_root, 'passing', 'test.sh'),
             base.passing.report.expected_report,
             {}
+        ),
+        (
+            os.path.join(fixture_root, 'passing', 'test_env.sh'),
+            base.passing.report.expected_report,
+            dict(
+                proc_env={'proc_env1': 'abc', 'proc_env2': '123'},
+                environment=[MyDriver(name='My executable', my_val='hello')]
+            )
         ),
         (
             os.path.join(fixture_root, 'sleeping', 'test.sh'),

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -15,7 +15,7 @@ from threading import Thread, Lock
 from schema import Use, Or, And
 
 from testplan.common.config import ConfigOption, validate_func
-from testplan.common.entity import Resource, Runnable
+from testplan.common.entity import Runnable
 from testplan.common.utils.interface import (
     check_signature, MethodSignatureMismatch
 )
@@ -85,14 +85,15 @@ class MultiTestConfig(TestConfig):
 
         return {
             'suites': Use(iterable_suites),
-            ConfigOption('environment', default=[]): [Resource],
+            ConfigOption('result', default=Result): is_subclass(Result),
             ConfigOption('before_start', default=None): start_stop_signature,
             ConfigOption('after_start', default=None): start_stop_signature,
             ConfigOption('before_stop', default=None): start_stop_signature,
             ConfigOption('after_stop', default=None): start_stop_signature,
-            ConfigOption('result', default=Result): is_subclass(Result),
             ConfigOption('thread_pool_size', default=0): int,
-            ConfigOption('max_thread_pool_size', default=10): int
+            ConfigOption('max_thread_pool_size', default=10): int,
+            ConfigOption('part', default=None): Or(None, And((int,),
+                lambda tp: len(tp) == 2 and 0 <= tp[0] < tp[1] and tp[1] > 1))
         }
 
 
@@ -109,10 +110,6 @@ class MultiTest(Test):
         :py:func:`@testcase <testplan.testing.multitest.suite.testcase>`
         decorated methods representing the tests.
     :type suites: ``list``
-    :param environment: List of
-        :py:class:`drivers <testplan.tesitng.multitest.driver.base.Driver>` to
-        be started and made available on tests execution.
-    :type environment: ``list``
     :param result: Result class definition for result object made available
         from within the testcases.
     :type result: :py:class:`~testplan.testing.multitest.result.Result`
@@ -124,14 +121,14 @@ class MultiTest(Test):
     :type before_stop: ``callable`` taking environment and a result arguments.
     :param after_stop: Callable to execute after stopping the environment.
     :type after_stop: ``callable`` taking environment and a result arguments.
-    :param part: Execute only a part of the total testcases. MultiTest needs to
-                 know which part of the total it is.
-    :type part: ``tuple`` of (``int``, ``int``)
     :param thread_pool_size: Size of the thread pool which executes testcases
         with execution_group specified in parallel (default 0 means no pool).
     :type thread_pool_size: ``int``
     :param max_thread_pool_size: Maximum number of threads allowed in the pool.
     :type max_thread_pool_size: ``int``
+    :param part: Execute only a part of the total testcases. MultiTest needs to
+        know which part of the total it is. Only works with Multitest.
+    :type part: ``tuple`` of (``int``, ``int``)
 
     Also inherits all
     :py:class:`~testplan.testing.base.Test` options.
@@ -150,11 +147,6 @@ class MultiTest(Test):
 
         super(MultiTest, self).__init__(**options)
 
-        for resource in self.cfg.environment:
-            resource.parent = self
-            resource.cfg.parent = self.cfg
-            self.resources.add(resource)
-
         # For all suite instances (and their bound testcase methods,
         # along with parametrization template methods)
         # update tag indices with native tags of this instance.
@@ -172,6 +164,17 @@ class MultiTest(Test):
         self._thread_pool_size = 0
         self._thread_pool_active = False
         self._thread_pool_available = False
+
+    def _init_test_report(self):
+        """Overwrite parent's."""
+        self.result.report = TestGroupReport(
+            name=self.cfg.name,
+            description=self.cfg.description,
+            category=self.__class__.__name__.lower(),
+            uid=self.uid(),
+            tags=self.cfg.tags,
+            part=self.cfg.part,
+        )
 
     def _execute_step(self, step, *args, **kwargs):
         """

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -28,8 +28,6 @@ class PyTestConfig(testing.TestConfig):
             config.ConfigOption('select', default=''): str,
             config.ConfigOption('extra_args', default=None): schema.Or(
                 [str], None),
-            config.ConfigOption('environment', default=None): schema.Or(
-                [entity.Resource], None),
             config.ConfigOption('quiet', default=True): bool
         }
 
@@ -44,15 +42,6 @@ class PyTest(testing.Test):
 
     def __init__(self, **options):
         super(PyTest, self).__init__(**options)
-
-        # Add the environment to our list of resources.
-        if self.cfg.environment is None:
-            self.cfg.environment = []
-
-        for resource in self.cfg.environment:
-            resource.parent = self
-            resource.cfg.parent = self.cfg
-            self.resources.add(resource)
 
         # Initialise a seperate plugin object to pass to PyTest. This avoids
         # namespace clashes with the PyTest object, since PyTest will scan for

--- a/testplan/testing/tagging.py
+++ b/testplan/testing/tagging.py
@@ -76,7 +76,7 @@ def validate_tag_value(tag_value):
     :param tag_value: User defined tag value.
     :type tag_value: ``string``, ``iterable`` of ``string`` or
                      a ``dict`` with ``string`` keys
-                     and ``string`` or ``iterable`` of ``strings`` as values.
+                     and ``string`` or ``iterable`` of ``string`` as values.
 
     :return: Internal representation of the tag context.
     :rtype: ``dict`` of ``set``


### PR DESCRIPTION
* Only MultiTest has drivers which can be started and stopped along
  with test execution. We want to enable this feature for unittest.
  Just move related code to the parent class of MultiTest, and then
  ProcessRunnerTest can utilize the drivers, thus the derived class
  of ProcessRunnerTest, such as GTest, is able to aquire information
  of drivers from environment variables of unittest process.