### PR TITLE
Add timeout support for testplan

### DIFF
--- a/test/functional/testplan/testing/func_basic_tasks.py
+++ b/test/functional/testplan/testing/func_basic_tasks.py
@@ -1,0 +1,94 @@
+import time
+
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+
+@testsuite
+class Suite1(object):
+    """A test suite which will be executed locally."""
+    @testcase(
+        parameters=(2, 1, 0)
+    )
+    def test_true(self, env, result, val):
+        result.true(val, description='Check if value is true')
+
+
+@testsuite
+class Suite2(object):
+    """A test suite which will be executed locally (timeout)."""
+    @testcase
+    def test_false(self, env, result):
+        result.false(None, description='Check if value is false')
+        time.sleep(600)
+
+
+@testsuite
+class Suite3(object):
+    """A test suite which will be executed in thread pool."""
+    @testcase(
+        parameters=(
+            (1+2, 3),
+            (1*2, 2),
+            (1%2, 1)
+        )
+    )
+    def test_equal(self, env, result, a, b):
+        result.equal(a, b, description='Check if 2 values are equal')
+
+
+@testsuite
+class Suite4(object):
+    """A test suite which will be executed in thread pool (timeout)."""
+    @testcase
+    def test_not_equal(self, env, result):
+        result.not_equal(1, 0, description='Check if 2 values are not equal')
+        time.sleep(600)
+
+
+@testsuite
+class Suite5(object):
+    """A test suite which will be executed in process pool."""
+    @testcase(
+        parameters=(
+            ('foo', ['foo', 'bar', 'baz']),
+            ('bar', ['foo', 'bar', 'baz']),
+            ('baz', ['foo', 'bar', 'baz'])
+        )
+    )
+    def test_contain(self, env, result, item, arr):
+        result.contain(item, arr, description='Check if an item is in a list')
+        if item == 'baz':
+            raise Exception('Raise exception deliberately')
+
+
+@testsuite
+class Suite6(object):
+    """A test suite which will be executed in process pool (timeout)."""
+    @testcase
+    def test_not_contain(self, env, result):
+        result.not_contain('foobar', ['foo', 'bar', 'baz'],
+                           description='Check if an item is not in a list')
+        time.sleep(600)
+
+
+def get_mtest1():
+    return MultiTest(name='MTest1', suites=[Suite1()])
+
+
+def get_mtest2():
+    return MultiTest(name='MTest2', suites=[Suite2()])
+
+
+def get_mtest3():
+    return MultiTest(name='MTest3', suites=[Suite3()])
+
+
+def get_mtest4():
+    return MultiTest(name='MTest4', suites=[Suite4()])
+
+
+def get_mtest5():
+    return MultiTest(name='MTest5', suites=[Suite5()])
+
+
+def get_mtest6():
+    return MultiTest(name='MTest6', suites=[Suite6()])

--- a/test/functional/testplan/testing/multitest/test_multitest_parts.py
+++ b/test/functional/testplan/testing/multitest/test_multitest_parts.py
@@ -40,7 +40,7 @@ def get_mtest(part_tuple=None):
                      part=part_tuple)
     return test
 
-'''
+
 def test_multi_parts_not_merged():
     """Execute MultiTest parts but do not merge report."""
     plan = Testplan(name='plan', parse_cmdline=False,
@@ -154,7 +154,7 @@ def test_multi_parts_invalid_parameter_2():
     assert plan.report.entries[0].entries[1].status == Status.FAILED  # Suite2
     assert 'invalid parameter of part provided' in \
            plan.report.entries[0].logs[0]['message']
-'''
+
 
 def test_multi_parts_missing_parts():
     """

--- a/test/functional/testplan/testing/test_timeout.py
+++ b/test/functional/testplan/testing/test_timeout.py
@@ -1,0 +1,63 @@
+import os
+
+from testplan import Testplan
+from testplan.runners.pools import ThreadPool, ProcessPool
+from testplan.runners.pools.tasks import Task
+from testplan.report.testing import Status
+from testplan.common.utils.testing import log_propagation_disabled
+from testplan.logger import TESTPLAN_LOGGER
+
+from test.functional.testplan.testing import func_basic_tasks
+
+
+def test_runner_timeout():
+    """
+    Execute MultiTests in LocalRunner, ThreadPool and ProcessPool respectively.
+    Some of them will timeout and we'll get a report showing execution details.
+    """
+    plan = Testplan(name='plan', parse_cmdline=False,
+                    timeout=10, abort_wait_timeout=5)
+    thread_pool_name = 'MyThreadPool'
+    proc_pool_name = 'MyProcessPool'
+    mod_path = os.path.dirname(os.path.abspath(__file__))
+
+    pool1 = ThreadPool(name=thread_pool_name, size=2)
+    pool2 = ProcessPool(name=proc_pool_name, size=2)
+    plan.add_resource(pool1)
+    plan.add_resource(pool2)
+    plan.add(func_basic_tasks.get_mtest1())
+    plan.add(func_basic_tasks.get_mtest2())
+
+    task3 = Task(target='get_mtest3', module='func_basic_tasks', path=mod_path)
+    task4 = Task(target='get_mtest4', module='func_basic_tasks', path=mod_path)
+    task5 = Task(target='get_mtest5', module='func_basic_tasks', path=mod_path)
+    task6 = Task(target='get_mtest6', module='func_basic_tasks', path=mod_path)
+    plan.schedule(task3, resource=thread_pool_name)
+    plan.schedule(task4, resource=thread_pool_name)
+    plan.schedule(task5, resource=proc_pool_name)
+    plan.schedule(task6, resource=proc_pool_name)
+
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        assert plan.run().run is False
+
+    assert len(plan.report.entries) == 6
+    assert plan.report.status == Status.ERROR
+
+    entries = plan.report.entries
+    assert entries[0].name == 'MTest1'
+    assert entries[0].status == Status.FAILED  # testcase 'test_true' failed
+    assert entries[2].name == 'MTest3'
+    assert entries[2].status == Status.PASSED  # testcase 'test_equal' passed
+    assert entries[4].name == 'MTest5'
+    assert entries[4].status == Status.ERROR   # testcase 'test_contain' raised
+    assert entries[1].name == 'MTest2'
+    assert entries[1].status == Status.ERROR   # timeout
+    assert entries[1].logs[0]['message'].startswith('Task discarding')
+    assert entries[3].name == 'Task[get_mtest4]'
+    assert entries[3].status == Status.ERROR   # timeout
+    assert entries[3].logs[0]['message'].startswith('_target: get_mtest4')
+    assert entries[3].logs[1]['message'].startswith('Task discarding')
+    assert entries[5].name == 'Task[get_mtest6]'
+    assert entries[5].status == Status.ERROR   # timeout
+    assert entries[5].logs[0]['message'].startswith('_target: get_mtest6')
+    assert entries[5].logs[1]['message'].startswith('Task discarding')

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -399,7 +399,7 @@ class Entity(object):
 
     def _abort_entity(self, entity, wait_timeout=None):
         """Method to abort an entity and log exceptions."""
-        timeout = wait_timeout   or self.cfg.abort_wait_timeout
+        timeout = wait_timeout or self.cfg.abort_wait_timeout
         try:
             self.logger.debug('Aborting {}'.format(entity))
             entity.abort()
@@ -869,14 +869,6 @@ class Resource(Entity):
         return True
 
 
-class RunnableManagerStatus(EntityConfig):
-    """
-    Status of a
-    :py:class:`RunnableManager <testplan.common.entity.base.RunnableManager>`
-    entity.
-    """
-
-
 class RunnableManagerConfig(EntityConfig):
     """
     Configuration object for
