### PR TITLE
Add custom value comparators to dictmatch

### DIFF
--- a/examples/Assertions/Basic/test_plan.py
+++ b/examples/Assertions/Basic/test_plan.py
@@ -559,6 +559,33 @@ class SampleSuite(object):
         result.dict.match(
             actual, expected, description='Dict match: Custom comparators')
 
+        # You can also specify a comparator function to apply to all values in
+        # your dict. Standard comparators are available under
+        # testplan.common.utils.comparison.COMPARE_FUNCTIONS but any function
+        # f(x: Any, y: Any) -> bool can be used.
+        actual = {'foo': 1, 'bar': 2, 'baz': 3}
+        expected = {'foo': 1.0, 'bar': 2.0, 'baz': 3.0}
+
+        result.dict.match(
+            actual,
+            expected,
+            description='default assertion passes because the values are '
+                        'numerically equal')
+        result.dict.match(
+            actual,
+            expected,
+            description='when we check types the assertion will fail',
+            value_cmp_func=comparison.COMPARE_FUNCTIONS['check_types'])
+
+        actual = {'foo': 1.02, 'bar': 2.28, 'baz': 3.50}
+        expected = {'foo': 0.98, 'bar': 2.33, 'baz': 3.46}
+        result.dict.match(
+            actual,
+            expected,
+            description='use a custom comparison function to check within a '
+                        'tolerance',
+            value_cmp_func=lambda x, y: abs(x - y) < 0.1)
+
         # `dict.check` can be used for checking existence / absence
         # of keys within a dictionary
 

--- a/test/functional/testplan/runners/fixtures/assertions_failing/report.py
+++ b/test/functional/testplan/runners/fixtures/assertions_failing/report.py
@@ -1091,6 +1091,11 @@ expected_report = TestReport(
                                     'type': 'DictMatch',
                                     'passed': False,
                                     'description': 'error func',
+                                },
+                                {
+                                    'type': 'DictMatch',
+                                    'passed': False,
+                                    'description': 'type checking fails',
                                 }
                             ]
                         ),
@@ -1196,6 +1201,13 @@ expected_report = TestReport(
                                     'type': 'FixMatch',
                                     'passed': False,
                                     'description': 'error func',
+                                },
+                                {
+                                    'type': 'FixMatch',
+                                    'passed': False,
+                                    'description':
+                                        'typed fixmsgs have different value '
+                                        'types',
                                 }
                             ]
                         ),

--- a/test/functional/testplan/runners/fixtures/assertions_failing/suites.py
+++ b/test/functional/testplan/runners/fixtures/assertions_failing/suites.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 
-from testplan.common.utils import comparison as cmp
+from testplan.common.utils import comparison as cmp, testing as test_utils
 
 
 def always_true(obj):
@@ -488,7 +488,6 @@ class MySuite(object):
 
     @testcase
     def test_dict_match(self, env, result):
-
         result.dict.match(
             actual={'foo': 1, 'bar': 2, 'baz': 2},
             expected={'foo': 1, 'bar': 2, 'bat': 3},
@@ -537,6 +536,12 @@ class MySuite(object):
             },
             description='error func'
         )
+
+        result.dict.match(
+            actual={'foo': 1, 'bar': 2},
+            expected={'foo': 1.0, 'bar': 2.0},
+            description='type checking fails',
+            value_cmp_func=cmp.COMPARE_FUNCTIONS['check_types'])
 
     @testcase
     def test_dict_match_all(self, env, result):
@@ -638,6 +643,15 @@ class MySuite(object):
             },
             description='error func'
         )
+
+        typed_fixmsg_actual = test_utils.FixMessage(
+            (('foo', 1), ('bar', 2.0)), typed_values=True)
+        typed_fixmsg_ex = test_utils.FixMessage(
+            (('foo', 1), ('bar', 2)), typed_values=True)
+        result.fix.match(
+            actual=typed_fixmsg_actual,
+            expected=typed_fixmsg_ex,
+            description='typed fixmsgs have different value types')
 
     @testcase
     def test_fix_match_all(self, env, result):

--- a/test/functional/testplan/runners/fixtures/assertions_passing/report.py
+++ b/test/functional/testplan/runners/fixtures/assertions_passing/report.py
@@ -661,6 +661,24 @@ expected_report = TestReport(
                                     'description':
                                         'match with regex & custom func',
                                 },
