### PR TITLE
fix hobbes test listing issue with python3

### DIFF
--- a/test/functional/testplan/testing/cpp/test_hobbestest.py
+++ b/test/functional/testplan/testing/cpp/test_hobbestest.py
@@ -4,7 +4,7 @@ import platform
 import pytest
 
 from testplan import Testplan
-from testplan.common.utils.testing import log_propagation_disabled, check_report
+from testplan.common.utils.testing import log_propagation_disabled, check_report, captured_logging, argv_overridden
 from testplan.logger import TESTPLAN_LOGGER
 from testplan.testing.cpp import HobbesTest
 
@@ -62,3 +62,32 @@ def test_hobbestest(binary_dir, expected_report):
         assert plan.run().run is True
 
     check_report(expected=expected_report, actual=plan.report)
+
+@pytest.mark.skipif(
+    platform.system() == 'Windows',
+    reason='HobbesTest is skipped on Windows.'
+)
+@pytest.mark.parametrize(
+    'binary_dir, expected_output',
+    (
+        (
+            os.path.join(fixture_root, 'passing'),
+            hobbestest.passing.report.expected_output,
+        ),
+    )
+)
+def test_hobbestest_listing(binary_dir, expected_output):
+
+    binary_path = os.path.join(binary_dir, 'hobbes-test')
+    cmdline_args = ['--list']
+
+    with argv_overridden(*cmdline_args):
+        plan = Testplan(name='plan', parse_cmdline=True)
+
+        with log_propagation_disabled(TESTPLAN_LOGGER):
+            with captured_logging(TESTPLAN_LOGGER) as log_capture:
+                plan.add(HobbesTest(name='MyHobbesTest', driver=binary_path, tests=['Hog', 'Net', 'Recursives']))
+                result = plan.run()
+                print(log_capture.output)
+                assert log_capture.output == expected_output
+                assert len(result.test_report) == 0, 'No tests should be run.'

--- a/test/functional/testplan/testing/fixtures/cpp/hobbestest/passing/report.py
+++ b/test/functional/testplan/testing/fixtures/cpp/hobbestest/passing/report.py
@@ -92,3 +92,21 @@ expected_report = TestReport(
                                 u'type': 'RawAssertion'}])],
                     tags=None)],
             tags=None)])
+
+expected_output =\
+'''MyHobbesTest
+  Arrays
+  Compiler
+  Definitions
+  Existentials
+  Hog
+  Matching
+  Net
+  Objects
+  Prelude
+  Recursives
+  Storage
+  Structs
+  TypeInf
+  Variants
+'''

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -1,6 +1,7 @@
 """Base classes for all Tests"""
-import os
+import os, sys
 import subprocess
+import six
 
 from lxml import objectify
 from schema import Or, Use, And
@@ -339,8 +340,12 @@ class ProcessRunnerTest(Test):
             env=self.cfg.proc_env,
             stdout=subprocess.PIPE)
 
-        return self.parse_test_context(
-            test_list_output=proc.communicate()[0])
+        test_list_output = proc.communicate()[0]
+
+        if not isinstance(test_list_output, six.string_types):  # with python3, stdout is bytes
+            test_list_output = test_list_output.decode(sys.stdout.encoding)
+
+        return self.parse_test_context(test_list_output)
 
     def parse_test_context(self, test_list_output):
         """


### PR DESCRIPTION
With python3, stdout and stderr now returns bytes instead of string. The fix is to decode stdout if it is not string type, so that we can later on parse it and generate test list.