@@ -956,7 +948,7 @@ class RunnableManager(Entity):
         :rtype: :py:class:`RunnableResult <testplan.common.entity.base.RunnableResult>`
         """
         for sig in self._cfg.abort_signals:
-            signal.signal(sig,  self._handle_abort)
+            signal.signal(sig, self._handle_abort)
         execute_as_thread(self._runnable.run, daemon=True, join=True,
                           break_join=lambda: self.aborted is True)
         if isinstance(self._runnable.result, Exception):
@@ -970,7 +962,7 @@ class RunnableManager(Entity):
 
     def _handle_abort(self, signum, frame):
         for sig in self._cfg.abort_signals:
-            signal.signal(sig,  signal.SIG_IGN)
+            signal.signal(sig, signal.SIG_IGN)
         self.logger.debug('Signal handler called for signal {} from {}'.format(
             signum, threading.current_thread()))
         self.abort()

--- a/testplan/common/utils/thread.py
+++ b/testplan/common/utils/thread.py
@@ -29,7 +29,7 @@ def execute_as_thread(target, args=None, kwargs=None, daemon=False, join=True,
     :type timeout: :py:class:`~testplan.common.utils.timing.TimeoutException`
     """
     thr = threading.Thread(target=target, args=args or tuple(),
-                        kwargs=kwargs or {})
+                           kwargs=kwargs or {})
     thr.daemon = daemon
     thr.start()
     if join is True:
@@ -37,10 +37,9 @@ def execute_as_thread(target, args=None, kwargs=None, daemon=False, join=True,
         while True:
             if not thr.isAlive():
                 return
-            elif break_join is not None:
-                if break_join():
-                    break
-            elif timeout and time.time() - start_time > timeout:
+            if break_join is not None and break_join():
+                break
+            if timeout and time.time() - start_time > timeout:
                 raise TimeoutException('Thread {} timeout after {}s'.format(
                     thr, timeout))
             time.sleep(join_sleep)

--- a/testplan/exporters/testing/pdf/renderers/base.py
+++ b/testplan/exporters/testing/pdf/renderers/base.py
@@ -80,4 +80,3 @@ class MetadataMixin(object):
             for key, label in self.get_metadata_labels()
             if source.meta.get(key)
         ])
-

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -371,6 +371,12 @@ class MultiTest(Test):
 
                 time.sleep(self.cfg.active_loop_sleep)
 
+            if ctx:  # Execution aborted and still some suites left there
+                self.report.logger.error('Not all of the suites are done.')
+                st = Status.precedent([self.report.status, Status.INCOMPLETE])
+                if st != self.report.status:
+                    self.report.status_override = Status.INCOMPLETE
+
             if self._thread_pool_size > 0:
                 self._stop_thread_pool()
 


### PR DESCRIPTION
* Some tasks may spend too much time to execute or have a dead loop,
  testplan provides a timeout option to end the execution.

* Make sure that after timeout, user can get a pdf report showing
  the results of finished tasks, while unfinished tasked can still be
  listed with an error message.

* If timeout, the status of testplan report is ERROR with an error
  message displayed in pdf report, even all finished tasks are passed.

* This feature should be work for all tasks that executed in local
  runner or pools.