### PR TITLE
Fixing install-testplan-ui:

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+recursive-include testplan/web_ui *.js
+recursive-include testplan/web_ui *.css
+recursive-include testplan/web_ui *.html
+recursive-include testplan/web_ui *.json

--- a/install-testplan-ui
+++ b/install-testplan-ui
@@ -11,10 +11,10 @@ import logging
 import sys
 import os
 
+from testplan import web_ui
+
 TESTPLAN_UI_DIR = os.path.join(
-    os.path.dirname(__file__),
-    'testplan',
-    'web_ui',
+    os.path.dirname(web_ui.__file__),
     'testing'
 )
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(name='Testplan',
   author_email='eti-testplan@morganstanley.com',
   url='https://github.com/Morgan-Stanley/testplan',
   packages=['testplan'] + find_packages(),
+  include_package_data=True,
   install_requires=REQUIRED,
   scripts=['install-testplan-ui']
  )


### PR DESCRIPTION
* The .js .css .html .json files needed for the UI will be installed when using
  pip install.
* The install-testplan-ui script finds the path to the UI code by importing
  testplan.