### PR TITLE
Fix test_pool_remote failure

### DIFF
--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -510,7 +510,7 @@ class RemoteWorker(ProcessWorker):
                '--testplan', self._testplan_import_path.remote]
 
         if os.environ.get(testplan.TESTPLAN_DEPENDENCIES_PATH):
-            cmd.extend(['--testplan-deps', self._remote_testplan_runpath])
+            cmd.extend(['--testplan-deps', self._remote_testplan_path])
 
         return self.cfg.ssh_cmd(self.ssh_cfg, ' '.join(cmd))
 

--- a/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -23,6 +23,7 @@ class MySuite(object):
         assert os.path.exists(env.runpath) is True
         assert env.runpath.endswith(env.cfg.name)
 
+
 def get_mtest(name):
     """TODO."""
     return MultiTest(name='MTest{}'.format(name), suites=[MySuite()])

--- a/tests/functional/testplan/runners/pools/test_pool_remote.py
+++ b/tests/functional/testplan/runners/pools/test_pool_remote.py
@@ -14,8 +14,6 @@ from .func_pool_base_tasks import schedule_tests_to_pool
 
 IS_WIN = platform.system() == 'Windows'
 
-# pytestmark = pytest.mark.xfail(reason='Remote Pool tests are unstable')
-
 
 def mock_ssh(host, command):
     """Avoid network connection."""


### PR DESCRIPTION
When we use oss repo internally, dependencies.py is copied to remote host, but due to a code defect child.py is looking for dependencies.py file in a wrong path.