### PR TITLE
Serialization fixes

### DIFF
--- a/test/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/test/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -13,6 +13,7 @@ from testplan.testing.multitest.base import MultiTestConfig
 
 from test.unit.testplan.common.serialization.test_fields import UnPickleableInt
 
+
 @testsuite
 class MySuite(object):
 
@@ -23,17 +24,6 @@ class MySuite(object):
         assert isinstance(env.cfg, MultiTestConfig)
         assert os.path.exists(env.runpath) is True
         assert env.runpath.endswith(env.cfg.name)
-
-    @testcase
-    def test_serialize(self, env, result):
-        """Test serialization of test results."""
-        # As an edge case, store a deliberately "un-pickleable" type that
-        # inherits from int on the result. This should not cause an error
-        # since the value should be formatted as a string.
-        x = UnPickleableInt(42)
-        result.equal(actual=x,
-                     expected=42,
-                     description='Compare unpickleable type')
 
 
 def get_mtest(name):
@@ -109,7 +99,7 @@ def schedule_tests_to_pool(name, pool, schedule_path=None, **pool_cfg):
     assert res.success is True
     assert plan.report.passed is True
     assert plan.report.status == Status.PASSED
-    assert plan.report.counts.passed == 18  # 2 testcases * 9 iterations
+    assert plan.report.counts.passed == 9  # 1 testcase * 9 iterations
     assert plan.report.counts.error == plan.report.counts.skipped == \
            plan.report.counts.failed == plan.report.counts.incomplete == 0
 
@@ -125,3 +115,29 @@ def schedule_tests_to_pool(name, pool, schedule_path=None, **pool_cfg):
     # All tasks scheduled once
     for uid in pool.task_assign_cnt:
         assert pool.task_assign_cnt[uid] == 1
+
+
+@testsuite
+class SerializationSuite(object):
+    """Test suite to test serialization edge cases."""
+
+    @testcase
+    def test_serialize(self, env, result):
+        """Test serialization of test results."""
+        # As an edge case, store a deliberately "un-pickleable" type that
+        # inherits from int on the result. This should not cause an error
+        # since the value should be formatted as a string.
+        x = UnPickleableInt(42)
+        result.equal(actual=x,
+                     expected=42,
+                     description='Compare unpickleable type')
+
+
+def make_serialization_mtest():
+    """
+    Task target to make a MultiTest containing just the SerializationSuite
+    defined above.
+    """
+    return MultiTest(
+        name='MTestSerialization',
+        suites=[SerializationSuite()])

--- a/test/functional/testplan/runners/pools/test_pool_process.py
+++ b/test/functional/testplan/runners/pools/test_pool_process.py
@@ -1,15 +1,13 @@
-"""Process worker pool unit tests."""
+"""Process worker pool functional tests."""
 
 import os
 
+import pytest
+
 from testplan.common.utils.testing import log_propagation_disabled
-
-
 from testplan.report.testing import Status
 from testplan.runners.pools import ProcessPool
-
 from testplan import Testplan
-
 from testplan.common.utils.logger import TESTPLAN_LOGGER
 
 from .func_pool_base_tasks import schedule_tests_to_pool
@@ -180,3 +178,88 @@ def test_custom_reschedule_condition():
     assert res.success is True
     assert pool.task_assign_cnt[uid] == max_reschedules
     assert plan.report.status == Status.PASSED
