### PR TITLE
Add timeout feature to testcases

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -1249,6 +1249,23 @@ Testcases in the same group will be executed concurrently.
                                   suites=[SampleTest()],
                                   thread_pool_size=2))
 
+.. _testcase_timeout:
+
+Testcase timeout
+----------------
+
+If testcases are susceptible to hanging, or not expected to be time consuming, you may want to spot this and abort those testcases early. You can achieve it by passing a "timeout" parameter to the testcase decorator, like:
+
+.. code-block:: python
+
+    @testcase(timeout=10*60)  # 10 minute timeout, given in seconds.
+    def test_hanging(self, env, result):
+        ...
+
+If the testcase times out it will raise a :py:class:`TimeoutException <testplan.common.utils.timing.TimeoutException>`, causing its status to be "ERROR". The timeout will be noted on the report in the same way as any other unhandled Exception. The timeout parameter can be combined with other testcase parameters (e.g. used with parametrized testcases) in the way you would expect - each individual parametrized testcase will be subject to a seperate timeout.
+
+Also keep in mind that testplan will take a little bit of effort to monitor execution time of testcases with ``timeout`` attribute, so it is better to allocate a little more seconds than you have estimated how long a testcase would need.
+
 .. _multitest_drivers:
 
 Drivers

--- a/test/functional/testplan/testing/multitest/test_multitest_parts.py
+++ b/test/functional/testplan/testing/multitest/test_multitest_parts.py
@@ -1,4 +1,3 @@
-import os
 
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 

