### PR TITLE
Add PyUnit test runner and fix minor test issue

### DIFF
--- a/test/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/test/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import tempfile
 
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 
@@ -16,10 +17,12 @@ from testplan.testing.multitest.driver.tcp import TCPServer, TCPClient
 from testplan.logger import TESTPLAN_LOGGER
 
 
+CUSTOM_RUNPATH = os.path.join(tempfile.gettempdir(),
+                              'test_multitest_drivers_runpath')
 
-def runpath_maker(obj):
-    """TODO."""
-    return '{sep}tmp{sep}'.format(sep=os.sep)
+def runpath_maker(_):
+    """Return a custom runpath location."""
+    return CUSTOM_RUNPATH
 
 
 @testsuite

--- a/testplan/examples/PyTest/test_plan.py
+++ b/testplan/examples/PyTest/test_plan.py
@@ -7,11 +7,7 @@ import testplan
 from testplan.testing import py_test
 
 
-# We specify a description for the testplan, as well as a database to which
-# the report should be committed. It is useful to specify a database, even
-# if you don't intend for the results to be persisted : the cost is negligible
-# and it provides an easily shared and detailed view of the test results.
-# noinspection PyUnresolvedReferences
+# Specify the name and description of the testplan via the decorator.
 @testplan.test_plan(name='PyTestExample',
                     description='PyTest basic example')
 def main(plan):
@@ -25,8 +21,7 @@ def main(plan):
 
 
 # Finally we trigger our main function when the script is run, and
-# set the return status. Note that it has to be inverted because it's
-# a boolean value.
+# set the return status.
 if __name__ == '__main__':
     res = main()
     sys.exit(res.exit_code)

--- a/testplan/examples/PyUnit/test_plan.py
+++ b/testplan/examples/PyUnit/test_plan.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""Example to demonstrate PyUnit integration with Testplan."""
+
+import sys
+import testplan
+import unittest
+from testplan.testing import pyunit
+
+
+class MyTest(unittest.TestCase):
+    """
+    Minimal PyUnit testcase with a single trivial test method. For more
+    information about the unittest library, see the [documentation](
+    http://docs.python.org/2/library/unittest.html).
+    """
+
+    def test_example(self):
+        """Test with basic assertions."""
+        self.assertTrue(True)
+        self.assertFalse(False)
+
+
+@testplan.test_plan(name='PyUnit',
+                    description='UnitTest example')
+def main(plan):
+    # Now we are inside a function that will be passed a plan object, we
+    # can add tests to this plan. Here we will add a unittest suite, made up
+    # of a single TestCase defined above.
+    plan.add(pyunit.PyUnit(name='My PyUnit',
+                           description='PyUnit example testcase',
+                           suite=unittest.makeSuite(MyTest)))
+
+
+# Finally we trigger our main function when the script is run, and
+# set the return status.
+if __name__ == '__main__':
+    res = main()
+    sys.exit(res.exit_code)

--- a/testplan/testing/pyunit.py
+++ b/testplan/testing/pyunit.py
@@ -1,0 +1,64 @@
+"""PyUnit test runner."""
+
+from testplan.testing import base as testing
+from testplan.report import testing as report_testing
+from testplan.common import config
+from testplan.testing.multitest.entries import assertions
+from testplan.testing.multitest.entries import schemas
+
+import unittest
+
+
+class PyUnitConfig(testing.TestConfig):
+    """
+    Configuration object for :py:class`~testplan.testing.pyunit.PyUnit` test
+    runner.
+    """
+
+    @classmethod
+    def get_options(cls):
+        return {
+            config.ConfigOption('suite'): unittest.suite.TestSuite
+        }
+
+
+class PyUnit(testing.Test):
+    """Test runner for PyUnit unit tests."""
+
+    CONFIG = PyUnitConfig
+
+    def __init__(self, **options):
+        super(PyUnit, self).__init__(**options)
+        self._suite_report = report_testing.TestGroupReport(
+            name=self.cfg.name,
+            category='suite')
+
+    def main_batch_steps(self):
+        """Specify the test steps: run the tests, then log the results."""
+        self._add_step(self.run_tests)
+        self._add_step(self.log_test_results)
+
+    def run_tests(self):
+        """Run PyUnit and wait for it to terminate."""
+        suite_result = unittest.TestResult()
+        self.cfg.suite.run(suite_result)
+
+        for call, error in suite_result.errors:
+            testcase_report = report_testing.TestCaseReport(name=str(call))
+            assertion_obj = assertions.RawAssertion(
+                description=str(call),
+                content=str(error).strip(),
+                passed=False)
+            testcase_report.append(
+                schemas.base.registry.serialize(assertion_obj))
+            self.result.report.entries.append(testcase_report)
+
+        for call, error in suite_result.failures:
+            testcase_report = report_testing.TestCaseReport(name=str(call))
+            assertion_obj = assertions.RawAssertion(
+                description=str(call),
+                content=str(error).strip(),
+                passed=False)
+            testcase_report.append(
+                schemas.base.registry.serialize(assertion_obj))
+            self.result.report.entries.append(testcase_report)


### PR DESCRIPTION
- Port the PyUnit test runner to the open-source + add example of its usage

- Fix a test that was using /tmp as a custom runpath to use a different directory. This was causing problems due to testplan cleaning the runpath and removing many other files under /tmp - including local Kerberos tokens! This means that kinit no longer has to be run after running the tests internally.