### PR TITLE
Fix serialization edge cases for Task results

### DIFF
--- a/testplan/common/serialization/fields.py
+++ b/testplan/common/serialization/fields.py
@@ -51,11 +51,17 @@ def native_or_pformat(value):
     elif callable(value):
         value = getattr(value, '__name__', _repr_obj(value))
 
-    result = value if isinstance(value, COMPATIBLE_TYPES) else pprint.pformat(value)
-    obj_repr = _repr_obj(result)
+    # For basic builtin types we return the value unchanged. All other types
+    # will be formatted as strings.
+    if type(value) in COMPATIBLE_TYPES:
+        result = value
+    else:
+        result = pprint.pformat(value)
 
+    obj_repr = _repr_obj(result)
     if len(obj_repr) > MAX_LENGTH:
         result = obj_repr[:MAX_LENGTH] + '[truncated]...'
+
     return result
 
 

--- a/testplan/common/serialization/fields.py
+++ b/testplan/common/serialization/fields.py
@@ -27,10 +27,17 @@ from testplan.common.utils import comparison
 # pylint: disable=unused-argument
 
 
-# JSON & pickle Serialization compatible types
-# types.NoneType is gone in python3
+# We explicitly enumerate types that are known to be safe to serialize by
+# pickle. All other types will be converted to strings before pickling.
+# types.NoneType is gone in python3 so we inspect the type of None directly.
 COMPATIBLE_TYPES = (
-    bool, float, type(None)) + six.string_types + six.integer_types
+    bool, float, type(None), str, bytes, int)
+
+# For Python 2 only, also consider unicode and long types to be pickle-safe.
+# These types are removed from Python 3.
+if six.PY2:
+    COMPATIBLE_TYPES += (unicode, long)  # pylint: disable=undefined-variable
+
 MAX_LENGTH = 1000  # this will be configurable
 
 

