### PR TITLE
Warn and fail if no tests were run and add default ProcessRunnerTest suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.4"
 
 install:
-  - pip install -r requirements.txt
+  - pip install -r requirements.txt --upgrade
   - python setup.py develop
 
 script:

--- a/test/unit/testplan/common/config/test_generic_config.py
+++ b/test/unit/testplan/common/config/test_generic_config.py
@@ -72,7 +72,7 @@ def test_basic_schema_fail():
                  pattern=re.compile(r".*\n.*should be instance of 'int'.*",
                                     re.MULTILINE))
     should_raise(SchemaError, First, kwargs=dict(d=1.0),
-                 pattern=re.compile(r".*Wrong keys 'd'.*"))
+                 pattern=re.compile(r".*Wrong keys? 'd'.*"))
 
 
 def test_lambda_matching():

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -801,6 +801,7 @@ class Runnable(Entity):
         pass
 
     def _run(self):
+        self.logger.debug('Running %s', self)
         self.status.change(RunnableStatus.RUNNING)
         while self.active:
             if self.status.tag == RunnableStatus.RUNNING:
@@ -808,14 +809,18 @@ class Runnable(Entity):
                     func, args, kwargs = self._steps.popleft()
                     self.pre_step_call(func)
                     if self.skip_step(func) is False:
-                        self.logger.debug('Executing step of {} - {}'.format(
-                            self, func.__name__))
+                        self.logger.debug(
+                            'Executing step of %s - %s', self, func.__name__)
                         start_time = time.time()
                         self._execute_step(func, *args, **kwargs)
                         self.logger.debug(
-                            'Finished step of {}, {} - {}s'.format(
-                                self, func.__name__,
-                                round(time.time() - start_time, 5)))
+                            'Finished step of %s - %s. Took %ds',
+                            self,
+                            func.__name__,
+                            round(time.time() - start_time, 5))
+                    else:
+                        self.logger.debug(
+                            'Skipping step of %s - %s', self, func.__name__)
                     self.post_step_call(func)
                 except IndexError:
                     self.status.change(RunnableStatus.FINISHED)

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -42,7 +42,6 @@ TestReport(name='MyPlan')
 import copy
 import collections
 import inspect
-import uuid
 
 from testplan.common.report import (
     ExceptionLogger as ExceptionLoggerBase, Report, ReportGroup)

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -389,6 +389,8 @@ class TestRunner(Runnable):
             target = runnable
 
         should_run = target.should_run()
+        self.logger.debug('should_run %s? %s', target.name, bool(should_run))
+
         # --list always returns False
         if should_run and self.cfg.test_lister is not None:
             self.cfg.test_lister.log_test_info(target)

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -589,10 +589,14 @@ class TestRunner(Runnable):
         return self.cfg.name
 
     def _log_test_status(self):
-        log_test_status(
-            name=self.cfg.name,
-            passed=self._result.test_report.passed
-        )
+        if not self._result.test_report.entries:
+            self.logger.warning(
+                'No tests were run - check your filter patterns.')
+            self._result.test_report.status_override = Status.FAILED
+        else:
+            log_test_status(
+                name=self.cfg.name,
+                passed=self._result.test_report.passed)
 
     def _invoke_exporters(self):
         # Add this logic into a ReportExporter(Runnable)

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -260,6 +260,9 @@ class Test(Runnable):
                 return style.display_suite, SUITE_INDENT
             elif test_obj.category == 'parametrization':
                 return False, 0  # DO NOT display
+            else:
+                raise ValueError('Unexpected test group category: {}'
+                                 .format(test_obj.category))
         elif isinstance(test_obj, TestCaseReport):
             return style.display_case, TESTCASE_INDENT
         elif isinstance(test_obj, dict):
@@ -384,6 +387,12 @@ class ProcessRunnerTest(Test):
 
     CONFIG = ProcessRunnerTestConfig
 
+    # Some process runners might not have a simple way to list
+    # suites/testcases or might not even have the concept of test suites. If
+    # no list_command is specified we will store all testcase results in a
+    # single suite, with a default name.
+    _DEFAULT_SUITE_NAME = 'AllTests'
+
     def __init__(self, **options):
         super(ProcessRunnerTest, self).__init__(**options)
 
@@ -444,7 +453,7 @@ class ProcessRunnerTest(Test):
         """
         cmd = self.list_command()
         if cmd is None:
-            return []
+            return [(self._DEFAULT_SUITE_NAME, ())]
 
         proc = subprocess_popen(
             cmd,


### PR DESCRIPTION
Previously:

`./test_plan.py --pattern BADPATTERN`

Would run no tests and just print that the testplan has passed. This is not very helpful when you mistype a pattern.

This PR changes behaviour so that if no tests were run we make an explicit warning and do not report the testplan as passed. Marking the testplan as failed gives a non-zero exit code and skips report generation in this case.