+                                {
+                                    'type': 'DictMatch',
+                                    'passed': True,
+                                    'description':
+                                        'dict match checking types',
+                                },
+                                {
+                                    'type': 'DictMatch',
+                                    'passed': True,
+                                    'description':
+                                        'comparison of different types',
+                                },
+                                {
+                                    'type': 'DictMatch',
+                                    'passed': True,
+                                    'description':
+                                        'match with stringify method',
+                                },
                             ]
                         ),
                         TestCaseReport(
@@ -728,6 +746,26 @@ expected_report = TestReport(
                                     'passed': True,
                                     'description':
                                         'match with regex & custom func',
+                                },
+                                {
+                                    'type': 'FixMatch',
+                                    'passed': True,
+                                    'description':
+                                        'default untyped fixmatch will '
+                                        'stringify',
+                                },
+                                {
+                                    'type': 'FixMatch',
+                                    'passed': True,
+                                    'description':
+                                        'typed fixmatch will compare types',
+                                },
+                                {
+                                    'type': 'FixMatch',
+                                    'passed': True,
+                                    'description':
+                                        'mixed fixmatch will compare string '
+                                        'values',
                                 },
                             ]
                         ),

--- a/test/unit/testplan/testing/multitest/test_result.py
+++ b/test/unit/testplan/testing/multitest/test_result.py
@@ -1,11 +1,12 @@
-"""TODO."""
+"""Unit tests for the testplan.testing.multitest.result module."""
 
-import re
-
+import mock
 import pytest
 
+from testplan.testing.multitest import result as result_mod
 from testplan.testing.multitest.suite import testcase, testsuite
 from testplan.testing.multitest import MultiTest
+from testplan.common.utils import comparison, testing
 
 
 @testsuite
@@ -45,3 +46,163 @@ def test_assertion_orders():
     for idx, entry in enumerate(assertions):
         assert entry['description'] == expected[idx]
 
+
+@pytest.fixture
+def dict_ns():
+    """Dict namespace with a mocked out result object."""
+    mock_result = mock.MagicMock()
+    return result_mod.DictNamespace(mock_result)
+
+
+@pytest.fixture
+def fix_ns():
+    """FIX namespace with a mocked out result object."""
+    mock_result = mock.MagicMock()
+    return result_mod.FixNamespace(mock_result)
+
+
+class TestDictNamespace(object):
+    """Unit testcases for the result.DictNamespace class."""
+
+    def test_basic_match(self, dict_ns):
+        """
+        Test the match method against identical expected and actual dicts.
+        """
+        expected = {'key': 123}
+        actual = expected.copy()
+
+        assert dict_ns.match(
+            actual,
+            expected,
+            description='Basic dictmatch of identical dicts passes')
+
+        assert dict_ns.match(
+            actual,
+            expected,
+            description='Force type-check of values',
+            value_cmp_func=comparison.COMPARE_FUNCTIONS['check_types'])
+
+        assert dict_ns.match(
+            actual,
+            expected,
+            description='Convert values to strings before comparing',
+            value_cmp_func=comparison.COMPARE_FUNCTIONS['stringify'])
+
+    def test_duck_match(self, dict_ns):
+        """
+        Test the match method by seting different types that can be compared.
+        Due to duck-typing, ints and floats can be equal if they refer to the
+        same numeric value - in this case, 123 == 123.0. However if
+        type-checking is forced by use of the check_types comparison method
+        the assertion will fail.
+        """
+        expected = {'key': 123}
+        actual = {'key': 123.0}
+
+        assert dict_ns.match(
+            actual,
+            expected,
+            description='Dictmatch passes since the numeric values are equal.')
+
+        assert not dict_ns.match(
+            actual,
+            expected,
+            description='Dictmatch fails when type comparison is forced.',
+            value_cmp_func=comparison.COMPARE_FUNCTIONS['check_types'])
+
+        assert not dict_ns.match(
+            actual,
+            expected,
+            description='Dictmatch with string conversion fails due to '
+                        'different string representations of int/float.',
+            value_cmp_func=comparison.COMPARE_FUNCTIONS['stringify'])
+
+    def test_fail_match(self, dict_ns):
+        """
+        Test the match method for types that do not compare equal - in this
+        case, 123 should not match "123".
+        """
+        expected = {'key': 123}
+        actual = {'key': '123'}
+
+        assert not dict_ns.match(
+            actual,
+            expected,
+            description='Dictmatch fails because 123 != "123')
+
+        assert not dict_ns.match(
+            actual,
+            expected,
+            description='Dictmatch fails due to type mismatch',
+            value_cmp_func=comparison.COMPARE_FUNCTIONS['check_types'])
+
+        assert dict_ns.match(
+            actual,
+            expected,
+            description='Dictmatch passes when values are converted to strings',
+            value_cmp_func=comparison.COMPARE_FUNCTIONS['stringify'])
+
+    def test_custom_match(self, dict_ns):
+        """Test a dict match using a user-defined comparison function."""
+        expected = {'key': 174.24}
+        actual = {'key': 174.87}
+
+        tolerance = 1.0
+        def cmp_with_tolerance(lhs, rhs):
+            """Check that both values are within a given tolerance range."""
+            return abs(lhs - rhs) < tolerance
+
+        assert not dict_ns.match(
+            actual,
+            expected,
+            description='Values are not exactly equal')
+
+        assert dict_ns.match(
+            actual,
+            expected,
+            description='Values are equal within tolerance',
+            value_cmp_func=cmp_with_tolerance)
+
+
+class TestFIXNamespace(object):
+    """Unit testcases for the result.FixNamespace class."""
+
+    def test_untyped_fixmatch(self, fix_ns):
+        """Test FIX matches between untyped FIX messages."""
+        expected = testing.FixMessage(
+            ((35, 'D'), (38, '1000000'), (44, '125.83')))
+        actual = expected.copy()
+
+        assert fix_ns.match(actual, expected, description='Basic FIX match')
+
+    def test_typed_fixmatch(self, fix_ns):
+        """Test FIX matches between typed FIX messages."""
+        expected = testing.FixMessage(
+            ((35, 'D'), (38, 1000000), (44, 125.83)),
+            typed_values=True)
+        actual = expected.copy()
+
+        assert fix_ns.match(actual, expected, description='Basic FIX match')
+
+        # Now change the type of the actual 38 key's value to str. The assert
+        # should fail since we are performing a typed match.
+        actual[38] = '1000000'
+        assert not fix_ns.match(
+            actual, expected, description='Failing str/int comparison')
+
+        # Change the type to a float. The match should still fail because of
+        # the type difference, despite the numeric values being equal.
+        actual[38] = 1000000.0
+        assert not fix_ns.match(
+            actual, expected, description='Failing float/int comparison')
+
+    def test_mixed_fixmatch(self, fix_ns):
+        """Test FIX matches between typed and untyped FIX messages."""
+        expected = testing.FixMessage(
+            ((35, 'D'), (38, '1000000'), (44, '125.83')),
+            typed_values=False)
+        actual = testing.FixMessage(
+            ((35, 'D'), (38, '1000000'), (44, 125.83)),
+            typed_values=True)
+
+        assert fix_ns.match(actual, expected, description='Mixed FIX match')

