### PR TITLE
Replace report_all flag with report_mode option

### DIFF
--- a/examples/Assertions/Basic/test_plan.py
+++ b/examples/Assertions/Basic/test_plan.py
@@ -586,6 +586,20 @@ class SampleSuite(object):
                         'tolerance',
             value_cmp_func=lambda x, y: abs(x - y) < 0.1)
 
+        # The report_mode can be specified to limit the comparison
+        # information stored. By default all comparisons are stored and added
+        # to the report, but you can choose to discard some comparisons to
+        # reduce the size of the report when comparing very large dicts.
+        actual = {'key{}'.format(i): i for i in range(10)}
+        expected = actual.copy()
+        expected['bad_key'] = 'expected'
+        actual['bad_key'] = 'actual'
+        result.dict.match(
+            actual,
+            expected,
+            description='only report the failing comparison',
+            report_mode=comparison.ReportOptions.FAILS_ONLY)
+
         # `dict.check` can be used for checking existence / absence
         # of keys within a dictionary
 

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -1090,7 +1090,7 @@ class DictMatch(Assertion):
                  expected,
                  include_keys=None,
                  exclude_keys=None,
-                 report_all=True,
+                 report_mode=comparison.ReportOptions.ALL,
                  description=None,
                  category=None,
                  actual_description=None,
@@ -1101,8 +1101,8 @@ class DictMatch(Assertion):
         self.include_keys = include_keys
         self.exclude_keys = exclude_keys
         self.actual_description = actual_description
-        self.report_all = report_all
         self.expected_description = expected_description
+        self._report_mode = report_mode
         self._value_cmp_func = value_cmp_func
 
         self.comparison = None  # will be set by evaluate
@@ -1116,7 +1116,7 @@ class DictMatch(Assertion):
             rhs=self.expected,
             ignore=self.exclude_keys,
             only=self.include_keys,
-            report_all=self.report_all,
+            report_mode=self._report_mode,
             value_cmp_func=self._value_cmp_func)
         self.comparison = flatten_dict_comparison(cmp_result)
         return passed
@@ -1127,12 +1127,16 @@ class FixMatch(DictMatch):
         Similar to DictMatch, however dict keys
         will have fix tag info popups on web UI
     """
-    def __init__(
-        self, value, expected,
-        include_tags=None, exclude_tags=None, report_all=True,
-        description=None, category=None,
-        actual_description=None, expected_description=None
-    ):
+    def __init__(self,
+                 value,
+                 expected,
+                 include_tags=None,
+                 exclude_tags=None,
+                 report_mode=comparison.ReportOptions.ALL,
+                 description=None,
+                 category=None,
+                 actual_description=None,
+                 expected_description=None):
         """
         If both FIX messages are typed, we enable strict type checking.
         Otherwise, if either side is untyped we will compare the values as
@@ -1150,7 +1154,7 @@ class FixMatch(DictMatch):
             value=value, expected=expected,
             include_keys=include_tags,
             exclude_keys=exclude_tags,
-            report_all=report_all,
+            report_mode=report_mode,
             description=description,
             category=category,
             actual_description=actual_description,

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -754,7 +754,7 @@ class DictNamespace(AssertionNamespace):
               category=None,
               include_keys=None,
               exclude_keys=None,
-              report_all=True,
+              report_mode=comparison.ReportOptions.ALL,
               actual_description=None,
               expected_description=None,
               value_cmp_func=comparison.COMPARE_FUNCTIONS['native_equality']):
@@ -802,10 +802,11 @@ class DictNamespace(AssertionNamespace):
         :type include_keys: ``list`` of ``object`` (items must be hashable)
         :param exclude_keys: Keys to ignore in the comparison.
         :type include_keys: ``list`` of ``object`` (items must be hashable)