--- a/test/functional/testplan/testing/multitest/test_timeout_on_testcases.py
+++ b/test/functional/testplan/testing/multitest/test_timeout_on_testcases.py
@@ -1,0 +1,193 @@
+import time
+
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+from testplan.testing.multitest.base import Categories
+
+from testplan import Testplan
+from testplan.runners.pools import ThreadPool
+from testplan.runners.pools.tasks import Task
+
+from testplan.common.utils.testing import (
+    check_report, log_propagation_disabled
+)
+from testplan.report.testing import (
+    Status, TestReport, TestGroupReport, TestCaseReport
+)
+from testplan.common.utils.logger import TESTPLAN_LOGGER
+
+
+@testsuite
+class Suite1(object):
+    """A test suite with basic testcases."""
+    @testcase(timeout=2)
+    def test_normal(self, env, result):
+        result.log('Testcase will finish execution in time')
+
+    @testcase(timeout=2)
+    def test_abnormal(self, env, result):
+        result.log('Testcase will definitely timeout')
+        time.sleep(5)
+
+
+@testsuite
+class Suite2(object):
+    """A test suite with parameterized testcases in different exec groups."""
+    @testcase(
+        parameters=(1, 2, 3),
+        execution_group='first',
+        timeout=5
+    )
+    def test_timeout_1(self, env, result, val):
+        result.log('Testcase will sleep for {} seconds'.format(val))
+        time.sleep(val)
+
+    @testcase(
+        parameters=(1, 2, 5),
+        execution_group='second',
+        timeout=3
+    )
+    def test_timeout_2(self, env, result, val):
+        result.log('Testcase will sleep for {} seconds'.format(val))
+        time.sleep(val)
+
+
+def get_mtest():
+    test = MultiTest(name='MTest',
+                     suites=[Suite1(), Suite2()],
+                     thread_pool_size=2)
+    return test
+
+
+def _create_testcase_report(name, status_override=None, entries=None):
+    report = TestCaseReport(name=name)
+    report.status_override = status_override
+    if entries:
+        report.entries = entries
+    return report
+
+
+def test_timeout_on_testcases():
+
+    plan = Testplan(name='plan', parse_cmdline=False)
+    pool = ThreadPool(name='MyPool', size=2)
+    plan.add_resource(pool)
+
+    task = Task(target=get_mtest())
+    plan.schedule(task, resource='MyPool')
+
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        plan.run()
+
+    expected_report = TestReport(
+        name='plan',
+        entries=[
+            TestGroupReport(
+                name='MTest',
+                category=Categories.MULTITEST,
+                entries=[
+                    TestGroupReport(
+                        name='Suite1',
+                        description='A test suite with basic testcases.',
+                        category=Categories.SUITE,
+                        entries=[
+                            TestCaseReport(
+                                name='test_normal',
+                                entries=[
+                                    {
+                                        'type': 'Log',
+                                        'message': 'Testcase will finish execution in time'
+                                    }
+                                ]
+                            ),
+                            _create_testcase_report(
+                                name='test_abnormal',
+                                status_override=Status.ERROR,
+                                entries=[
+                                    {
+                                        'type': 'Log',
+                                        'message': 'Testcase will definitely timeout'
+                                    }
+                                ]
+                            )
+                        ]
+                    ),
+                    TestGroupReport(
+                        name='Suite2',
+                        description='A test suite with parameterized testcases in different exec groups.',
+                        category=Categories.SUITE,
+                        entries=[
+                            TestGroupReport(
+                                name='test_timeout_1',
+                                category=Categories.PARAMETRIZATION,
+                                entries=[
+                                    TestCaseReport(
+                                        name='test_timeout_1__val_1',
+                                        entries=[
+                                            {
+                                                'type': 'Log',
+                                                'message': 'Testcase will sleep for 1 seconds'
+                                            }
+                                        ]
+                                    ),
+                                    TestCaseReport(
+                                        name='test_timeout_1__val_2',
+                                        entries=[
+                                            {
+                                                'type': 'Log',
+                                                'message': 'Testcase will sleep for 2 seconds'
+                                            }
+                                        ]
+                                    ),
+                                    TestCaseReport(
+                                        name='test_timeout_1__val_3',
+                                        entries=[
+                                            {
+                                                'type': 'Log',
+                                                'message': 'Testcase will sleep for 3 seconds'
+                                            }
+                                        ]
+                                    )
+                                ]
+                            ),
+                            TestGroupReport(
+                                name='test_timeout_2',
+                                category=Categories.PARAMETRIZATION,
+                                entries=[
+                                    TestCaseReport(
+                                        name='test_timeout_2__val_1',
+                                        entries=[
+                                            {
+                                                'type': 'Log',
+                                                'message': 'Testcase will sleep for 1 seconds'
+                                            }
+                                        ]
+                                    ),
+                                    TestCaseReport(
+                                        name='test_timeout_2__val_2',
+                                        entries=[
+                                            {
+                                                'type': 'Log',
+                                                'message': 'Testcase will sleep for 2 seconds'
+                                            }
+                                        ]
+                                    ),
+                                    _create_testcase_report(
+                                        name='test_timeout_2__val_5',
+                                        status_override=Status.ERROR,
+                                        entries=[
+                                            {
+                                                'type': 'Log',
+                                                'message': 'Testcase will sleep for 5 seconds'
+                                            }
+                                        ]
+                                    )
+                                ]
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+
+    check_report(expected_report, plan.report)

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -22,6 +22,7 @@ from testplan.common.utils.interface import (
 from testplan.common.utils.thread import interruptible_join
 from testplan.common.utils.validation import is_subclass
 from testplan.common.utils.logger import TESTPLAN_LOGGER
+from testplan.common.utils.timing import timeout as timeout_deco
 from testplan.common.utils import callable as callable_utils
 from testplan.report import TestGroupReport, TestCaseReport
 from testplan.report.testing import Status
@@ -548,7 +549,13 @@ class MultiTest(Test):
                 if pre_testcase and callable(pre_testcase):
                     _run_case_related(pre_testcase)
 
-                testcase(self.resources, case_result)
+                time_restriction = getattr(testcase, 'timeout', None)
+                if time_restriction:
+                    timeout_deco(
+                        time_restriction, 'Testcase timeout after {} seconds'
+                    )(testcase)(self.resources, case_result)
+                else:
+                    testcase(self.resources, case_result)
 
                 if post_testcase and callable(post_testcase):
                     _run_case_related(post_testcase)

--- a/testplan/testing/multitest/parametrization.py
+++ b/testplan/testing/multitest/parametrization.py
@@ -336,7 +336,8 @@ def generate_functions(
     num_passing,
     num_failing,
     key_combs_limit,
-    execution_group
+    execution_group,
+    timeout
 ):
     """
     Generate test cases using the given parameter context, use the name_func
@@ -382,6 +383,8 @@ def generate_functions(
     :param execution_group: Name of execution group in which the testcases
                             can be executed in parallel.
     :type execution_group: ``str``
+    :param timeout: Timeout in seconds to wait for testcase to be finished.
+    :type timeout: ``int``
     :return: List of functions that is testcase compliant
              (accepts ``self``, ``env``, ``result`` as arguments) and have
              unique names.
@@ -417,6 +420,7 @@ def generate_functions(
         func.summarize_num_failing = num_failing
         func.summarize_key_combs_limit = key_combs_limit
         func.execution_group = execution_group
+        func.timeout = timeout
 
     _ensure_unique_names(functions)
 

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -354,7 +354,8 @@ def _testcase_meta(
     num_passing=defaults.SUMMARY_NUM_PASSING,
     num_failing=defaults.SUMMARY_NUM_FAILING,
     key_combs_limit=defaults.SUMMARY_KEY_COMB_LIMIT,
-    execution_group=None
+    execution_group=None,
+    timeout=None
 ):
     """
     Wrapper function that allows us to call :py:func:`@testcase <testcase>`
@@ -382,7 +383,8 @@ def _testcase_meta(
                 num_passing=num_passing,
                 num_failing=num_failing,
                 key_combs_limit=key_combs_limit,
-                execution_group=execution_group
+                execution_group=execution_group,
+                timeout=timeout
             )
 
             # Register generated functions as test_cases
@@ -413,6 +415,7 @@ def _testcase_meta(
             function.summarize_num_failing = num_failing
             function.summarize_key_combs_limit = key_combs_limit
             function.execution_group = execution_group
+            function.timeout = timeout
             function.__tags_index__ = copy.deepcopy(tag_dict)
 
             return _testcase(function)


### PR DESCRIPTION
* Add a timeout option, specified in the testcase decorator, to guard
  against testcases taking a very long time to execute. If a single
  testcase times out it will fail with status of report set to ERROR.

* The timeout parameter can be combined with other testcase parameters
  (e.g. used with parametrized testcases) in the way you would expect:
  each individual parametrized testcase will be subject to a seperate
  timeout. Also can be combined with "execution group" attribute.

* Please note that testplan will take a little bit of effort to monitor
  execution time, so it is better to allocate a little more seconds
  than you have estimated how long a testcase would need.