### PR TITLE
Mark remote pool tests as xfail

### DIFF
--- a/tests/functional/testplan/runners/pools/test_pool_remote.py
+++ b/tests/functional/testplan/runners/pools/test_pool_remote.py
@@ -14,7 +14,7 @@ from .func_pool_base_tasks import schedule_tests_to_pool
 
 IS_WIN = platform.system() == 'Windows'
 
-# pytestmark = pytest.mark.skipif(True, reason='Remote Pool tests are unstable')
+pytestmark = pytest.mark.xfail(reason='Remote Pool tests are unstable')
 
 
 def mock_ssh(host, command):


### PR DESCRIPTION
Remote pool tests are sometimes failing in master. Mark as xfail - they will still run, but won't block when they fail. Then we can debug why they are failing.