-        :param report_all: If a bool is used its a formatting flag to include
-          even ignored keys in report. If a list is used, it will trim all
-          passing keys that are not present in the given list.
-        :type report_all: ``bool`` or ``list`` of keys.
+        :param report_mode: Specify which comparisons should be kept and
+                            reported. Default option is to report all
+                            comparisons but this can be restricted if desired.
+                            See ReportOptions enum for more detail.
+        :type report_mode: ``testplan.common.utils.comparison.ReportOptions``
         :param actual_description: Column header description for original dict.
         :type actual_description: ``str``
         :param expected_description: Column header
@@ -815,6 +816,16 @@ class DictNamespace(AssertionNamespace):
         :type description: ``str``
         :param category: Custom category that will be used for summarization.
         :type category: ``str``
+        :param value_cmp_func: Function to use to compare values in expected
+                               and actual dicts. Defaults to using
+                               `operator.eq()`.
+        :type value_cmp_func: ``Callable[[Any, Any], bool]``
+        :param discard_passing: Flag to discard passing comparisons from the
+                                result and only include failures, to reduce the
+                                size of the result when comparing very large
+                                dicts. Defaults to False.
+        :type discard_passing: ``bool``
+
         :return: Assertion pass status
         :rtype: ``bool``
         """
@@ -824,7 +835,7 @@ class DictNamespace(AssertionNamespace):
             description=description,
             include_keys=include_keys,
             exclude_keys=exclude_keys,
-            report_all=report_all,
+            report_mode=report_mode,
             expected_description=expected_description,
             actual_description=actual_description,
             category=category,
@@ -960,11 +971,16 @@ class FixNamespace(AssertionNamespace):
         )
 
     @bind_entry
-    def match(
-        self, actual, expected, description=None, category=None,
-        include_tags=None, exclude_tags=None, report_all=True,
-        actual_description=None, expected_description=None,
-    ):
+    def match(self,
+              actual,
+              expected,
+              description=None,
+              category=None,
+              include_tags=None,
+              exclude_tags=None,
+              report_mode=comparison.ReportOptions.ALL,
+              actual_description=None,
+              expected_description=None):
         """
         Matches two FIX messages, supports repeating groups (nested data).
         Custom comparators can be used as values on the ``expected`` msg.
@@ -998,10 +1014,11 @@ class FixNamespace(AssertionNamespace):
         :type include_tags: ``list`` of ``object`` (items must be hashable)
         :param exclude_tags: Keys to ignore in the comparison.
         :type exclude_tags: ``list`` of ``object`` (items must be hashable)
-        :param report_all: If a bool is used its a formatting flag to include
-          even ignored keys in report. If a list is used, it will trim all
-          passing keys that are not present in the given list.
-        :type report_all: ``bool`` or ``list`` of keys.
+        :param report_mode: Specify which comparisons should be kept and
+                            reported. Default option is to report all
+                            comparisons but this can be restricted if desired.
+                            See ReportOptions enum for more detail.
+        :type report_mode: ``testplan.common.utils.comparison.ReportOptions``
         :param actual_description: Column header description for original msg.
         :type actual_description: ``str``
         :param expected_description: Column header
@@ -1011,6 +1028,12 @@ class FixNamespace(AssertionNamespace):
         :type description: ``str``
         :param category: Custom category that will be used for summarization.
         :type category: ``str``
+        :param discard_passing: Flag to discard passing comparisons from the
+                                result and only include failures, to reduce the
+                                size of the result when comparing very large
+                                dicts. Defaults to False.
+        :type discard_passing: ``bool``
+
         :return: Assertion pass status
         :rtype: ``bool``
         """
@@ -1022,10 +1045,9 @@ class FixNamespace(AssertionNamespace):
             category=category,
             include_tags=include_tags,
             exclude_tags=exclude_tags,
-            report_all=report_all,
+            report_mode=report_mode,
             expected_description=expected_description,
-            actual_description=actual_description,
-        )
+            actual_description=actual_description)
 
     @bind_entry
     def match_all(


### PR DESCRIPTION
Instead of using a report_all flag to control reporting of
dict and fix match results, add a report_mode option.
This can be set to one of the values of the new ReportOptions
enum to control the reporting behaviour. Current reporting
options are ALL (default), NO_IGNORED or FAILS_ONLY but more
could be added.