+
+
+def test_unserializable_result():
+    """
+    Test scheduling a Task that stores a result which cannot be directly
+    serialized by pickle. Even though the type inherits from a trivially
+    serializalbe type (int), Testplan should still format it as a string
+    before pickling.
+    """
+    # Set up a testplan and add a ProcessPool.
+    plan = Testplan(
+        name='ProcPlan',
+        parse_cmdline=False)
+
+    pool = ProcessPool(name='ProcPool',
+                       size=2)
+    plan.add_resource(pool)
+
+    dirname = os.path.dirname(os.path.abspath(__file__))
+    plan.schedule(target='make_serialization_mtest',
+                  module='func_pool_base_tasks',
+                  path=dirname)
+
+    # Run the plan and make standard assertions that the plan has passed.
+    res = plan.run()
+    assert res.run
+    assert res.success
+    assert plan.report.passed
+    assert plan.report.status == Status.PASSED
+    assert plan.report.counts.passed == 1
+    assert plan.report.counts.error == 0
+    assert plan.report.counts.skipped == 0
+    assert plan.report.counts.failed == 0
+    assert plan.report.counts.incomplete == 0
+
+    # Dig down into the assertion result and check that the expected string
+    # format for our UnPickleableInt is stored.
+    assert len(plan.report.entries) == 1
+    mtest_report = plan.report.entries[0]
+    assert mtest_report.category == 'multitest'
+    assert len(mtest_report.entries) == 1
+
+    suite_report = mtest_report.entries[0]
+    assert suite_report.category == 'suite'
+    assert len(suite_report.entries) == 1
+
+    testcase_report = suite_report.entries[0]
+    assert len(testcase_report.entries) == 1
+
+    assertion_result = testcase_report.entries[0]
+    assert assertion_result['first'] == 'UnPickleableInt[42]'
+    assert assertion_result['second'] == 42
+
+
+def test_schedule_from_main():
+    """
+    Test scheduling Tasks from __main__ - it should not be allowed for
+    ProcessPool.
+    """
+    # Set up a testplan and add a ProcessPool.
+    plan = Testplan(
+        name='ProcPlan',
+        parse_cmdline=False)
+
+    pool = ProcessPool(name='ProcPool',
+                       size=2)
+    plan.add_resource(pool)
+
+    # First check that scheduling a Task with module string of '__main__'
+    # raises the expected ValueError.
+    with pytest.raises(ValueError):
+        plan.schedule(target='target',
+                      module='__main__',
+                      resource='ProcPool')
+
+
+    # Secondly, check that scheduling a callable target with a __module__ attr
+    # of __main__ also raises a ValueError.
+    def callable_target():
+        raise RuntimeError
+
+    callable_target.__module__ = '__main__'
+
+    with pytest.raises(ValueError):
+        plan.schedule(target=callable_target, resource='ProcPool')

--- a/test/unit/testplan/common/serialization/test_fields.py
+++ b/test/unit/testplan/common/serialization/test_fields.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for the testplan.common.serialization.fields module.
+"""
+import pytest
+
+from testplan.common.serialization import fields
+
+
+@pytest.fixture
+def native_or_pretty():
+    return fields.NativeOrPretty()
+
+
+class SerializeMe(object):
+    """Custom type that returns a string as its "serialization"."""
+
+    def __repr__(self):
+        return "I have been serialized!"
+
+
+class UnPickleableInt(int):
+    """A type that derives from int but cannot itself be serialized."""
+
+    def __getstate__(self):
+        raise NotImplementedError
+
+    def __repr__(self):
+        return "{}[{}]".format(
+            self.__class__.__name__, super(UnPickleableInt, self).__repr__())
+
+
+class SerializationTargets(object):
+    """
+    An object that contains some different values to be serialized for
+    testing.
+    """
+
+    def __init__(self):
+        self.x = 123
+        self.y = "foo"
+        self.z = None
+
+        self.serializable = SerializeMe()
+        self.unpickleable= UnPickleableInt(42)
+
+
+@pytest.fixture
+def targets():
+    return SerializationTargets()
+
+
+class TestNativeOrPretty(object):
+
+    def test_basic(self, native_or_pretty, targets):
+        """Test serialization of basic types: no change is required."""
+        for attr in ('x', 'y', 'z'):
+            serialized = native_or_pretty.serialize(attr, targets)
+            assert serialized == getattr(targets, attr)
+
+    def test_format(self, native_or_pretty, targets):
+        """Test serializing of a custom type."""
+        serialized = native_or_pretty.serialize('serializable', targets)
+        assert serialized == "I have been serialized!"
+
+    def test_derived_type(self, native_or_pretty, targets):
+        """
+        Test serializing of a type that inherits from a builtin, but is not
+        itself pickle-able. The correct behaviour is to return a formatted
+        string.
+        """
+        serialized = native_or_pretty.serialize('unpickleable', targets)
+        assert serialized == 'UnPickleableInt[42]'

--- a/test/unit/testplan/runners/pools/test_process_worker.py
+++ b/test/unit/testplan/runners/pools/test_process_worker.py
@@ -1,1 +1,47 @@
 """Unit test for process pool."""
+import pytest
+import time
+
+from testplan.runners.pools import process
+from testplan.runners.pools import tasks
+from testplan.common.utils import logger
+
+from test.unit.testplan.runners.pools.tasks.data.sample_tasks import Runnable
+
+logger.TESTPLAN_LOGGER.setLevel(logger.DEBUG)
+
+
+@pytest.fixture
+def proc_pool():
+    return process.ProcessPool(name='ProcPool', size=2)
+
+
+class TestProcPool(object):
+    """Tests for the ProcessPool class."""
+
+    def test_run_task(self, proc_pool):
+        """
+        Test that a simple Task can be scheduled to a process pool and run.
+        """
+        # Create and add a basic example Task. When materialized and run,
+        # the Runnable will return the product of its args: 7 * 3 => 21.
+        example_task = tasks.Task(target=Runnable, args=(7, 3))
+        proc_pool.add(example_task, example_task.uid())
+        with proc_pool:
+            while proc_pool.pending_work():
+                assert proc_pool.is_alive
+                time.sleep(0.2)
+
+        # Check that the expected result is stored both on the worker and
+        # on the pool's result.
+        assert proc_pool.get(example_task.uid()).result == 21
+        assert proc_pool.results[example_task.uid()].result == 21
+
+    def test_add_main(self, proc_pool):
+        """
+        Test scheduling a Task from the __main__ module. This should not be
+        allowed, since __main__ is a different module for the child process.
+        """
+        main_task = tasks.Task(target='runnable', module='__main__')
+        with pytest.raises(ValueError):
+            proc_pool.add(main_task, main_task.uid())

--- a/testplan/common/serialization/fields.py
+++ b/testplan/common/serialization/fields.py
@@ -51,11 +51,17 @@ def native_or_pformat(value):
     elif callable(value):
         value = getattr(value, '__name__', _repr_obj(value))
 
-    result = value if isinstance(value, COMPATIBLE_TYPES) else pprint.pformat(value)
-    obj_repr = _repr_obj(result)
+    # For basic builtin types we return the value unchanged. All other types
+    # will be formatted as strings.
+    if type(value) in COMPATIBLE_TYPES:
+        result = value
+    else:
+        result = pprint.pformat(value)
 
+    obj_repr = _repr_obj(result)
     if len(obj_repr) > MAX_LENGTH:
         result = obj_repr[:MAX_LENGTH] + '[truncated]...'
+
     return result
 
 

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -394,7 +394,7 @@ class Pool(Executor):
         :type uid: ``str``
         """
         if not isinstance(task, Task):
