### PR TITLE
Parallelise tests and cache pip installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+cache: pip
+
 python:
   - "2.7"
   - "3.4"
@@ -10,5 +12,5 @@ install:
 
 script:
   - pylint --rcfile pylintrc testplan
-  - pytest tests --verbose
+  - pytest tests --verbose -n 8
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 -e .
 pylint
+pytest
+pytest-xdist
 


### PR DESCRIPTION
Use pytest-xdist to run the tests in parallel for speed.
Enable pip caching in Travis to reduce install time.