### PR TITLE
Open output JSON in text mode to avoid json.load errors

### DIFF
--- a/tests/functional/testplan/test_timeout.py
+++ b/tests/functional/testplan/test_timeout.py
@@ -23,7 +23,7 @@ def test_runner_timeout():
     current_proc = psutil.Process()
     start_procs = current_proc.children()
 
-    with tempfile.NamedTemporaryFile() as output_json:
+    with tempfile.NamedTemporaryFile(mode='r') as output_json:
         proc = subprocess.Popen(
             [sys.executable, testplan_script, '--json', output_json.name],
             stdout=subprocess.PIPE)
@@ -53,4 +53,3 @@ def test_runner_timeout():
 
     # Check that no extra child processes remain since before starting.
     assert current_proc.children() == start_procs
-


### PR DESCRIPTION
To fix test_timeout for Python 3.4, open the JSON file output
by testplan in text mode instead of the default binary mode.
This avoids an error with json.load() that does not support
binary input before Python 3.6.

Fixes https://github.com/Morgan-Stanley/testplan/issues/185