### PR TITLE
Warn if command line argument takes no effect

### DIFF
--- a/testplan/base.py
+++ b/testplan/base.py
@@ -122,6 +122,10 @@ class Testplan(RunnableManager):
         self._parsed_args = self.parser.parse_args()
         self._processed_args = self.parser.process_args(self._parsed_args)
         for key, value in self._processed_args.items():
+            if key in options:
+                self.logger.warning('WARNING: Command line argument for '
+                    '"{}" will be overridden by the one programmatically '
+                        'defined in {} constructor'.format(key, self))
             options.setdefault(key, value)
 
         return options

--- a/testplan/common/config/base.py
+++ b/testplan/common/config/base.py
@@ -54,7 +54,7 @@ def ConfigOption(key, default=ABSENT, block_propagation=True):
     Think that you have a 'display_style' option in config, then you can
     customize the output. If multitests were added to testplan, where there is
     also such a 'display_style' option in its config, so we should apply the
-    ptions from their parent.
+    options from their parent.
 
     With `block_propagation` set to be False, the default value defined in
     parent class has higher priority to be retrieved.


### PR DESCRIPTION
* User can specify argument for running testplan by programmatically
  writting it in script or by passing it in command line. If argument
  specified on both side, command line argument will be overridden. We
  should print warning to let user know it.