### PR TITLE
Webserver exporter improvements

### DIFF
--- a/testplan/exporters/testing/webserver/base.py
+++ b/testplan/exporters/testing/webserver/base.py
@@ -24,13 +24,11 @@ class WebServerExporterConfig(ExporterConfig):
     def get_options(cls):
         return {
             ConfigOption(
-                'ui_port', default=defaults.WEB_SERVER_PORT,
-                block_propagation=False): Or(None, int),
+                'ui_port', default=defaults.WEB_SERVER_PORT): int,
             ConfigOption(
                 'web_server_startup_timeout',
                 default=defaults.WEB_SERVER_TIMEOUT): int,
         }
-
 
 class WebServerExporter(Exporter):
 

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -42,7 +42,7 @@ def get_default_exporters(config):
     if config.xml_dir:
         result.append(test_exporters.XMLExporter())
     if config.ui_port is not None:
-        result.append(test_exporters.WebServerExporter())
+        result.append(test_exporters.WebServerExporter(ui_port=config.ui_port))
     return result
 
 

--- a/tests/functional/exporters/testing/dummy_programmatic_test_plan.py
+++ b/tests/functional/exporters/testing/dummy_programmatic_test_plan.py
@@ -3,7 +3,6 @@ import sys
 
 from testplan import test_plan
 from testplan.testing.multitest import MultiTest, testsuite, testcase
-from testplan import defaults
 from testplan.exporters.testing import WebServerExporter
 
 @testsuite
@@ -15,7 +14,7 @@ class Alpha(object):
 
 @test_plan(
     name='Multiply',
-    exporters=WebServerExporter(ui_port=defaults.WEB_SERVER_PORT)
+    exporters=WebServerExporter()
 )
 def main(plan):
     test = MultiTest(name='MultiplyTest',


### PR DESCRIPTION
For the webserver exporter:
- Add a timeout to prevent webserver test from blocking indefinitely due to unexpected stdout from the testplan subprocess
- Fixes a bug when adding the WebServerExporter programmatically, if no port is specified the default value (0) will be used.

(removed previous pool-related changes from this PR and updated title/description)