### PR TITLE
Use six.moves to import modules

### DIFF
--- a/doc/en/getting_started.rst
+++ b/doc/en/getting_started.rst
@@ -274,7 +274,7 @@ To install docker, you can follow the instructions for your OS from this list:
 
             sudo apt-get update
             sudo apt-get remove docker docker-engine docker.io
-            sudo  apt-get install apt-transport-https ca-certificates curl software-properties-common
+            sudo apt-get install apt-transport-https ca-certificates curl software-properties-common
             curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
             sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
             sudo apt-get update

--- a/examples/App/FXConverter/converter.py
+++ b/examples/App/FXConverter/converter.py
@@ -12,10 +12,8 @@ import re
 import sys
 import socket
 import logging
-try:
-    from ConfigParser import ConfigParser
-except ImportError:
-    from configparser import ConfigParser
+
+from six.moves.configparser import ConfigParser
 
 
 logging.basicConfig(stream=sys.stdout, format='%(message)s')

--- a/testplan/common/utils/sockets/fix/server.py
+++ b/testplan/common/utils/sockets/fix/server.py
@@ -4,7 +4,7 @@ import errno
 import socket
 import select
 import threading
-from six.moves import queue as Queue
+from six.moves import queue
 
 from testplan.common.utils.timing import (TimeoutException,
                                           TimeoutExceptionInfo,
@@ -351,7 +351,7 @@ class Server(object):
         """
         conndetails = self._conndetails_by_fd[fdesc]
         conndetails.name = conn_name
-        conndetails.queue = Queue.Queue()
+        conndetails.queue = queue.Queue()
         conndetails.in_seqno = 1
         conndetails.out_seqno = 1
         self._conndetails_by_name[conn_name] = conndetails
@@ -551,5 +551,5 @@ class Server(object):
         try:
             while True:
                 queue.get(False)
-        except Queue.Empty:
+        except queue.Empty:
             return

--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -8,14 +8,9 @@ import uuid
 import inspect
 import threading
 
-if six.PY2:
-    from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler  # pylint: disable=no-name-in-module,import-error
-    from SocketServer import ThreadingMixIn  # pylint: disable=no-name-in-module,import-error
-    from urlparse import urlparse  # pylint: disable=no-name-in-module,import-error
-else:
-    from http.server import HTTPServer, BaseHTTPRequestHandler  # pylint: disable=no-name-in-module,import-error
-    from socketserver import ThreadingMixIn  # pylint: disable=no-name-in-module,import-error
-    from urllib.parse import urlparse  # pylint: disable=no-name-in-module,import-error
+from six.moves.BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+from six.moves.socketserver import ThreadingMixIn
+from six.moves.urllib.parse import urlparse
 
 from testplan.common.utils.exceptions import format_trace
 from testplan.common.config import ConfigOption

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -1,17 +1,12 @@
 """Multitest main test execution framework."""
 
 import os
-import inspect
 import collections
 import functools
 import time
 
-try:
-    from Queue import Queue, Empty
-except ImportError:
-    from queue import Queue, Empty
-
-from threading import Thread, Lock
+from threading import Thread
+from six.moves import queue
 from schema import Use, Or, And
 
 from testplan.common.config import ConfigOption
@@ -590,7 +585,7 @@ class MultiTest(Test):
                 task = self._testcase_queue.get(
                     timeout=self.cfg.active_loop_sleep)
                 testcase, pre_testcase, post_testcase, testcase_report = task
-            except Empty:
+            except queue.Empty:
                 continue
 
             self._run_testcase(
@@ -617,7 +612,7 @@ class MultiTest(Test):
     def _start_thread_pool(self):
         """Start a thread pool for executing testcases in parallel."""
         if not self._testcase_queue:
-            self._testcase_queue = Queue()
+            self._testcase_queue = queue.Queue()
 
         self._thread_pool_size = min(self.cfg.thread_pool_size,
                                      self.cfg.max_thread_pool_size) \

--- a/testplan/testing/multitest/driver/fix/server.py
+++ b/testplan/testing/multitest/driver/fix/server.py
@@ -2,8 +2,7 @@
 
 import os
 
-from six.moves import queue as Queue
-
+from six.moves import queue
 from schema import Use
 
 from testplan.common.config import ConfigOption
@@ -150,7 +149,7 @@ class FixServer(Driver):
         timeout_info = TimeoutExceptionInfo()
         try:
             received = self._server.receive(conn_name, timeout=timeout or 0)
-        except Queue.Empty:
+        except queue.Empty:
             self.logger.debug(
                 'Timed out waiting for message for {} seconds'.format(
                     timeout or 0))

--- a/testplan/testing/multitest/driver/http/client.py
+++ b/testplan/testing/multitest/driver/http/client.py
@@ -1,15 +1,12 @@
 """HTTPClient Driver."""
 
-from schema import Use, Or
-from threading import Thread, Event
 import time
 import os
-try:
-  import Queue
-except ImportError:
-  import queue as Queue
+from threading import Thread, Event
 
 import requests
+from schema import Use, Or
+from six.moves import queue
 
 from testplan.common.config import ConfigOption as Optional
 from testplan.common.utils.context import expand, is_context
@@ -96,7 +93,7 @@ class HTTPClient(Driver):
         self.protocol = expand(self.cfg.protocol, self.context)
         self.timeout = self.cfg.timeout
         self.interval = self.cfg.interval
-        self.responses = Queue.Queue()
+        self.responses = queue.Queue()
         self.file_logger.debug(
             'Started HTTPClient sending requests to {}://{}{}'.format(
                 self.protocol,
@@ -280,7 +277,7 @@ class HTTPClient(Driver):
         while time.time() < timeout:
             try:
                 response = self.responses.get(False)
-            except Queue.Empty:
+            except queue.Empty:
                 self.file_logger.debug('Waiting for response...')
                 response = None
             else:
@@ -300,7 +297,7 @@ class HTTPClient(Driver):
         while not self.responses.empty() and time.time() < timeout:
             try:
                 self.responses.get(block=False)
-            except Queue.Empty:
+            except queue.Empty:
                 self.file_logger.debug('Responses queue flushed.')
             else:
                 self.responses.task_done()

--- a/testplan/testing/multitest/driver/http/server.py
+++ b/testplan/testing/multitest/driver/http/server.py
@@ -6,13 +6,8 @@ from threading import Thread
 
 from schema import Use
 
-try:
-  import BaseHTTPServer as http_server
-  import Queue as queue
-except ImportError:
-  from testplan.runnable.interactive import http as http_server
-  import queue
-
+import six.moves.BaseHTTPServer as http_server
+from six.moves import queue
 
 from testplan.common.config import ConfigOption as Optional
 from testplan.common.utils.strings import slugify

--- a/testplan/vendor/tempita/__init__.py
+++ b/testplan/vendor/tempita/__init__.py
@@ -30,16 +30,17 @@ from __future__ import absolute_import, division, print_function
 
 import re
 import sys
+import os
+import tokenize
+
 try:
-    from urllib.parse import quote as url_quote
     from io import StringIO
     from html import escape as html_escape
 except ImportError:
-    from urllib import quote as url_quote
     from cStringIO import StringIO
     from cgi import escape as html_escape
-import os
-import tokenize
+from six.moves.urllib.parse import quote as url_quote
+
 from ._looper import looper
 from .compat3 import (
     PY3, bytes, basestring_, next, is_unicode, coerce_text, iteritems)


### PR DESCRIPTION
* To avoid a lot of try... except... ImportError sentences.
  Better adopt py3 representation notation for module names.