### PR TITLE
Fix unnecessary testplan package copy in remote pool test

### DIFF
--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -35,6 +35,7 @@ def fix_home_prefix(path):
 
     return path
 
+
 def module_abspath(module):
     """Returns file path of a python module."""
     return fix_home_prefix(module.__file__)
@@ -43,6 +44,11 @@ def module_abspath(module):
 def pwd():
     """Working directory path."""
     return fix_home_prefix(os.getcwd())
+
+
+def workspace_root():
+    """Default workspace root is the current directory."""
+    return pwd()
 
 
 def default_runpath(entity):

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -328,8 +328,10 @@ class Pool(Executor):
         :param request: Worker request.
         :type request: :py:class:`~testplan.runners.pools.communication.Message`
         """
+
         sender_index = request.sender_metadata['index']
         worker = self._workers[sender_index]
+
         if not worker.active:
             self.logger.warning(
                 'Message {} - {} from inactive worker {}'.format(

--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -16,17 +16,18 @@ import testplan
 from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.common.config import ConfigOption
 from testplan.common.utils.path import (module_abspath,
-                                        pwd, makedirs, fix_home_prefix)
+                                        pwd, makedirs, fix_home_prefix,
+                                        workspace_root)
 from testplan.common.utils.strings import slugify
 from testplan.common.utils.remote import (
     ssh_cmd, copy_cmd, link_cmd, remote_filepath_exists)
 from testplan.common.utils import path as pathutils
 from testplan.common.utils.process import execute_cmd
 
-from .base import Pool, PoolConfig
-from .process import ProcessWorker, ProcessWorkerConfig
-from .connection import ZMQServer
-from .communication import Message
+from testplan.runners.pools.base import Pool, PoolConfig
+from testplan.runners.pools.process import ProcessWorker, ProcessWorkerConfig
+from testplan.runners.pools.connection import ZMQServer
+from testplan.runners.pools.communication import Message
 
 
 class WorkerSetupMetadata(object):
@@ -622,7 +623,7 @@ class RemotePoolConfig(PoolConfig):
                 lambda x: callable(x),
             ConfigOption('ssh_cmd', default=ssh_cmd):
                 lambda x: callable(x),
-            ConfigOption('workspace', default=pwd()): str,
+            ConfigOption('workspace', default=workspace_root()): str,
             ConfigOption('workspace_exclude', default=[]): Or(list, None),
             ConfigOption('remote_workspace', default=None): Or(str, None),
             ConfigOption('copy_workspace_check',


### PR DESCRIPTION
- It's not necessary to copy the testplan package in the test code - this is handled in the pool logic now
- Add a workspace_root util to be overridden internally