### PR TITLE
Stabilise the timeout test

### DIFF
--- a/tests/functional/testplan/test_timeout.py
+++ b/tests/functional/testplan/test_timeout.py
@@ -5,11 +5,14 @@ import psutil
 import subprocess
 import sys
 import tempfile
-import time
 import threading
 
 
-def timeout_cbk(proc):
+def _timeout_cbk(proc):
+    """
+    Callback function called if the testplan subprocess doesn't terminate in a
+    reasonable length of time.
+    """
     proc.kill()
     raise RuntimeError('Timeout popped.')
 
@@ -23,33 +26,39 @@ def test_runner_timeout():
     current_proc = psutil.Process()
     start_procs = current_proc.children()
 
-    with tempfile.NamedTemporaryFile(mode='r') as output_json:
+    _, output_json = tempfile.mkstemp(suffix='.json')
+
+    try:
         proc = subprocess.Popen(
-            [sys.executable, testplan_script, '--json', output_json.name],
-            stdout=subprocess.PIPE)
+            [sys.executable, testplan_script, '--json', output_json],
+            stdout=subprocess.PIPE,
+            universal_newlines=True)
 
         # Set our own timeout so that we don't wait forever if the testplan
         # script fails to timeout. 10 minutes ought to be long enough.
         # In Python 3 we could wait() with a timeout, but this is not
         # available in Python 2 so we need to roll our own timeout mechanism.
-        timer = threading.Timer(300, timeout_cbk, args=[proc])
+        timer = threading.Timer(300, _timeout_cbk, args=[proc])
         timer.start()
-        stdout_bytes, _ = proc.communicate()
+        stdout, _ = proc.communicate()
         timer.cancel()
 
-        stdout = stdout_bytes.decode('utf-8')
         rc = proc.returncode
 
-        report = json.load(output_json)
+        with open(output_json, 'r') as json_file:
+            report = json.load(json_file)
 
-    # Check that the testplan exited with an error status.
-    assert rc == 1
-    assert report['status'] == 'error'
+        # Check that the testplan exited with an error status.
+        assert rc == 1
+        assert report['status'] == 'error'
 
-    # Check that the timeout is logged to stdout.
-    assert re.match(r'^Timeout: Aborting execution after 5 seconds$',
-                    stdout,
-                    flags=re.MULTILINE)
+        # Check that the timeout is logged to stdout.
+        if not re.search(r'Timeout: Aborting execution after 5 seconds',
+                         stdout):
+            print(stdout)
+            raise RuntimeError('Timeout log not found in stdout')
 
-    # Check that no extra child processes remain since before starting.
-    assert current_proc.children() == start_procs
+        # Check that no extra child processes remain since before starting.
+        assert current_proc.children() == start_procs
+    finally:
+        os.remove(output_json)


### PR DESCRIPTION
Don't open the report json until after testplan subprocess has
terminated, open the stdout pipe in text mode with universal
newlines so that the same output is returned on Windows,
use re.search() instead of re.match() in case there are
extra stdout logs made before the timeout gets logged.