### PR TITLE
Use NamedTemporaryFile instead of mkstemp

### DIFF
--- a/tests/functional/testplan/test_timeout.py
+++ b/tests/functional/testplan/test_timeout.py
@@ -26,7 +26,7 @@ def test_runner_timeout():
     current_proc = psutil.Process()
     start_procs = current_proc.children()
 
-    _, output_json = tempfile.mkstemp(suffix='.json')
+    output_json = tempfile.NamedTemporaryFile(suffix='.json').name
 
     try:
         proc = subprocess.Popen(


### PR DESCRIPTION
Fix for Windows - mkstemp causes issues if the OS file handle
isn't explicitly closed. Use NamedTemporaryFile instead to
avoid this issue.