-            raise ValueError('Task was expected, got {} instead.'.format(
+            raise TypeError('Task was expected, got {} instead.'.format(
                 type(task)))
         super(Pool, self).add(task, uid)
         self.unassigned.append(uid)
@@ -439,6 +439,8 @@ class Pool(Executor):
     def handle_request(self, request):
         """
         Handles a worker request. I.e TaskPull, TaskResults, Heartbeat etc.
+
+        TODO refactor me into sub-functions to handle each request type!
 
         :param request: Worker request.
         :type request: :py:class:`~testplan.runners.pools.communication.Message`

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -14,6 +14,7 @@ from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.common.config import ConfigOption
 from testplan.common.utils.process import kill_process
 from testplan.common.utils.match import match_regexps_in_file
+from testplan.runners.pools import tasks
 
 from .base import Pool, PoolConfig, Worker, WorkerConfig
 from .connection import TCPConnectionManager
@@ -197,3 +198,12 @@ class ProcessPool(Pool):
 
     CONFIG = ProcessPoolConfig
     CONN_MANAGER = TCPConnectionManager
+
+    def add(self, task, uid):
+        """
+        Before adding Tasks to a ProcessPool, check that the Task target does
+        not come from __main__.
+        """
+        if isinstance(task, tasks.Task) and task.module == '__main__':
+            raise ValueError('Cannot add Tasks from __main__ to ProcessPool')
+        super(ProcessPool, self).add(task, uid)

--- a/testplan/runners/pools/tasks/base.py
+++ b/testplan/runners/pools/tasks/base.py
@@ -103,6 +103,14 @@ class Task(object):
         """Task target kwargs."""
         return self._kwargs
 
+    @property
+    def module(self):
+        """Task target module."""
+        if callable(self._target):
+            return self._target.__module__
+        else:
+            return self._module
+
     def materialize(self, target=None):
         """
         Create the actual task target executable/runnable/callable object.


### PR DESCRIPTION
**Serialization fix for custom result types**

Fix so that only types that are known to be serializable
are returned as their native type for result serialization.
Types that inherit from these primitive types (e.g. int)
may not necessarily also be serializable, so replace an
isintance() check with an explicit equality check of type().

**Check if Task is being scheduled from the main module**

Tasks shouldn't be scheduled to ProcessPools from the special
__main__ module. __main__ will be a different module for Process
workers (the child.py module to be exact) and so target from the
original __main__ will not be found - or worse will be replaced
by an attribute from child.py.