### PR TITLE
Add wait_for_connection() method to FixServer

### DIFF
--- a/testplan/common/utils/sockets/fix/server.py
+++ b/testplan/common/utils/sockets/fix/server.py
@@ -386,7 +386,7 @@ class Server(object):
         """
         return conn_name in self._conndetails_by_name
 
-    def wait_for_connection(self, timeout = 60, conn_name = None):
+    def accept_connection(self, timeout = 10, conn_name = None):
         """
         Waits for the given connection to appear, or any connection if None.
 

--- a/testplan/testing/multitest/driver/fix/server.py
+++ b/testplan/testing/multitest/driver/fix/server.py
@@ -113,6 +113,13 @@ class FixServer(Driver):
         return self._server.is_connection_active(conn_name)
     is_connection_active.__doc__ = Server.is_connection_active.__doc__
 
+    def wait_for_connection(self, timeout = 60, conn_name = None):
+        """
+        Docstring from Server.wait_for_connection
+        """
+        return self._server.wait_for_connection(conn_name)
+    wait_for_connection.__doc__ = Server.wait_for_connection.__doc__
+
     def send(self, msg, conn_name=(None, None)):
         """
         Docstring from Server.send

--- a/testplan/testing/multitest/driver/fix/server.py
+++ b/testplan/testing/multitest/driver/fix/server.py
@@ -113,12 +113,12 @@ class FixServer(Driver):
         return self._server.is_connection_active(conn_name)
     is_connection_active.__doc__ = Server.is_connection_active.__doc__
 
-    def wait_for_connection(self, timeout = 60, conn_name = None):
+    def accept_connection(self, timeout = 10, conn_name = None):
         """
-        Docstring from Server.wait_for_connection
+        Docstring from Server.accept_connection
         """
-        return self._server.wait_for_connection(conn_name)
-    wait_for_connection.__doc__ = Server.wait_for_connection.__doc__
+        return self._server.accept_connection(conn_name)
+    accept_connection.__doc__ = Server.accept_connection.__doc__
 
     def send(self, msg, conn_name=(None, None)):
         """


### PR DESCRIPTION
Occasionally there is a race when using FixServer in a testcase when the first thing the testcase does is try to receive a message from the FixServer before the connection has been established:
```
msg = env.fixserver.receive()
```
which results in:
```
Exception: Cannot use default connection since more connections active
```
(This error is not entirely correct as there are no connections active yet (server checks if number of connections != 1) - but that does not really concern me).

This patch adds a `wait_for_connection()` method which fixes the race.
BTW. I was wondering if it would be desirable to do this in the FixServer's `receive()` method. I did not want to impact other users/uses of `receive()` so opted to expose this function instead.