### PR TITLE
Logmatcher improvements

### DIFF
--- a/testplan/common/utils/match.py
+++ b/testplan/common/utils/match.py
@@ -3,6 +3,9 @@ Module of utility types and functions that perform matching.
 """
 import os
 import time
+import re
+
+import six
 
 from . import timing
 from . import logger
@@ -98,8 +101,9 @@ class LogMatcher(logger.Loggable):
         end of the file. If a match is found the line number is stored and the
         match is returned. If no match is found an Exception is raised.
 
-        :param regex: compiled regular expression (``re.compile``)
-        :type regex: ``re.Pattern``
+        :param regex: regex string or compiled regular expression
+            (``re.compile``)
+        :type regex: ``Union[str, re.Pattern]``
 
         :return: The regex match or raise an Exception if no match is found.
         :rtype: ``re.Match``
@@ -107,6 +111,11 @@ class LogMatcher(logger.Loggable):
         match = None
         start_time = time.time()
         end_time = start_time + timeout
+
+        # As a convenience, we create the compiled regex if a string was
+        # passed.
+        if not hasattr(regex, 'match'):
+            regex = re.compile(regex)
 
         with open(self.log_path, 'r') as log:
             log.seek(self.position)

--- a/testplan/common/utils/match.py
+++ b/testplan/common/utils/match.py
@@ -137,6 +137,6 @@ class LogMatcher(logger.Loggable):
             raise timing.TimeoutException(
                 'No matches found in {}s'.format(timeout))
         else:
-            self.logger.debug('Match found in %ds', time.time() - start_time)
+            self.logger.debug('Match found in %.2fs', time.time() - start_time)
         return match
 

--- a/tests/unit/testplan/common/utils/test_match.py
+++ b/tests/unit/testplan/common/utils/test_match.py
@@ -86,12 +86,11 @@ class TestLogMatcher(object):
         logfile and return the match without timing out.
         """
         matcher = LogMatcher(log_path=large_logfile)
-        regex = re.compile(r'^Match me\!$')
 
         # Check that the LogMatcher can find the last 'Match me!' line in a
         # reasonable length of time. 30s is quite a generous timeout, most
         # of the time it should complete in <5s.
-        match = matcher.match(regex=regex, timeout=30)
+        match = matcher.match(regex=r'^Match me!$', timeout=30)
 
         assert match is not None
         assert match.group(0) == 'Match me!'

--- a/tests/unit/testplan/common/utils/test_match.py
+++ b/tests/unit/testplan/common/utils/test_match.py
@@ -1,21 +1,42 @@
 import os
 import re
-from mock import mock_open, patch
+import itertools
+import tempfile
 
 import pytest
 
 from testplan.common.utils.match import LogMatcher
+from testplan.common.utils import timing
 
-MATCH_OPEN_LIB = 'testplan.common.utils.match.open'
-TMP_FILENAME = 'no_file.log'
-LOG_LINES = [
-    'fifth',
-    'fourth',
-    'third',
-    'second',
-    'first'
-]
-LOG_FILECONTENTS = '\n'.join(LOG_LINES)
+@pytest.yield_fixture(scope='module')
+def basic_logfile():
+    """Write a very small logfile for basic functional testing."""
+    log_lines = [
+        'first\n',
+        'second\n',
+        'third\n',
+        'fourth\n',
+        'fifth\n']
+
+    with tempfile.NamedTemporaryFile('w', delete=False) as logfile:
+        logfile.writelines(log_lines)
+        filepath = logfile.name
+
+    yield filepath
+    os.remove(filepath)
+
+
+@pytest.yield_fixture(scope='module')
+def large_logfile():
+    """Write a larger logfile for more realistic performance testing."""
+    with tempfile.NamedTemporaryFile('w', delete=False) as logfile:
+        # Write 10,000 lines of 'blah' followed by one line 'Match me!'.
+        logfile.writelines('blah\n' for _ in  range(int(1e5)))
+        logfile.write('Match me!\n')
+        filepath = logfile.name
+
+    yield filepath
+    os.remove(filepath)
 
 
 class TestLogMatcher(object):
