### PR TITLE
Write sys.path to file and read it in child

### DIFF
--- a/examples/ExecutionPools/Process/test_plan.py
+++ b/examples/ExecutionPools/Process/test_plan.py
@@ -55,7 +55,6 @@ def main(plan):
         # All Task arguments need to be serializable.
         task = Task(target='make_multitest',
                     module='tasks',
-                    path=os.path.dirname(os.path.abspath(__file__)),
                     kwargs={'index': idx})
         plan.schedule(task, resource='MyPool')
 

--- a/examples/ExecutionPools/Remote/test_plan.py
+++ b/examples/ExecutionPools/Remote/test_plan.py
@@ -122,7 +122,6 @@ def main(plan):
         # All Task arguments need to be serializable.
         task = Task(target='make_multitest',
                     module='tasks',
-                    path='.',
 
                     # We specify the full paths to files as they will be found
                     # on the remote host.

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -27,6 +27,7 @@ def parse_cmdline():
     parser.add_argument('--log-level', action="store", default=0, type=int)
     parser.add_argument('--remote-pool-type', action="store", default='thread')
     parser.add_argument('--remote-pool-size', action="store", default=1)
+    parser.add_argument('--sys-path-file', action='store')
 
     return parser.parse_args()
 
@@ -344,6 +345,19 @@ def child_logic(args):
         loop.worker_loop()
 
 
+def _parse_syspath_file(filename):
+    """
+    Read and parse the syspath file, which should contain each sys.path entry
+    on a separate line. Remove the file once we have read it.
+    """
+    with open(filename) as f:
+        new_syspath = f.read().split('\n')
+
+    os.remove(filename)
+
+    return new_syspath
+
+
 if __name__ == '__main__':
     """
     To start an external child process worker.
@@ -351,7 +365,9 @@ if __name__ == '__main__':
     ARGS = parse_cmdline()
     if ARGS.wd:
         os.chdir(ARGS.wd)
-        sys.path.insert(0, ARGS.wd)
+
+    if ARGS.sys_path_file:
+        sys.path = _parse_syspath_file(ARGS.sys_path_file)
 
     if ARGS.testplan:
         sys.path.append(ARGS.testplan)

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -8,6 +8,7 @@ import signal
 import subprocess
 from schema import Or
 import psutil
+import tempfile
 
 import testplan
 from testplan.common.utils.logger import TESTPLAN_LOGGER
@@ -70,12 +71,20 @@ class ProcessWorker(Worker):
                '--testplan', os.path.join(os.path.dirname(testplan.__file__),
                                           '..'),
                '--type', 'process_worker',
-               '--log-level', TESTPLAN_LOGGER.getEffectiveLevel()]
+               '--log-level', TESTPLAN_LOGGER.getEffectiveLevel(),
+               '--sys-path-file', self._write_syspath()]
         if os.environ.get(testplan.TESTPLAN_DEPENDENCIES_PATH):
             cmd.extend(
                 ['--testplan-deps', fix_home_prefix(
                     os.environ[testplan.TESTPLAN_DEPENDENCIES_PATH])])
         return cmd
+
+    def _write_syspath(self):
+        """Write out our current sys.path to a file and return the filename."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write('\n'.join(sys.path))
+            self.logger.debug('Written sys.path to file: %s', f.name)
+            return f.name
 
     def starting(self):
         """Start a child process worker."""


### PR DESCRIPTION
Fixes https://github.com/Morgan-Stanley/testplan/issues/199 for both process and remote worker pools. Supersedes https://github.com/Morgan-Stanley/testplan/pull/200