### PR TITLE
Show name of discarded tasks on console when timeout

### DIFF
--- a/test/functional/testplan/testing/test_timeout.py
+++ b/test/functional/testplan/testing/test_timeout.py
@@ -16,7 +16,7 @@ def test_runner_timeout():
     Some of them will timeout and we'll get a report showing execution details.
     """
     plan = Testplan(name='plan', parse_cmdline=False,
-                    timeout=10, abort_wait_timeout=5)
+                    timeout=30, abort_wait_timeout=10)
     thread_pool_name = 'MyThreadPool'
     proc_pool_name = 'MyProcessPool'
     mod_path = os.path.dirname(os.path.abspath(__file__))

--- a/testplan/runners/local.py
+++ b/testplan/runners/local.py
@@ -81,6 +81,7 @@ class LocalRunner(Executor):
             result.report = TestGroupReport(name=uid)
             result.report.status_override = Status.ERROR
             result.report.logger.critical(
-                'Item {} discarding due to {} abort.'.format(uid, self.uid()))
+                'Test [{}] discarding due to {} abort.'.format(
+                    uid, self.uid()))
             self._results[uid] = result
 

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -661,7 +661,8 @@ class Pool(Executor):
             uid = self.ongoing[0]
             self._results[uid] = TaskResult(
                 task=self._input[uid], status=False,
-                reason='Task discarding due to pool {} abort.'.format(self))
+                reason='Task [{}] discarding due to {} abort.'.format(
+                    self._input[uid]._target, self))
             self.ongoing.pop(0)
 
     def _print_test_result(self, task_result):


### PR DESCRIPTION
* A small improvement that when timeout, the test executers will
  abort, it should display the name of ongoing tasks which are
  discarded, for easier debugging.

* Functional test of timeout on Windows sometimes takes longer time
  till ProcessPool ready, so, expand waiting time to make test stable.