### PR TITLE
By default continue executing cases even exception raised

### DIFF
--- a/test/functional/testplan/test_timeout.py
+++ b/test/functional/testplan/test_timeout.py
@@ -60,7 +60,7 @@ class MyTestRunner(TestRunner):
                 break
 
             if self.cfg.timeout and (timeout_flag or time.time() >
-                    self._start_time + min(self.cfg.timeout, 600)):
+                    self._start_time + max(self.cfg.timeout, 600)):
                 self.result.test_report.logger.error(
                     'Timeout: Aborting execution after {} seconds'.format(
                         self.cfg.timeout))

--- a/test/functional/testplan/testing/multitest/test_stop_on_error.py
+++ b/test/functional/testplan/testing/multitest/test_stop_on_error.py
@@ -1,0 +1,349 @@
+import time
+
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+from testplan.testing.multitest.base import Categories
+
+from testplan import Testplan
+from testplan.common.utils.testing import (
+    check_report, log_propagation_disabled
+)
+from testplan.report.testing import (
+    Status, TestReport, TestGroupReport, TestCaseReport
+)
+from testplan.common.utils.logger import TESTPLAN_LOGGER
+
+
+@testsuite
+class Suite1(object):
+
+    def setup(self, env, result):
+        pass
+
+    @testcase
+    def test_case_1(self, env, result):
+        pass
+
+    @testcase
+    def test_case_2(self, env, result):
+        raise Exception('Exception raised for no reason')
+
+    @testcase
+    def test_case_3(self, env, result):
+        pass
+
+    def teardown(self, env, result):
+        pass
+
+
+@testsuite
+class Suite2(object):
+
+    def setup(self, env, result):
+        pass
+
+    @testcase(
+        parameters=(
+            -1, 0, 1
+        )
+    )
+    def test_case_divide_by_arg(self, env, result, arg):
+        result.equal(1, arg / arg, '{} / {} == 1'.format(arg, arg))
+
+    @testcase(
+        parameters=(
+            -1, 0, 1
+        )
+    )
+    def test_case_divide_by_one(self, env, result, arg):
+        result.equal(arg, arg / 1, '{} / 1 == {}'.format(arg, arg))
+
+    def teardown(self, env, result):
+        pass
+
+
+@testsuite
+class Suite3(object):
+
+    def setup(self, env, result):
+        pass
+
+    @testcase(execution_group='first')
+    def test_case_first_group_1(self, env, result):
+        pass
+
+    @testcase(execution_group='second')
+    def test_case_second_group_1(self, env, result):
+        pass
+
+    @testcase(execution_group='first')
+    def test_case_first_group_2(self, env, result):
+        time.sleep(5)  # enough time for executing testcases in 'first' group
+        raise Exception('Exception raised for no reason')
+
+    @testcase(execution_group='second')
+    def test_case_second_group_2(self, env, result):
+        pass
+
+    @testcase(execution_group='first')
+    def test_case_first_group_3(self, env, result):
+        pass
+
+    @testcase(execution_group='second')
+    def test_case_second_group_3(self, env, result):
+        pass
+
+    def teardown(self, env, result):
+        pass
+
+
+def _create_testcase_report(name, status_override=None):
+    report = TestCaseReport(name=name)
+    report.status_override = status_override
+    return report
+
+
+def test_execution_order():
+
+    multitest_1 = MultiTest(
+        name='Multitest_1',
+        suites=[Suite1(), Suite2(), Suite3()],
+        thread_pool_size=2,
+        stop_on_error=False
+    )
+    multitest_2 = MultiTest(
+        name='Multitest_2',
+        suites=[Suite1(), Suite2(), Suite3()],
+        thread_pool_size=2,
+        stop_on_error=True
+    )
+
+    plan = Testplan(name='plan', parse_cmdline=False)
+    plan.add(multitest_1)
+    plan.add(multitest_2)
+
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        plan.run()
+
+    expected_report = TestReport(
+        name='plan',
+        entries=[
+            TestGroupReport(
+                name='Multitest_1',
+                category=Categories.MULTITEST,
+                entries=[
+                    TestGroupReport(
+                        name='Suite1',
+                        category=Categories.SUITE,
+                        entries=[
+                            TestCaseReport(
+                                name='setup'
+                            ),
+                            TestCaseReport(
+                                name='test_case_1'
+                            ),
+                            _create_testcase_report(
+                                name='test_case_2',
+                                status_override=Status.ERROR
+                            ),
+                            TestCaseReport(
+                                name='test_case_3'
+                            ),
+                            TestCaseReport(
+                                name='teardown'
+                            )
+                        ]
+                    ),
+                    TestGroupReport(
+                        name='Suite2',
+                        category=Categories.SUITE,
+                        entries=[
+                            TestCaseReport(
+                                name='setup'
+                            ),
+                            TestGroupReport(
+                                name='test_case_divide_by_arg',
+                                category=Categories.PARAMETRIZATION,
+                                entries=[
+                                    TestCaseReport(
+                                        name='test_case_divide_by_arg',
+                                        entries=[
+                                            {
+                                                'type': 'Equal',
+                                                'first': 1,
+                                                'second': 1,
+                                            }
+                                        ]
+                                    ),
+                                    _create_testcase_report(
+                                        name='test_case_divide_by_arg__arg_0',
+                                        status_override=Status.ERROR
+                                    ),
+                                    TestCaseReport(
+                                        name='test_case_divide_by_arg__arg_1',
+                                        entries=[
+                                            {
+                                                'type': 'Equal',
+                                                'first': 1,
+                                                'second': 1,
+                                            }
+                                        ]
+                                    )
+                                ]
+                            ),
+                            TestGroupReport(
+                                name='test_case_divide_by_one',
+                                category=Categories.PARAMETRIZATION,
+                                entries=[
+                                    TestCaseReport(
+                                        name='test_case_divide_by_one',
+                                        entries=[
+                                            {
+                                                'type': 'Equal',
+                                                'first': -1,
+                                                'second': -1,
+                                            }
+                                        ]
+                                    ),
+                                    TestCaseReport(
+                                        name='test_case_divide_by_one__arg_0',
+                                        entries=[
+                                            {
+                                                'type': 'Equal',
+                                                'first': 0,
+                                                'second': 0,
+                                            }
+                                        ]
+                                    ),
+                                    TestCaseReport(
+                                        name='test_case_divide_by_one__arg_1',
+                                        entries=[
+                                            {
+                                                'type': 'Equal',
+                                                'first': 1,
+                                                'second': 1,
+                                            }
+                                        ]
+                                    )
+                                ]
+                            ),
+                            TestCaseReport(
+                                name='teardown'
+                            ),
+                        ]
+                    ),
+                    TestGroupReport(
+                        name='Suite3',
+                        category=Categories.SUITE,
+                        entries=[
+                            TestCaseReport(
+                                name='setup'
+                            ),
+                            TestCaseReport(
+                                name='test_case_first_group_1'
+                            ),
+                            _create_testcase_report(
+                                name='test_case_first_group_2',
+                                status_override=Status.ERROR
+                            ),
+                            TestCaseReport(
+                                name='test_case_first_group_3'
+                            ),
+                            TestCaseReport(
+                                name='test_case_second_group_1',
+                            ),
+                            TestCaseReport(
+                                name='test_case_second_group_2'
+                            ),
+                            TestCaseReport(
+                                name='test_case_second_group_3'
+                            ),
+                            TestCaseReport(
+                                name='teardown'
+                            )
+                        ]
+                    )
+                ]
+            ),
+            TestGroupReport(
+                name='Multitest_2',
+                category=Categories.MULTITEST,
+                entries=[
+                    TestGroupReport(
+                        name='Suite1',
+                        category=Categories.SUITE,
+                        entries=[
+                            TestCaseReport(
+                                name='setup'
+                            ),
+                            TestCaseReport(
+                                name='test_case_1'
+                            ),
+                            _create_testcase_report(
+                                name='test_case_2',
+                                status_override=Status.ERROR
+                            ),
+                            TestCaseReport(
+                                name='teardown'
+                            )
+                        ]
+                    ),
+                    TestGroupReport(
+                        name='Suite2',
+                        category=Categories.SUITE,
+                        entries=[
+                            TestCaseReport(
+                                name='setup'
+                            ),
+                            TestGroupReport(
+                                name='test_case_divide_by_arg',
+                                category=Categories.PARAMETRIZATION,
+                                entries=[
+                                    TestCaseReport(
+                                        name='test_case_divide_by_arg',
+                                        entries=[
+                                            {
+                                                'type': 'Equal',
+                                                'first': 1,
+                                                'second': 1,
+                                            }
+                                        ]
+                                    ),
+                                    _create_testcase_report(
+                                        name='test_case_divide_by_arg__arg_0',
+                                        status_override=Status.ERROR
+                                    )
+                                ]
+                            ),
+                            TestCaseReport(
+                                name='teardown'
+                            ),
+                        ]
+                    ),
+                    TestGroupReport(
+                        name='Suite3',
+                        category=Categories.SUITE,
+                        entries=[
+                            TestCaseReport(
+                                name='setup'
+                            ),
+                            TestCaseReport(
+                                name='test_case_first_group_1'
+                            ),
+                            _create_testcase_report(
+                                name='test_case_first_group_2',
+                                status_override=Status.ERROR
+                            ),
+                            TestCaseReport(
+                                name='test_case_first_group_3'
+                            ),
+                            TestCaseReport(
+                                name='teardown'
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+
+    check_report(expected_report, plan.report)

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -95,6 +95,7 @@ class MultiTestConfig(TestConfig):
             ConfigOption('result', default=Result): is_subclass(Result),
             ConfigOption('thread_pool_size', default=0): int,
             ConfigOption('max_thread_pool_size', default=10): int,
+            ConfigOption('stop_on_error', default=True): bool,
             ConfigOption('part', default=None): Or(None, And((int,),
                 lambda tp: len(tp) == 2 and 0 <= tp[0] < tp[1] and tp[1] > 1)),
             ConfigOption('interactive_runner', default=MultitestIRunner):
@@ -132,6 +133,9 @@ class MultiTest(Test):
     :type thread_pool_size: ``int``
     :param max_thread_pool_size: Maximum number of threads allowed in the pool.
     :type max_thread_pool_size: ``int``
+    :param stop_on_error: When exception raised, stop executing remaining
+        testcases in the current test suite. Default: True
+    :type stop_on_error: ``bool``
     :param part: Execute only a part of the total testcases. MultiTest needs to
         know which part of the total it is. Only works with Multitest.
     :type part: ``tuple`` of (``int``, ``int``)
@@ -492,8 +496,9 @@ class MultiTest(Test):
                                 testcase_report=testcase_report
                             )
                             if testcase_report.status == Status.ERROR:
-                                self._thread_pool_available = False
-                                break
+                                if self.cfg.stop_on_error:
+                                    self._thread_pool_available = False
+                                    break
 
                 time.sleep(self.cfg.active_loop_sleep)
 
@@ -584,18 +589,23 @@ class MultiTest(Test):
             self._run_testcase(
                 testcase, pre_testcase, post_testcase, testcase_report)
 
+            if testcase_report.status == Status.ERROR:
+                if self.cfg.stop_on_error:
+                    self.logger.debug(
+                        'Error executing testcase {}'
+                        ' - will stop thread pool'.format(testcase.__name__))
+                    self._thread_pool_available = False
+
             try:
+                # Call task_done() after setting thread pool unavailable, it
+                # makes sure that when self.cfg.stop_on_error is True and if
+                # a testcase in an execution group raises, no testcase in the
+                # next execution group has a chance to be put into task queue.
                 self._testcase_queue.task_done()
             except ValueError:
-                # When error occurs, testcase queue will be cleared and
-                # cannot accept 'task done' signal.
+                # When error occurs, testcase queue might already be cleared
+                # and cannot accept 'task done' signal.
                 pass
-
-            if testcase_report.status == Status.ERROR:
-                self.logger.debug(
-                    'Error executing testcase {} - stop thread pool'.format(
-                        testcase.__name__))
-                self._thread_pool_available = False
 
     def _start_thread_pool(self):
         """Start a thread pool for executing testcases in parallel."""


### PR DESCRIPTION
* The current behavior is that if any exception raised from a testcase,
  then stop executing the following testcases in the same test suite,
  and turn to execute the next test suite. Change this behavior because
  generally all testcases should not depend on each other, but we can
  provide an option in Multitest constructor if use want to stop at
  once to save time.