### PR TITLE
Add resource monitor for testplan

### DIFF
--- a/test/functional/testplan/testing/test_resource_monitor.py
+++ b/test/functional/testplan/testing/test_resource_monitor.py
@@ -1,0 +1,144 @@
+import os
+import sys
+import mock
+import time
+import json
+import socket
+from collections import namedtuple
+
+from testplan import Testplan
+from testplan.logger import TESTPLAN_LOGGER
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+
+from testplan.common.utils.monitor import EventMonitor, ResourceMonitor, load_monitor_from_json
+from testplan.common.utils.testing import log_propagation_disabled
+
+
+class MockData:
+    cpu_count = 17
+    hostname = 'test_host_name'
+    getfqdn = 'test_host_name.example.com'
+    time = 19
+
+    @staticmethod
+    def virtual_memory():
+        virt_mem = namedtuple('svmem',
+            ['total', 'available', 'percent', 'used', 'free', 'active', 'inactive', 'buffers', 'cached', 'shared'])
+        return virt_mem(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+    @staticmethod
+    def disk_usage(path=None):
+        disk_used = namedtuple('sdiskusage', ['total', 'used', 'free', 'percent'])
+        return disk_used(201, 202, 203, 204)
+
+    @staticmethod
+    def memory_info():
+        mem_info = namedtuple('pmem', ['rss', 'vms', 'shared', 'text', 'lib', 'data', 'dirty'])
+        return mem_info(100, 101, 102, 103, 104, 105, 106)
+
+    @staticmethod
+    def cpu_percent(interval=0.1):
+        return 16
+
+    @staticmethod
+    def as_dict(attrs=[]):
+        return {
+            'cmdline': ['fake', 'cmd'],
+            'memory_info': MockData.memory_info(),
+            'pid': 107,
+            'name': 'mock_python',
+            'cpu_percent': MockData.cpu_percent()
+        }
+
+    @staticmethod
+    def children(recursive=False):
+        return []
+
+
+@mock.patch('time.time', return_value=MockData.time)
+@mock.patch('socket.getfqdn', return_value=MockData.getfqdn)
+def test_event_started(*args):
+    event_monitor = EventMonitor()
+    entity_uid = event_monitor.started('mock_event')
+    event_monitor.stopped(event_uuid=entity_uid)
+    assert event_monitor.hostname == MockData.getfqdn
+    assert event_monitor.events_data[entity_uid][0]['time'] == MockData.time
+    assert event_monitor.events_data[entity_uid][1]['time'] == MockData.time
+
+
+@mock.patch('multiprocessing.cpu_count', return_value=MockData.cpu_count)
+def test_host_metadata(*args):
+    resource_monitor = ResourceMonitor()
+    resource_monitor.start()
+    assert resource_monitor.host_metadata['num_cpu'] == MockData.cpu_count
+    resource_monitor.stop()
+
+
+@mock.patch('psutil.virtual_memory', side_effect=MockData.virtual_memory)
+@mock.patch('psutil.disk_usage', side_effect=MockData.disk_usage)
+@mock.patch('psutil.Process.as_dict', side_effect=MockData.as_dict)
+@mock.patch('psutil.Process.children', side_effect=MockData.children)
+@mock.patch('multiprocessing.cpu_count', return_value=MockData.cpu_count)
+def test_resource_polling(*args):
+    poll_interval = 1
+    timeout = 5
+    resource_monitor = ResourceMonitor()
+    resource_monitor.poll_interval = poll_interval
+    resource_monitor.start()
+    time.sleep(timeout)
+    resource_monitor.stop()
+
+    mock_memory = MockData.memory_info()
+    mock_resource_data = {
+        'cpu': MockData.cpu_percent(),
+        'memory': mock_memory.rss,
+        'disk': MockData.disk_usage().percent
+    }
+    mock_host_metadata = {
+        'num_cpu': MockData.cpu_count,
+        'memory': MockData.virtual_memory().total,
+        'disk_total': MockData.disk_usage().total,
+    }
+
+    for resource, value in mock_resource_data.items():
+        assert resource_monitor.monitor_metrics[resource][0] == value
+
+    for meta, value in mock_host_metadata.items():
+        assert resource_monitor.host_metadata[meta] == value
+
+
+@testsuite
+class Alpha(object):
+
+    @testcase
+    def test_memory_a(self, env, result):
+        _tmp = 'testplan' * 1024 * 1024 * (1024 // 8)  # 1GB memory
+        time.sleep(10)
+
+
+def test_resource_monitor():
+    plan = Testplan(name='plan', parse_cmdline=False,
+                    resource_monitor=True)
+
+    plan.add(MultiTest(name='multitest_x', suites=[Alpha()]))
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        plan.run()
+
+    hostname = socket.getfqdn()
+    with open(os.path.join(plan.cfg.report_dir, 'monitor.json')) as monitor_file:
+        monitor_json = json.load(monitor_file)
+    resource_monitor = load_monitor_from_json(monitor_json[hostname])
+
+    assert isinstance(resource_monitor, ResourceMonitor) is True
+    big_size = sys.getsizeof('testplan' * 1024 * 1024 * (1024 // 8))
+    assert max(resource_monitor.monitor_metrics['memory']) >= big_size
+
+    event_uuid = None
+    for uuid, metadata in resource_monitor.events_metadata.items():
+        if metadata['name'] == 'multitest_x':
+            event_uuid = uuid
+    assert event_uuid is not None
+
+    spent_time = resource_monitor.events_data[event_uuid][-1]['time'] - \
+                 resource_monitor.events_data[event_uuid][0]['time']
+    assert spent_time >= 10

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -458,6 +458,8 @@ class Entity(object):
         Creates runpath related directories.
         """
         self._runpath = self.generate_runpath()
+        # Update self.cfg.runpath if use the default runpath
+        self.cfg.runpath = self._runpath
         self._scratch = os.path.join(self._runpath, 'scratch')
         if self.runpath is None:
             raise RuntimeError('{} runpath cannot be None'.format(
@@ -561,6 +563,7 @@ class Runnable(Entity):
         self._environment = self.__class__.ENVIRONMENT(parent=self)
         self._result = self.__class__.RESULT()
         self._steps = deque()
+        self.resource_monitor = None
 
     @property
     def result(self):

--- a/testplan/common/utils/monitor/__init__.py
+++ b/testplan/common/utils/monitor/__init__.py
@@ -1,0 +1,269 @@
+"""Resource monitor utilities."""
+
+import os
+import uuid
+import time
+import json
+import socket
+import logging
+import threading
+from testplan.common.utils.path import makedirs
+from .collectors import get_collector
+
+
+class EventMonitor(object):
+    """
+    Event monitor will record event start and stop times(seconds)
+    """
+    def __init__(self, parent=None):
+        self.logger = logging.getLogger('Monitor')
+        self.parent = parent
+        self.hostname = socket.getfqdn()
+        self.events_metadata = {}
+        self.events_data = {}
+        self.lock = threading.Lock()
+        self.log_directory = None
+        self.uid = str(uuid.uuid4())
+
+    def attach(self, event_monitor):
+        """
+        Merge the record event in two EventMonitor
+
+        :param event_monitor:  The EventMonitor will be merged.
+        :type event_monitor: ``EventMonitor``
+        :return:
+        """
+        self.events_metadata.update(event_monitor.events_metadata)
+        self.events_data.update(event_monitor.events_data)
+
+    def setup_logger(self, log_path=None, log_level=None):
+        """
+        Sets up a unique logger for Monitor each time it is called. Should only be called once or logs will be directed
+        to new logger on subsequent call.
+
+        :param log_path: Absolute path to file to save logs to.
+        :type log_path: ``str``
+        :param log_level: Level of logging to save. Currently either ``logging.DEBUG`` if "debug" given or
+                          ``logging.INFO`` if anything else is given.
+        :type log_level: ``str``
+
+        :return: ``None``
+        :rtype: ``NoneType``
+        """
+        self.logger = logging.getLogger(str(uuid.uuid4()))
+        if log_level == 'debug':
+            log_level = logging.DEBUG
+        else:
+            log_level = logging.INFO
+        if log_path:
+            directory = log_path.rsplit(os.sep, 1)[0]
+            self.log_directory = directory
+            makedirs(directory)
+            file_handler = logging.FileHandler(filename=log_path)
+        else:
+            file_handler = logging.NullHandler()  # pylint: disable=bad-option-value
+        formatter = logging.Formatter('%(asctime)s-Monitor-%(levelname)-8s:  %(message)s')
+        file_handler.setFormatter(formatter)
+        file_handler.setLevel(log_level)
+        self.logger.setLevel(log_level)
+        self.logger.addHandler(file_handler)
+
+    def _record_event(self, event_uuid, event):
+        if event_uuid not in self.events_data:
+            self.events_data[event_uuid] = []
+        self.events_data[event_uuid].append({
+            'event': event,
+            'time': time.time(),
+        })
+
+    def started(self, event_type, metadata=None):
+        """
+        Record event started.
+
+        :param event_type: The type of event. ('Pool', 'Multitest' etc.)
+        :type event_type: ``str``
+        :param metadata: The properties of the event. ('name', 'pass' etc.)
+        :type metadata: ``dict``
+
+        :return: Event unique id
+        :rtype: ``str``
+        """
+        event_uuid = str(uuid.uuid4())
+        with self.lock:
+            if not metadata:
+                _metadata = {}
+            elif isinstance(metadata, dict):
+                _metadata = metadata.copy()
+            else:
+                raise TypeError('Event metadata must be a dictionary - not {}'.format(type(metadata)))
+            _metadata['type'] = event_type
+            self.events_metadata[event_uuid] = _metadata
+            self._record_event(event_uuid, 'start')
+        return event_uuid
+
+    def stopped(self, event_uuid, metadata=None):
+        """
+        Record event stopped.
+
+        :param event_uuid: Event unique id
+        :type event_uuid: ``str``
+        :param metadata: The properties of the event want to be updated.
+
+        :return: ``None``
+        :rtype: ``NoneType``
+        """
+        with self.lock:
+            if metadata:
+                self.events_metadata[event_uuid].update(metadata)
+            self._record_event(event_uuid, 'stop')
+
+    def to_dict(self):
+        """
+        Convert the internal data to a dictionary.
+
+        :return: dict of internal data
+        :rtype: ``dict``
+        """
+        _result = {
+            'events_metadata': self.events_metadata,
+            'events_data': self.events_data,
+            'hostname': self.hostname
+        }
+        return _result
+
+    def dumps(self):
+        """
+        Dump the internal data as a JSON string
+
+        :return: JSON string of internal data
+        :rtype: ``str``
+        """
+        return json.dumps(self.to_dict())
+
+    def save(self, scratch_path):
+        """
+        Save the internal data as a JSON string in file_path. Will append an integer to filename
+        ensuring it always writes to a new file
+
+        :param scratch_path: file path to save internal data to
+        :type scratch_path: ``str``
+
+        :return: ``None``
+        :rtype: ``NoneType``
+        """
+        directory = os.path.join(scratch_path, 'monitor')
+        file_name = 'monitor-{}-{}.data'.format(self.hostname, self.uid)
+        full_path = os.path.join(directory, file_name)
+        if not os.path.exists(directory):
+            self.logger.info('Creating directory %s', directory)
+            makedirs(directory)
+        with open(full_path, 'w') as monitor_file:
+            monitor_file.write(self.dumps())
+        # self.logger.debug('Monitor data saved to {}'.format(full_path))
+
+    def load(self, serial_json):
+        """
+        Load data from a JSON string or a dict.
+
+        :param serial_json: The json type of event monitor
+        :type serial_json: ``str`` or ``dict``
+
+        :return: ``None``
+        :rtype: ``NoneType``
+        """
+        if isinstance(serial_json, str):
+            _serial_json = json.loads(serial_json)
+        else:
+            _serial_json = serial_json
+        for name, value in _serial_json.items():
+            setattr(self, name, value)
+        self.logger.info('Internal data loaded, previous internal data overwritten')
+
+
+class ResourceMonitor(EventMonitor):
+    """
+    Resource Monitor will collect the host hardware information(CPU, memory, disk etc.)
+    and the metrics(the usage of CPU, memory and disk).
+
+    """
+
+    def __init__(self, directory=None, parent=None, collector=None):
+        super(ResourceMonitor, self).__init__(parent=parent)
+        self._collector = collector or get_collector(directory or os.getcwd())
+        self._poll = None
+        self._poll_event = threading.Event()
+        self._poll_start = False
+        self.poll_interval = 5
+        self.host_metadata = self._collector.metadata
+        self.monitor_metrics = {
+            'cpu': [],
+            'memory': [],
+            'disk': [],
+            'iops': [],
+            'read': [],
+            'write': [],
+            'time': []
+        }
+
+    def _monitoring(self):
+        while self._poll_start:
+            _now = time.time()
+            _metrics = self._collector.monitor()
+            _metrics['time'] = _now
+            for key in self.monitor_metrics.keys():
+                self.monitor_metrics[key].append(_metrics[key])
+
+            _sleep_time = self.poll_interval - (time.time() - _now)
+            if _sleep_time > 0:
+                time.sleep(_sleep_time)
+
+    def start(self):
+        """
+        Start the thread of collect the metrics.
+
+        :return: ``None``
+        :rtype: ``NoneType``
+        """
+        self._poll = threading.Thread(target=self._monitoring)
+        self._poll.daemon = True
+        self._poll_start = True
+        self._poll.start()
+        self.logger.info('Resource polling started')
+
+    def stop(self):
+        """
+        Stop collect metrics.
+
+        :return: ``None``
+        :rtype: ``NoneType``
+        """
+        if self._poll:
+            self._poll_start = False
+            self.logger.info('Resource polling stoped!')
+
+    def to_dict(self):
+        _result = super(ResourceMonitor, self).to_dict()
+        _result['host_metadata'] = self.host_metadata
+        _result['monitor_metrics'] = self.monitor_metrics
+        return _result
+
+
+def load_monitor_from_json(serial_json):
+    """
+    Convert JSON string to EventMonitor/ResourceMonitor
+
+    :param serial_json:
+
+    :return: EventMonitor/ResourceMonitor
+    :rtype: ``EventMonitor`` or ``ResourceMonitor``
+    """
+    if isinstance(serial_json, str):
+        _serial_json = json.loads(serial_json)
+    else:
+        _serial_json = serial_json
+    if 'host_metadata' in _serial_json:
+        event_monitor = ResourceMonitor()
+    else:
+        event_monitor = EventMonitor()
+    event_monitor.load(_serial_json)
+    return event_monitor

--- a/testplan/common/utils/monitor/collectors.py
+++ b/testplan/common/utils/monitor/collectors.py
@@ -1,0 +1,121 @@
+"""Collect system information"""
+
+import os
+import time
+import platform
+import subprocess
+import multiprocessing
+import psutil
+
+
+class Collector(object):
+    def __init__(self, director):
+        self.metadata = {
+            'num_cpu': multiprocessing.cpu_count(),
+            'memory': psutil.virtual_memory().total,
+            'disk_total': psutil.disk_usage(director).total,
+            'disk_director': director,
+            'system': platform.platform(),
+            'extra': {},
+        }
+        self._pid = os.getpid()
+
+        # save last io counter per process
+        self._io_counter = {}
+
+    def monitor(self):
+        parent = psutil.Process(self._pid)
+        procs = parent.children(recursive=True)
+        procs.append(parent)
+        monitor_result = {
+            'cpu': 0,
+            'memory': 0,
+            'disk': psutil.disk_usage(self.metadata['disk_director']).percent,
+            'iops': 0,
+            'read': 0,
+            'write': 0,
+        }
+        for proc in procs:
+            try:
+                raw_data = proc.as_dict(
+                    attrs=['pid', 'name', 'memory_info', 'cpu_percent', 'io_counters', 'create_time', 'io_counters'])
+
+            except psutil.NoSuchProcess:
+                continue
+            monitor_result['cpu'] += raw_data['cpu_percent'] if raw_data['cpu_percent'] > 0 else 0
+            monitor_result['memory'] += raw_data['memory_info'].rss
+            try:
+                counters = {
+                    'io_counter': raw_data['io_counters'].read_count + raw_data['io_counters'].write_count,
+                    'read_counter': raw_data['io_counters'].read_bytes,
+                    'write_counter': raw_data['io_counters'].write_bytes,
+                    'time': time.time()
+                }
+                iops = read = write = 0
+                if raw_data['pid'] in self._io_counter \
+                        and self._io_counter[raw_data['pid']]['io_counter'] >= counters['io_counter']:
+                    _interval = counters['time'] - self._io_counter[raw_data['pid']]['time']
+                    iops = (counters['io_counter'] - self._io_counter[raw_data['pid']]['io_counter']) / _interval
+                    read = (counters['read_counter'] - self._io_counter[raw_data['pid']]['read_counter']) / _interval
+                    write = (counters['write_counter'] - self._io_counter[raw_data['pid']]['write_counter']) / _interval
+                else:
+                    _interval = counters['time'] - raw_data['create_time']
+                    if _interval >= 1.0:
+                        iops = counters['io_counter'] / _interval
+                        read = counters['read_counter'] / _interval
+                        write = counters['write_counter'] / _interval
+                self._io_counter[raw_data['pid']] = counters.copy()
+                monitor_result['iops'] += iops
+                monitor_result['read'] += read
+                monitor_result['write'] += write
+            except (AttributeError, KeyError):
+                # process exited or no io counters
+                pass
+        return monitor_result
+
+
+class LinuxCollector(Collector):
+    def __init__(self, director):
+        super(LinuxCollector, self).__init__(director)
+        try:
+            cpu_info = subprocess.check_output(['lscpu'])
+            self.metadata['extra']['cpu_info'] = cpu_info.decode()
+        except Exception:
+            pass
+
+
+class LinuxContainerCollector(LinuxCollector):
+    def __init__(self, director):
+        super(LinuxContainerCollector, self).__init__(director)
+        with open('/proc/1/cgroup') as cgroup_file:
+            for cgroup in cgroup_file:
+                try:
+                    if ':memory:' in cgroup:
+                        path = os.path.join('/sys/fs/cgroup/memory/', cgroup.split(':')[-1][1:],
+                                            'memory.limit_in_bytes')
+                        with open(path, 'r') as memory_file:
+                            self.metadata['memory'] = int(memory_file.read())
+                except (IOError, AttributeError, ValueError):
+                    pass
+
+
+class WindowsCollector(Collector):
+    def __init__(self, director):
+        super(WindowsCollector, self).__init__(director)
+
+
+def get_collector(director=os.getcwd()):
+    if platform.system() == 'Windows':
+        return WindowsCollector(director)
+    elif platform.system() == 'Linux':
+        try:
+            with open('/proc/1/cgroup') as cgroup_file:
+                for cgroup in cgroup_file:
+                    pid, name, group = cgroup.split(':')
+                    if group.strip() != '/':
+                        return LinuxContainerCollector(director)
+        except (IOError, ValueError):
+            pass
+        return LinuxCollector(director)
+    else:
+        raise RuntimeError('Unsupported system {}'.format(platform.system()))

--- a/testplan/exporters/testing/__init__.py
+++ b/testplan/exporters/testing/__init__.py
@@ -2,3 +2,4 @@ from .pdf import PDFExporter, TagFilteredPDFExporter
 from .xml import XMLExporter
 from .json import JSONExporter
 from .base import Exporter
+from .resource import ResourceExporter

--- a/testplan/exporters/testing/resource/__init__.py
+++ b/testplan/exporters/testing/resource/__init__.py
@@ -1,0 +1,52 @@
+
+import os
+import json
+from testplan import defaults
+from testplan.common.config import ConfigOption
+from testplan.common.exporters import ExporterConfig
+from testplan.common.utils.monitor import load_monitor_from_json
+from testplan.logger import TESTPLAN_LOGGER
+
+from ..base import Exporter
+
+
+class ResourceExporterConfig(ExporterConfig):
+    @classmethod
+    def get_options(cls):
+        return {
+            ConfigOption(
+                'report_dir', default=defaults.REPORT_DIR,
+                block_propagation=False): str
+        }
+
+
+class ResourceExporter(Exporter):
+    CONFIG = ResourceExporterConfig
+
+    def export(self, source):
+        run_path = self.cfg.runpath
+        host_event = {}
+        path = os.path.join('scratch', 'monitor')
+        for dir_path, dir_name, file_names in os.walk(run_path):
+            if dir_path.endswith(path) and not dir_name:
+                for file_name in file_names:
+                    with open(os.path.join(dir_path, file_name)) as event_file:
+                        serial_json = json.load(event_file)
+                    event_monitor = load_monitor_from_json(serial_json)
+                    if event_monitor.hostname in host_event:
+                        if hasattr(event_monitor, 'host_metadata'):
+                            event_monitor.attach(host_event[event_monitor.hostname])
+                            host_event[event_monitor.hostname] = event_monitor
+                        else:
+                            host_event[event_monitor.hostname].attach(event_monitor)
+                    else:
+                        host_event[event_monitor.hostname] = event_monitor
+        report_content = {}
+        for host, event in host_event.items():
+            report_content[host] = event.to_dict()
+
+        file_path = os.path.join(self.cfg.report_dir, 'monitor.json')
+        with open(file_path, 'w') as monitor_report:
+            json.dump(report_content, monitor_report)
+        TESTPLAN_LOGGER.exporter_info(
+                'Resource monitor generated at {}'.format(file_path))

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -203,6 +203,10 @@ class TestplanParser(object):
             ])
         )
 
+        report_group.add_argument(
+            '-r', '--resource-monitor', action='store_true', dest='resource_monitor',
+            help='Enable resource monitor that will record hosts resource statistics and event start & stop times')
+
         self.add_arguments(parser)
         return parser
 

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -98,6 +98,8 @@ class ProcessWorker(Worker):
                                           '..'),
                '--type', 'process_worker',
                '--log-level', TESTPLAN_LOGGER.getEffectiveLevel()]
+        if self.cfg.resource_monitor:
+            cmd.extend(['--resource-monitor', ])
         if os.environ.get(testplan.TESTPLAN_DEPENDENCIES_PATH):
             cmd.extend(
                 ['--testplan-deps', fix_home_prefix(

--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -521,6 +521,8 @@ class RemoteWorker(ProcessWorker):
                '--runpath', self._remote_testplan_runpath,
                '--remote-pool-type', self.cfg.pool_type,
                '--remote-pool-size', str(self.cfg.workers)]
+        if self.cfg.resource_monitor:
+            cmd.extend(['--resource-monitor', ])
         self._add_testplan_import_path(cmd, flag='--testplan')
         if not self._should_transfer_workspace:
             self._add_testplan_deps_import_path(cmd, flag='--testplan-deps')


### PR DESCRIPTION
Add resource monitor that will export a JSON file includes:

* test and Testplan internals (events) start and stop times (seconds)
* resource utilisation per host

To run Testplan with Resource Monitor just run your Testplan script with the --resource-monitor command line argument.