--- a/testplan/common/utils/testing.py
+++ b/testplan/common/utils/testing.py
@@ -390,3 +390,22 @@ class XMLComparison(object):
         xml_bytes = bytes(bytearray(xml_str, encoding=encoding))
         xml_obj = objectify.fromstring(xml_bytes)
         self._compare_obj(xml_obj)
+
+
+class FixMessage(dict):
+    """
+    Basic FIX message for testing. A FIX message may be either typed or
+    untyped. In other respects is acts like a plain dict.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Default to untyped if no typed_values kwarg was provided.
+        self.typed_values = kwargs.pop('typed_values', False)
+        super(FixMessage, self).__init__(*args, **kwargs)
+
+    def copy(self):
+        """
+        Override copy() to return another FixMessage, preserving the
+        typed_values attribute.
+        """
+        return FixMessage(self.items(), typed_values=self.typed_values)

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -7,6 +7,7 @@ import uuid
 
 from testplan import defaults
 from testplan.defaults import STDOUT_STYLE
+from testplan.common.utils import comparison
 
 from .entries import assertions, base
 from .entries.schemas.base import registry as schema_registry
@@ -746,11 +747,17 @@ class DictNamespace(AssertionNamespace):
         )
 
     @bind_entry
-    def match(
-        self, actual, expected, description=None, category=None,
-        include_keys=None, exclude_keys=None, report_all=True,
-        actual_description=None, expected_description=None,
-    ):
+    def match(self,
+              actual,
+              expected,
+              description=None,
+              category=None,
+              include_keys=None,
+              exclude_keys=None,
+              report_all=True,
+              actual_description=None,
+              expected_description=None,
+              value_cmp_func=comparison.COMPARE_FUNCTIONS['native_equality']):
         """
         Matches two dictionaries, supports nested data. Custom
         comparators can be used as values on the ``expected`` dict.
@@ -821,7 +828,7 @@ class DictNamespace(AssertionNamespace):
             expected_description=expected_description,
             actual_description=actual_description,
             category=category,
-        )
+            value_cmp_func=value_cmp_func)
 
     @bind_entry
     def match_all(


### PR DESCRIPTION
Adds a new value_cmp_func kwarg to DictNamespace.match(),
which allows users to set a custom function for comparing
all values in a dict (versus adding a custom function for
comparing a value for a specific key). Built-in functions are defined
in comparison.CompareFunctions enum. The default option is to
use plain operator.eq - previously the default comparison
method was to always stringify.

Adds UTs for dict.match covering the new functionality.

Also update FixNamespace.match for typed vs untyped FIX matches.
With untyped or mixed, values are compared as strings. Else for
typed FIX messages the types will be checked explicitly.