@@ -23,48 +44,55 @@ class TestLogMatcher(object):
     Test the LogMatcher class.
     """
 
-    def test_match_found(self):
+    def test_match_found(self, basic_logfile):
         """Can the LogMatcher find the correct line in the log file."""
-        matcher = LogMatcher(log_path=TMP_FILENAME)
+        matcher = LogMatcher(log_path=basic_logfile)
         regex_exp = re.compile(r'second')
-        with patch(MATCH_OPEN_LIB,
-                   mock_open(read_data=LOG_FILECONTENTS),
-                   create=True):
-            match = matcher.match(regex=regex_exp)
+        match = matcher.match(regex=regex_exp)
 
         assert match is not None
+        assert match.group(0) == 'second'
 
-    def test_match_only_searches_after_position(self):
+    def test_match_only_searches_after_position(self, basic_logfile):
         """
         LogMatcher should only search the text after the position, therefore it
         shouldn't find any successful matches for strings that appear before
         position x.
         """
-        matcher = LogMatcher(log_path=TMP_FILENAME)
+        matcher = LogMatcher(log_path=basic_logfile)
         second_string = re.compile(r'second')
-        with patch(MATCH_OPEN_LIB,
-                   mock_open(read_data=LOG_FILECONTENTS),
-                   create=True):
-            match = matcher.match(regex=second_string)
+        match = matcher.match(regex=second_string)
 
         # It should find this string.
         assert match is not None
+        assert match.group(0) == 'second'
 
         # It shouldn't find this string as it has moved past this position.
         first_string = re.compile(r'first')
-        with patch(MATCH_OPEN_LIB,
-                   mock_open(read_data=LOG_FILECONTENTS),
-                   create=True):
-            with pytest.raises(ValueError):
-                matcher.match(regex=first_string, timeout=0.5)
+        with pytest.raises(timing.TimeoutException):
+            matcher.match(regex=first_string, timeout=0.5)
 
-    def test_match_not_found(self):
+    def test_match_not_found(self, basic_logfile):
         """Does the LogMatcher raise an exception when no match is found."""
-        matcher = LogMatcher(log_path=TMP_FILENAME)
+        matcher = LogMatcher(log_path=basic_logfile)
         regex_exp = re.compile(r'bob')
-        with patch(MATCH_OPEN_LIB,
-                   mock_open(read_data=LOG_FILECONTENTS),
-                   create=True):
-            with pytest.raises(ValueError):
-                matcher.match(regex=regex_exp, timeout=0.5)
+        with pytest.raises(timing.TimeoutException):
+            matcher.match(regex=regex_exp, timeout=0.5)
+
+    def test_match_large_file(self, large_logfile):
+        """
+        Test matching the last entry in a large logfile, as a more realistic
+        test. The LogMatcher should quickly iterate through lines in the
+        logfile and return the match without timing out.
+        """
+        matcher = LogMatcher(log_path=large_logfile)
+        regex = re.compile(r'^Match me\!$')
+
+        # Check that the LogMatcher can find the last 'Match me!' line in a
+        # reasonable length of time. 30s is quite a generous timeout, most
+        # of the time it should complete in <5s.
+        match = matcher.match(regex=regex, timeout=30)
+
+        assert match is not None
+        assert match.group(0) == 'Match me!'
 

--- a/tests/unit/testplan/common/utils/test_match.py
+++ b/tests/unit/testplan/common/utils/test_match.py
@@ -30,8 +30,8 @@ def basic_logfile():
 def large_logfile():
     """Write a larger logfile for more realistic performance testing."""
     with tempfile.NamedTemporaryFile('w', delete=False) as logfile:
-        # Write 10,000 lines of 'blah' followed by one line 'Match me!'.
-        logfile.writelines('blah\n' for _ in  range(int(1e5)))
+        # Write 1 million lines of 'blah' followed by one line 'Match me!'.
+        logfile.writelines('blah\n' for _ in  range(int(1e6)))
         logfile.write('Match me!\n')
         filepath = logfile.name
 
@@ -88,9 +88,9 @@ class TestLogMatcher(object):
         matcher = LogMatcher(log_path=large_logfile)
 
         # Check that the LogMatcher can find the last 'Match me!' line in a
-        # reasonable length of time. 30s is quite a generous timeout, most
-        # of the time it should complete in <5s.
-        match = matcher.match(regex=r'^Match me!$', timeout=30)
+        # reasonable length of time. 10s is a very generous timeout, most
+        # of the time it should complete in <1s.
+        match = matcher.match(regex=r'^Match me!$', timeout=10)
 
         assert match is not None
         assert match.group(0) == 'Match me!'


### PR DESCRIPTION
Improve performance of LogMatcher by only sleeping when there are no more lines to read - not when iterating through lines already there. Add test for matching a more realistically sized logfile (10k lines).

Making the above fix exposed a bug in the tests - the seek/tell methods do nothing for objects returned by mock_open! The test_match_only_searches_after_position() testcase was only passing because somehow it was actually timing out after 0.5s. Resolved by simplifying tests to read from real (temporary) logfiles, not by using mock_open.

Also includes a small change to the match() method to accept a regex string as an alternative to a compiled regex - it will compile the regex automatically.

Fixes https://github.com/Morgan-Stanley/testplan/issues/182