--- a/testplan/common/utils/thread.py
+++ b/testplan/common/utils/thread.py
@@ -45,9 +45,19 @@ def execute_as_thread(target, args=None, kwargs=None, daemon=False, join=True,
             time.sleep(join_sleep)
 
 
-def interruptible_join(thread):
+def interruptible_join(thread, timeout=10):
     """Joining a thread without ignoring signal interrupts."""
-    while True:
+    if timeout:
+        start_time = time.time()
+        end_time = start_time + timeout
+    else:
+        start_time = end_time = None
+
+    while timeout is None or time.time() < end_time:
         time.sleep(0.1)
         if not thread.is_alive():
-            break
+            return
+
+    raise TimeoutException('Thread {} did not terminate in {}s.'
+                           .format(thread, timeout))
+

--- a/testplan/runners/base.py
+++ b/testplan/runners/base.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 from testplan.common.entity import Resource, ResourceConfig
 from testplan.common.utils.thread import interruptible_join
+from testplan.common.utils import timing
 
 
 class ExecutorConfig(ResourceConfig):
@@ -86,7 +87,11 @@ class Executor(Resource):
     def stopping(self):
         """Stop the executor."""
         if self._loop_handler:
-            interruptible_join(self._loop_handler)
+            try:
+                interruptible_join(self._loop_handler, timeout=10)
+            except timing.TimeoutException:
+                self.abort()
+                raise
 
     def abort_dependencies(self):
         """Abort items running before aborting self."""

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -14,6 +14,7 @@ from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.common.config import ConfigOption
 from testplan.common.utils.process import kill_process
 from testplan.common.utils.match import match_regexps_in_file
+from testplan.runners.pools import tasks
 
 from .base import Pool, PoolConfig, Worker, WorkerConfig
 from .connection import TCPConnectionManager
@@ -197,3 +198,12 @@ class ProcessPool(Pool):
 
     CONFIG = ProcessPoolConfig
     CONN_MANAGER = TCPConnectionManager
+
+    def add(self, task, uid):
+        """
+        Before adding Tasks to a ProcessPool, check that the Task target does
+        not come from __main__.
+        """
+        if isinstance(task, tasks.Task) and task.module == '__main__':
+            raise ValueError('Cannot add Tasks from __main__ to ProcessPool')
+        super(ProcessPool, self).add(task, uid)

--- a/testplan/runners/pools/tasks/base.py
+++ b/testplan/runners/pools/tasks/base.py
@@ -103,6 +103,14 @@ class Task(object):
         """Task target kwargs."""
         return self._kwargs
 
+    @property
+    def module(self):
+        """Task target module."""
+        if callable(self._target):
+            return self._target.__module__
+        else:
+            return self._module
+
     def materialize(self, target=None):
         """
         Create the actual task target executable/runnable/callable object.

--- a/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -1,4 +1,4 @@
-"""TODO."""
+"""Base Testplan Tasks shared by different functional tests."""
 
 import os
 import psutil
@@ -11,7 +11,6 @@ from testplan.common.utils.path import fix_home_prefix
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 from testplan.testing.multitest.base import MultiTestConfig
 
-
 @testsuite
 class MySuite(object):
 
@@ -22,7 +21,6 @@ class MySuite(object):
         assert isinstance(env.cfg, MultiTestConfig)
         assert os.path.exists(env.runpath) is True
         assert env.runpath.endswith(env.cfg.name)
-
 
 def get_mtest(name):
     """TODO."""
@@ -97,7 +95,7 @@ def schedule_tests_to_pool(name, pool, schedule_path=None, **pool_cfg):
     assert res.success is True
     assert plan.report.passed is True
     assert plan.report.status == Status.PASSED
-    assert plan.report.counts.passed == 9
+    assert plan.report.counts.passed == 9  # 1 testcase * 9 iterations
     assert plan.report.counts.error == plan.report.counts.skipped == \
            plan.report.counts.failed == plan.report.counts.incomplete == 0
 

--- a/tests/functional/testplan/runners/pools/test_pool_process.py
+++ b/tests/functional/testplan/runners/pools/test_pool_process.py
@@ -1,18 +1,19 @@
-"""Process worker pool unit tests."""
+"""Process worker pool functional tests."""
 
 import os
 
+import pytest
+
 from testplan.common.utils.testing import log_propagation_disabled
-
-
 from testplan.report.testing import Status
 from testplan.runners.pools import ProcessPool
-
 from testplan import Testplan
-
 from testplan.common.utils.logger import TESTPLAN_LOGGER
+from testplan.testing import multitest
 
-from .func_pool_base_tasks import schedule_tests_to_pool
+from tests.functional.testplan.runners.pools.func_pool_base_tasks import (
+    schedule_tests_to_pool)
+from tests.unit.testplan.common.serialization import test_fields
 
 
 def test_pool_basic():
@@ -180,3 +181,68 @@ def test_custom_reschedule_condition():
     assert res.success is True
     assert pool.task_assign_cnt[uid] == max_reschedules
     assert plan.report.status == Status.PASSED
+
+
+def test_schedule_from_main():
+    """
+    Test scheduling Tasks from __main__ - it should not be allowed for
+    ProcessPool.
+    """
+    # Set up a testplan and add a ProcessPool.
+    plan = Testplan(name='ProcPlan', parse_cmdline=False)
+    pool = ProcessPool(name='ProcPool', size=2)
+    plan.add_resource(pool)
+
+    # First check that scheduling a Task with module string of '__main__'
+    # raises the expected ValueError.
+    with pytest.raises(ValueError):
+        plan.schedule(target='target',
+                      module='__main__',
+                      resource='ProcPool')
+
+
+    # Secondly, check that scheduling a callable target with a __module__ attr
+    # of __main__ also raises a ValueError.
+    def callable_target():
+        raise RuntimeError
+
+    callable_target.__module__ = '__main__'
+
+    with pytest.raises(ValueError):
+        plan.schedule(target=callable_target, resource='ProcPool')
+
+@multitest.testsuite
+class SerializationSuite(object):
+
+    @multitest.testcase
+    def test_serialize(self, env, result):
+        """Test serialization of test results."""
+        # As an edge case, store a deliberately "un-pickleable" type that
+        # inherits from int on the result. This should not cause an error
+        # since the value should be formatted as a string.
+        x = test_fields.UnPickleableInt(42)
+        result.equal(actual=x,
+                     expected=42,
+                     description='Compare unpickleable type')
+
+def make_serialization_mtest():
+    """
+    Callable target to make a MultiTest containing the SerializationSuite
+    defined above.
+    """
+    return multitest.MultiTest(name='SerializationMTest',
+                               suites=[SerializationSuite()])
+
+
+def test_serialization():
+    """Test serialization of test results."""
+    plan = Testplan(name='SerializationPlan', parse_cmdline=False)
+    pool = ProcessPool(name='ProcPool', size=2)
+    plan.add_resource(pool)
+    plan.schedule(target='make_serialization_mtest',
+                  module='test_pool_process',
+                  path=os.path.dirname(__file__))
+
+    res = plan.run()
+    assert res.success
+

--- a/tests/unit/testplan/common/serialization/test_fields.py
+++ b/tests/unit/testplan/common/serialization/test_fields.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for the testplan.common.serialization.fields module.
+"""
+import pytest
+
+from testplan.common.serialization import fields
+
+
+@pytest.fixture
+def native_or_pretty():
+    return fields.NativeOrPretty()
+
+
+class SerializeMe(object):
+    """Custom type that returns a string as its "serialization"."""
+
+    def __repr__(self):
+        return "I have been serialized!"
+
+
+class UnPickleableInt(int):
+    """A type that derives from int but cannot itself be serialized."""
+
+    def __getstate__(self):
+        raise NotImplementedError
+
+    def __repr__(self):
+        return "{}[{}]".format(
+            self.__class__.__name__, super(UnPickleableInt, self).__repr__())
+
+
+class SerializationTargets(object):
+    """
+    An object that contains some different values to be serialized for
+    testing.
+    """
+
+    def __init__(self):
+        self.x = 123
+        self.y = "foo"
+        self.z = None
+
+        self.serializable = SerializeMe()
+        self.unpickleable= UnPickleableInt(42)
+
+
+@pytest.fixture
+def targets():
+    return SerializationTargets()
+
+
+class TestNativeOrPretty(object):
+
+    def test_basic(self, native_or_pretty, targets):
+        """Test serialization of basic types: no change is required."""
+        for attr in ('x', 'y', 'z'):
+            serialized = native_or_pretty.serialize(attr, targets)
+            assert serialized == getattr(targets, attr)
+
+    def test_format(self, native_or_pretty, targets):
+        """Test serializing of a custom type."""
+        serialized = native_or_pretty.serialize('serializable', targets)
+        assert serialized == "I have been serialized!"
+
+    def test_derived_type(self, native_or_pretty, targets):
+        """
+        Test serializing of a type that inherits from a builtin, but is not
+        itself pickle-able. The correct behaviour is to return a formatted
+        string.
+        """
+        serialized = native_or_pretty.serialize('unpickleable', targets)
+        assert serialized == 'UnPickleableInt[42]'

--- a/tests/unit/testplan/runners/pools/test_process_worker.py
+++ b/tests/unit/testplan/runners/pools/test_process_worker.py
@@ -45,6 +45,15 @@ class TestProcPool(object):
         assert proc_pool.get(example_task.uid()).result == 21
         assert proc_pool.results[example_task.uid()].result == 21
 
+    def test_add_main(self, proc_pool):
+        """
+        Test scheduling a Task from the __main__ module. This should not be
+        allowed, since __main__ is a different module for the child process.
+        """
+        main_task = tasks.Task(target='runnable', module='__main__')
+        with pytest.raises(ValueError):
+            proc_pool.add(main_task, main_task.uid())
+
     def test_start_stop(self, proc_pool):
         """Test basic start/stop of ProcessPool."""
         current_proc = psutil.Process()


### PR DESCRIPTION
Fix serialisation of result types so that only the "safe" builtin types
such as int, str, NoneType etc. are directly pickled, all other objects
are converted to their string representation. In particular, types that
inherit from a "safe" builtin are no longer directly pickled - this was
causing problems with Boost.Python.enum type.

Also add a simple check to prevent scheduling of tasks from the
__main__ module for Process pool - this will always fail since __main__
is a completely different module for the child worker processes.