### PR TITLE
Upgrade axios to 0.19.0

### DIFF
--- a/testplan/web_ui/testing/package.json
+++ b/testplan/web_ui/testing/package.json
@@ -10,7 +10,7 @@
     "ag-grid-community": "19.0.0",
     "ag-grid-react": "19.0.0",
     "aphrodite": "2.2.3",
-    "axios": "0.18.0",
+    "axios": "0.19.0",
     "bootstrap": "4.3.1",
     "enzyme": "3.7.0",
     "enzyme-adapter-react-16": "1.6.0",


### PR DESCRIPTION
To avoid https://nvd.nist.gov/vuln/detail/CVE-2019-10742

(tested internally)