### PR TITLE
Reduce test instabilities

### DIFF
--- a/testplan/testing/multitest/driver/base.py
+++ b/testplan/testing/multitest/driver/base.py
@@ -53,7 +53,7 @@ class DriverConfig(ResourceConfig):
             'name': str,
             ConfigOption('install_files', default=None):
                 Or(None, list),
-            ConfigOption('timeout', default=5): int,
+            ConfigOption('timeout', default=60): int,
             ConfigOption('logfile', default=None):
                 Or(None, str),
             ConfigOption('log_regexps', default=None):

--- a/tests/functional/testplan/runners/pools/test_pool_process.py
+++ b/tests/functional/testplan/runners/pools/test_pool_process.py
@@ -17,7 +17,7 @@ from testplan.common.utils.logger import TESTPLAN_LOGGER
 from .func_pool_base_tasks import schedule_tests_to_pool
 
 
-pytestmark = pytest.mark.skip(reason='Process Pool tests are unstable')
+pytestmark = pytest.mark.skipif(True, reason='Process Pool tests are unstable')
 
 
 def test_pool_basic():

--- a/tests/functional/testplan/runners/pools/test_pool_remote.py
+++ b/tests/functional/testplan/runners/pools/test_pool_remote.py
@@ -9,11 +9,12 @@ import subprocess
 
 import testplan
 from testplan.runners.pools import RemotePool
-from testplan.common.utils.path import module_abspath
 from testplan.common.utils.remote import copy_cmd
 from .func_pool_base_tasks import schedule_tests_to_pool
 
 IS_WIN = platform.system() == 'Windows'
+
+pytestmark = pytest.mark.skipif(True, reason='Remote Pool tests are unstable')
 
 
 def mock_ssh(host, command):


### PR DESCRIPTION
- Increase the default driver start timeout value to 60s (5s is way too short for some drivers)
- Skip remote pool tests as well as process pool as they suffer from the same instabilities

Note: for some reason pytest.mark.skip() doesn't always skip tests as expected whereas skipif(True, ...) does, so using that instead for now.