### PR TITLE
Add resource monitor that will export a JSON file includes:

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -699,7 +699,12 @@ class RunnableConfig(EntityConfig):
             ConfigOption('interactive_handler', default=RunnableIHandler):
                 object,
             ConfigOption('interactive_runner', default=RunnableIRunner):
-                object
+                object,
+            ConfigOption(
+                'resource_monitor',
+                default=False,
+                block_propagation=False
+            ): bool,
         }
 
 

--- a/testplan/common/utils/monitor/__init__.py
+++ b/testplan/common/utils/monitor/__init__.py
@@ -1,0 +1,295 @@
+"""Resource monitor utilities."""
+
+import os
+import uuid
+import time
+import json
+import socket
+import logging
+import threading
+from testplan.common.utils.logger import TESTPLAN_LOGGER
+from testplan.common.utils.path import makedirs
+from .collectors import get_collector
+
+
+class EventMonitor(object):
+    """
+    Event monitor will record event start and stop times(seconds)
+    """
+    def __init__(self, parent=None):
+        self.logger = TESTPLAN_LOGGER
+        self.parent = parent
+        self.hostname = socket.getfqdn()
+        self.events_metadata = {}
+        self.events_data = {}
+        self.lock = threading.Lock()
+        self.log_directory = None
+        self.uid = str(uuid.uuid4())
+        self.thread_name = threading.current_thread().name
+        self.pid = os.getpid()
+        self.ppid = os.getppid()
+
+    def attach(self, event_monitor):
+        """
+        Merge the record event in two EventMonitor
+
+        :param event_monitor:  The EventMonitor will be merged.
+        :type event_monitor: ``EventMonitor``
+        :return:
+        """
+        self.events_metadata.update(event_monitor.events_metadata)
+        self.events_data.update(event_monitor.events_data)
+
+    def setup_logger(self, log_path=None):
+        """
+        Sets up a unique logger for Monitor each time it is called. Should only be called once or logs will be directed
+        to new logger on subsequent call.
+
+        :param log_path: Absolute path to file to save logs to.
+        :type log_path: ``str``
+
+        :return: ``None``
+        :rtype: ``NoneType``
+        """
+        self.logger = logging.getLogger(str(uuid.uuid4()))
+        if log_path:
+            directory = log_path.rsplit(os.sep, 1)[0]
+            self.log_directory = directory
+            makedirs(directory)
+            file_handler = logging.FileHandler(filename=log_path)
+        else:
+            file_handler = logging.NullHandler()  # pylint: disable=bad-option-value
+        formatter = logging.Formatter('%(asctime)s-Monitor-%(levelname)-8s:  %(message)s')
+        file_handler.setFormatter(formatter)
+        file_handler.setLevel(TESTPLAN_LOGGER.level)
+        self.logger.setLevel(TESTPLAN_LOGGER.level)
+        self.logger.addHandler(file_handler)
+
+    def _record_event(self, event_uuid, event):
+        if event_uuid not in self.events_data:
+            self.events_data[event_uuid] = []
+        self.events_data[event_uuid].append({
+            'event': event,
+            'time': time.time(),
+        })
+
+    def event_started(self, event_type, metadata=None):
+        """
+        Record event started.
+
+        :param event_type: The type of event. ('Pool', 'Multitest' etc.)
+        :type event_type: ``str``
+        :param metadata: The properties of the event. ('name', 'pass' etc.)
+        :type metadata: ``dict``
+
+        :return: Event unique id
+        :rtype: ``str``
+        """
+        event_uuid = str(uuid.uuid4())
+        with self.lock:
+            if not metadata:
+                _metadata = {}
+            elif isinstance(metadata, dict):
+                _metadata = metadata.copy()
+            else:
+                raise TypeError('Event metadata must be a dictionary - not {}'.format(type(metadata)))
+            _metadata['type'] = event_type
+            self.events_metadata[event_uuid] = _metadata
+            self._record_event(event_uuid, 'start')
+        return event_uuid
+
+    def event_stopped(self, event_uuid, metadata=None):
+        """
+        Record event stopped.
+
+        :param event_uuid: Event unique id
+        :type event_uuid: ``str``
+        :param metadata: The properties of the event want to be updated.
+
+        :return: ``None``
+        :rtype: ``NoneType``
+        """
+        with self.lock:
+            if metadata:
+                self.events_metadata[event_uuid].update(metadata)
+            self._record_event(event_uuid, 'stop')
+
+    def to_dict(self):
+        """
+        Convert the internal data to a dictionary.
+
+        :return: dict of internal data
+        :rtype: ``dict``
+        """
+        return {
+            'events_metadata': self.events_metadata,
+            'events_data': self.events_data,
+            'hostname': self.hostname,
+            'parent': self.pid,
+            'thread_name': self.thread_name,
+            'ppid': self.ppid,
+            'pid': self.pid
+        }
+
+    def dump_data(self):
+        _result = {
+            'events_metadata': self.events_metadata,
+            'events_data': [x for x in self.events_data.items()]
+        }
+        _result['events_data'].sort(key=lambda x: x[1][0]['time'])
+        _result['start_time'] = min([x[1][0]['time'] for x in _result['events_data']]) \
+            if _result['events_data'] else 0
+        _result['stop_time'] = max([x[1][-1]['time'] for x in _result['events_data']]) \
+            if _result['events_data'] else 0
+        return _result
+
+    def dumps(self):
+        """
+        Dump the internal data as a JSON string
+
+        :return: JSON string of internal data
+        :rtype: ``str``
+        """
+        return json.dumps(self.to_dict())
+
+    def save(self, scratch_path):
+        """
+        Save the internal data as a JSON string in file_path. Will append an integer to filename
+        ensuring it always writes to a new file
+
+        :param scratch_path: file path to save internal data to
+        :type scratch_path: ``str``
+
+        :return: ``None``
+        :rtype: ``NoneType``
+        """
+        directory = os.path.join(scratch_path, 'monitor')
+        file_name = 'monitor-{}-{}.data'.format(self.hostname, self.uid)
+        full_path = os.path.join(directory, file_name)
+        if not os.path.exists(directory):
+            TESTPLAN_LOGGER.info('Creating directory %s', directory)
+            makedirs(directory)
+        with open(full_path, 'w') as monitor_file:
+            monitor_file.write(self.dumps())
+        TESTPLAN_LOGGER.debug('Monitor data saved to {}'.format(full_path))
+
+    def load(self, serial_json):
+        """
+        Load data from a JSON string or a dict.
+
+        :param serial_json: The json type of event monitor
+        :type serial_json: ``str`` or ``dict``
+
+        :return: ``None``
+        :rtype: ``NoneType``
+        """
+        if isinstance(serial_json, str):
+            _serial_json = json.loads(serial_json)
+        else:
+            _serial_json = serial_json
+        for name, value in _serial_json.items():
+            setattr(self, name, value)
+        TESTPLAN_LOGGER.info('Internal data loaded, previous internal data overwritten.')
+
+    def to_event_monitor(self):
+        return self
+
+
+class ResourceMonitor(EventMonitor):
+    """
+    Resource Monitor will collect the host hardware information(CPU, memory, disk etc.)
+    and the metrics(the usage of CPU, memory and disk).
+
+    """
+
+    def __init__(self, directory=None, parent=None, collector=None):
+        super(ResourceMonitor, self).__init__(parent=parent)
+        self._collector = collector or get_collector(directory)
+        self._poll = None
+        self._poll_event = threading.Event()
+        self._poll_start = False
+        self.poll_interval = 2
+        self.host_metadata = self._collector.metadata
+        self.monitor_metrics = {
+            'cpu': [],
+            'memory': [],
+            'disk': [],
+            'iops': [],
+            'read': [],
+            'write': [],
+            'time': []
+        }
+
+    def _monitoring(self):
+        while self._poll_start:
+            _now = time.time()
+            _metrics = self._collector.monitor()
+            _metrics['time'] = _now
+            for key in self.monitor_metrics.keys():
+                self.monitor_metrics[key].append(_metrics[key])
+
+            _sleep_time = self.poll_interval - (time.time() - _now)
+            if _sleep_time > 0:
+                time.sleep(_sleep_time)
+
+    def start(self):
+        """
+        Start the thread of collect the metrics.
+
+        :return: ``None``
+        :rtype: ``NoneType``
+        """
+        self._poll = threading.Thread(target=self._monitoring)
+        self._poll.daemon = True
+        self._poll_start = True
+        self._poll.start()
+        TESTPLAN_LOGGER.info('Resource polling started.')
+
+    def stop(self):
+        """
+        Stop collect metrics.
+
+        :return: ``None``
+        :rtype: ``NoneType``
+        """
+        if self._poll:
+            self._poll_start = False
+            TESTPLAN_LOGGER.info('Resource polling stopped.')
+
+    def to_dict(self):
+        _result = super(ResourceMonitor, self).to_dict()
+        _result['host_metadata'] = self.host_metadata
+        _result['monitor_metrics'] = self.monitor_metrics
+        return _result
+
+    def to_event_monitor(self):
+        _event_monitor = EventMonitor()
+        _event_monitor.hostname = self.hostname
+        _event_monitor.pid = self.pid
+        _event_monitor.ppid = self.ppid
+        _event_monitor.thread_name = self.thread_name
+        _event_monitor.events_metadata = self.events_metadata
+        _event_monitor.events_data = self.events_data
+        return _event_monitor
+
+
+def load_monitor_from_json(serial_json):
+    """
+    Convert JSON string to EventMonitor/ResourceMonitor object
+
+    :param serial_json:
+    :type serial_json: ``str`` or ``dict``
+
+    :return: the instance of EventMonitor/ResourceMonitor
+    :rtype: ``EventMonitor`` or ``ResourceMonitor``
+    """
+    if isinstance(serial_json, str):
+        _serial_json = json.loads(serial_json)
+    else:
+        _serial_json = serial_json
+    if 'host_metadata' in _serial_json:
+        event_monitor = ResourceMonitor()
+    else:
+        event_monitor = EventMonitor()
+    event_monitor.load(_serial_json)
+    return event_monitor

--- a/testplan/common/utils/monitor/collectors.py
+++ b/testplan/common/utils/monitor/collectors.py
@@ -1,0 +1,141 @@
+"""Collect system information"""
+
+import os
+import time
+import platform
+import subprocess
+import multiprocessing
+import psutil
+from testplan.common.utils.path import pwd
+
+
+class Collector(object):
+    def __init__(self, director):
+        self.metadata = {
+            'num_cpu': multiprocessing.cpu_count(),
+            'memory': psutil.virtual_memory().total,
+            'disk_total': psutil.disk_usage(director).total,
+            'disk_director': director,
+            'system': platform.platform(),
+            'extra': {},
+        }
+        self._pid = os.getpid()
+
+        # save last io counter per process
+        self._io_counter = {}
+
+    def monitor(self):
+        parent = psutil.Process(self._pid)
+        procs = parent.children(recursive=True)
+        procs.append(parent)
+        monitor_result = {
+            'cpu': 0,
+            'memory': 0,
+            'disk': psutil.disk_usage(self.metadata['disk_director']).percent,
+            'iops': 0,
+            'read': 0,
+            'write': 0,
+        }
+        for proc in procs:
+            try:
+                raw_data = proc.as_dict(
+                    attrs=[
+                        'pid',
+                        'name',
+                        'memory_info',
+                        'cpu_percent',
+                        'io_counters',
+                        'create_time',
+                        'io_counters'
+                    ])
+
+            except psutil.NoSuchProcess:
+                continue
+            monitor_result['cpu'] += raw_data['cpu_percent'] \
+                if raw_data['cpu_percent'] > 0 else 0
+            monitor_result['memory'] += raw_data['memory_info'].rss
+            try:
+                counters = {
+                    'io_counter': raw_data['io_counters'].read_count +
+                                  raw_data['io_counters'].write_count,
+                    'read_counter': raw_data['io_counters'].read_bytes,
+                    'write_counter': raw_data['io_counters'].write_bytes,
+                    'time': time.time()
+                }
+                iops = read = write = 0
+                if raw_data['pid'] in self._io_counter \
+                        and self._io_counter[raw_data['pid']]['io_counter'] >= \
+                        counters['io_counter']:
+                    _io_counter = self._io_counter[raw_data['pid']]
+                    _interval = counters['time'] - _io_counter['time']
+                    iops = (counters['io_counter'] -
+                            _io_counter['io_counter']) / _interval
+                    read = (counters['read_counter'] -
+                            _io_counter['read_counter']) / _interval
+                    write = (counters['write_counter'] -
+                             _io_counter['write_counter']) / _interval
+                else:
+                    _interval = counters['time'] - raw_data['create_time']
+                    if _interval >= 1.0:
+                        iops = counters['io_counter'] / _interval
+                        read = counters['read_counter'] / _interval
+                        write = counters['write_counter'] / _interval
+                self._io_counter[raw_data['pid']] = counters.copy()
+                monitor_result['iops'] += iops
+                monitor_result['read'] += read
+                monitor_result['write'] += write
+            except (AttributeError, KeyError):
+                # process exited or no io counters
+                pass
+        return monitor_result
+
+
+class LinuxCollector(Collector):
+    def __init__(self, director):
+        super(LinuxCollector, self).__init__(director)
+        try:
+            cpu_info = subprocess.check_output(['lscpu'])
+            self.metadata['extra']['cpu_info'] = cpu_info.decode()
+        except OSError:
+            pass
+
+
+class LinuxContainerCollector(LinuxCollector):
+    def __init__(self, director):
+        super(LinuxContainerCollector, self).__init__(director)
+        with open('/proc/1/cgroup') as cgroup_file:
+            for cgroup in cgroup_file:
+                try:
+                    if ':memory:' in cgroup:
+                        path = os.path.join(
+                            '/sys/fs/cgroup/memory/',
+                            cgroup.split(':')[-1][1:],
+                            'memory.limit_in_bytes')
+                        with open(path, 'r') as memory_file:
+                            self.metadata['memory'] = int(memory_file.read())
+                except (IOError, AttributeError, ValueError):
+                    pass
+
+
+class WindowsCollector(Collector):
+    def __init__(self, director):
+        super(WindowsCollector, self).__init__(director)
+
+
+def get_collector(director=None):
+    if director is None:
+        director = pwd()
+    if platform.system() == 'Windows':
+        return WindowsCollector(director)
+    elif platform.system() == 'Linux':
+        try:
+            with open('/proc/1/cgroup') as cgroup_file:
+                for cgroup in cgroup_file:
+                    pid, name, group = cgroup.split(':')
+                    if group.strip() != '/':
+                        return LinuxContainerCollector(director)
+        except (IOError, ValueError):
+            pass
+        return LinuxCollector(director)
+    else:
+        raise RuntimeError('Unsupported system {}'.format(platform.system()))

--- a/testplan/exporters/testing/__init__.py
+++ b/testplan/exporters/testing/__init__.py
@@ -2,4 +2,5 @@ from .pdf import PDFExporter, TagFilteredPDFExporter
 from .xml import XMLExporter
 from .json import JSONExporter
 from .webserver import WebServerExporter
+from .monitor import MonitorExporter
 from .base import Exporter, save_attachments

--- a/testplan/exporters/testing/monitor/__init__.py
+++ b/testplan/exporters/testing/monitor/__init__.py
@@ -1,0 +1,158 @@
+import os
+import json
+from testplan import defaults
+from testplan.common.config import ConfigOption
+from testplan.common.exporters import ExporterConfig
+from testplan.common.utils.monitor import load_monitor_from_json, ResourceMonitor
+from testplan.common.utils.logger import TESTPLAN_LOGGER
+
+from ..base import Exporter
+
+
+class MonitorExporterConfig(ExporterConfig):
+    @classmethod
+    def get_options(cls):
+        return {
+            ConfigOption(
+                'report_dir', default=defaults.REPORT_DIR,
+                block_propagation=False): str,
+            ConfigOption('runpath'): str,
+        }
+
+
+class MonitorExporter(Exporter):
+    CONFIG = MonitorExporterConfig
+
+    def export(self, source):
+        """
+        Read monitor data from each of scratch/monitor/monitor-hostname-uuid.data. Combine the data to
+        [
+            {
+                hostname: hostname1: str
+                process: [
+                    {
+                        pid: pid1,
+                        start_time; start_time,
+                        stop_time; stop_time,
+                        data:  [{
+                            thread: thread1:
+                            start_time; start_time,
+                            stop_time; stop_time,
+                            events_data: [
+                                [uid1, [{event: start, time: 1234567}, {event: stop, time: 12345678}]],
+                                [uid2, [{event: start, time: 1234568}, {event: stop, time: 12345678}]],
+                                ...
+                            ],
+                            events_metadata: {
+                                uid1:  {
+                                    name: 'multitest1',
+                                    passed: true,
+                                    type: 'Multitest'
+                                }
+                            }
+                        }, ...]
+                    },
+                    [pid2: str, start_time stop_time, ...],
+                    ...
+                ],
+                start_time: 1234567,
+                stop_time: 12345678,
+                host_metadata: {},
+                monitor_metrics: {}
+            }
+            hostname2: {
+                ...
+            }
+        ]
+        and order by start time.
+
+        :param source: Exporter instance
+        :type source: ``Exporter``
+
+        :return: ``None``
+        :rtype: ``NoneType``
+        """
+        run_path = self.cfg.runpath
+        monitor = {}
+        path = os.path.join('scratch', 'monitor')
+        for dir_path, dir_name, file_names in os.walk(run_path):
+            if dir_path.endswith(path) and not dir_name:
+                for file_name in file_names:
+                    if not file_name.endswith('data'):
+                        continue
+                    with open(os.path.join(dir_path, file_name)) as event_file:
+                        try:
+                            serial_json = json.load(event_file)
+                            event = load_monitor_from_json(serial_json)
+                        except ValueError:
+                            # ignore empty file
+                            continue
+                    if event.hostname not in monitor:
+                        monitor[event.hostname] = {
+                            'process': {}
+                        }
+                    if isinstance(event, ResourceMonitor):
+                        monitor[event.hostname]['host_metadata'] = event.host_metadata
+                        monitor[event.hostname]['monitor_metrics'] = event.monitor_metrics
+                    if event.pid not in monitor[event.hostname]['process']:
+                        monitor[event.hostname]['process'][event.pid] = {}
+                    if event.thread_name not in monitor[event.hostname]['process'][event.pid]:
+                        monitor[event.hostname]['process'][event.pid][event.thread_name] = event.to_event_monitor()
+                    else:
+                        monitor[event.hostname]['process'][event.pid][event.thread_name].attach(
+                            event.to_event_monitor()
+                        )
+
+        report = []
+        for hostname, host_data in monitor.items():
+            monitor_host = {
+                'hostname': hostname,
+                'host_metadata': host_data.get('host_metadata', {}),
+                'monitor_metrics': host_data.get('monitor_metrics', {})
+            }
+            processes = []
+            for pid, process_data in host_data['process'].items():
+                monitor_process = []
+                for thread_name, event_monitor in process_data.items():
+                    event_data = event_monitor.dump_data()
+                    if event_data['start_time']:
+                        monitor_process.append({
+                            'thread': thread_name,
+                            'start_time': event_data['start_time'],
+                            'stop_time': event_data['stop_time'],
+                            'data': event_data
+                        })
+                if monitor_process:
+                    monitor_process.sort(key=lambda x: x['start_time'])
+                    stop_time = max(monitor_process, key=lambda x: x['stop_time'])['stop_time']
+                    processes.append({
+                        'pid': pid,
+                        'start_time': monitor_process[0]['start_time'],
+                        'stop_time': stop_time,
+                        'data': monitor_process
+                    })
+            if processes:
+                processes.sort(key=lambda x: x['start_time'])
+            monitor_host['process'] = processes
+            monitor_host['start_time'] = processes[0]['start_time']
+            monitor_host['stop_time'] = max(processes, key=lambda x: x['stop_time'])['stop_time']
+            if monitor_host['monitor_metrics'].get('time', []):
+                monitor_host['start_time'] = min(monitor_host['start_time'], monitor_host['monitor_metrics']['time'][0])
+                monitor_host['stop_time'] = max(monitor_host['stop_time'], monitor_host['monitor_metrics']['time'][-1])
+            report.append(monitor_host)
+        report.sort(key=lambda x: x['start_time'])
+        start_time = min(report, key=lambda x: x['start_time'])['start_time']
+        stop_time = max(report, key=lambda x: x['stop_time'])['stop_time']
+
+        file_path = os.path.join(self.cfg.report_dir, 'monitor.json')
+        with open(file_path, 'w') as monitor_report:
+            json.dump({
+                'name': source.name,
+                'passed': source.counts.passed,
+                'failed': source.counts.failed,
+                'start_time': start_time,
+                'stop_time': stop_time,
+                'data': report,
+            }, monitor_report)
+        TESTPLAN_LOGGER.exporter_info(
+                'Resource monitor generated at {}'.format(file_path))

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -225,6 +225,16 @@ class TestplanParser(object):
             help='Specify log level for file logs. Set to NONE to disable file '
                  'logging.')
 
+        report_group.add_argument(
+            '-r', '--resource-monitor',
+            action='store_true',
+            dest='resource_monitor',
+            help=os.linesep.join([
+                'Enable resource monitor that will record hosts resource',
+                'statistics and event start/stop times'
+            ])
+        )
+
         self.add_arguments(parser)
         return parser
 

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -75,6 +75,8 @@ class ProcessWorker(Worker):
             cmd.extend(
                 ['--testplan-deps', fix_home_prefix(
                     os.environ[testplan.TESTPLAN_DEPENDENCIES_PATH])])
+        if self.cfg.resource_monitor:
+            cmd.extend(['--resource-monitor', ])
         return cmd
 
     def starting(self):

--- a/tests/functional/testplan/testing/test_resource_monitor.py
+++ b/tests/functional/testplan/testing/test_resource_monitor.py
@@ -1,0 +1,150 @@
+import os
+import sys
+import mock
+import time
+import json
+import socket
+from collections import namedtuple
+
+from testplan import Testplan
+from testplan.common.utils.logger import TESTPLAN_LOGGER
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+
+from testplan.common.utils.monitor import EventMonitor, ResourceMonitor, load_monitor_from_json
+from testplan.common.utils.testing import log_propagation_disabled
+
+
+class MockData:
+    cpu_count = 17
+    hostname = 'test_host_name'
+    getfqdn = 'test_host_name.example.com'
+    time = 19
+
+    @staticmethod
+    def virtual_memory():
+        virt_mem = namedtuple(
+            'svmem', ['total', 'available', 'percent', 'used', 'free', 'active',
+                      'inactive', 'buffers', 'cached', 'shared'])
+        return virt_mem(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+    @staticmethod
+    def disk_usage(path=None):
+        disk_used = namedtuple(
+            'sdiskusage', ['total', 'used', 'free', 'percent'])
+        return disk_used(201, 202, 203, 204)
+
+    @staticmethod
+    def memory_info():
+        mem_info = namedtuple(
+            'pmem', ['rss', 'vms', 'shared', 'text', 'lib', 'data', 'dirty'])
+        return mem_info(100, 101, 102, 103, 104, 105, 106)
+
+    @staticmethod
+    def cpu_percent(interval=0.1):
+        return 16
+
+    @staticmethod
+    def as_dict(attrs=[]):
+        return {
+            'cmdline': ['fake', 'cmd'],
+            'memory_info': MockData.memory_info(),
+            'pid': 107,
+            'name': 'mock_python',
+            'cpu_percent': MockData.cpu_percent()
+        }
+
+    @staticmethod
+    def children(recursive=False):
+        return []
+
+
+@mock.patch('time.time', return_value=MockData.time)
+@mock.patch('socket.getfqdn', return_value=MockData.getfqdn)
+def test_event_started(*args):
+    event_monitor = EventMonitor()
+    entity_uid = event_monitor.event_started('mock_event')
+    event_monitor.event_stopped(event_uuid=entity_uid)
+    assert event_monitor.hostname == MockData.getfqdn
+    assert event_monitor.events_data[entity_uid][0]['time'] == MockData.time
+    assert event_monitor.events_data[entity_uid][1]['time'] == MockData.time
+
+
+@mock.patch('multiprocessing.cpu_count', return_value=MockData.cpu_count)
+def test_host_metadata(*args):
+    resource_monitor = ResourceMonitor()
+    resource_monitor.start()
+    assert resource_monitor.host_metadata['num_cpu'] == MockData.cpu_count
+    resource_monitor.stop()
+
+
+@mock.patch('psutil.virtual_memory', side_effect=MockData.virtual_memory)
+@mock.patch('psutil.disk_usage', side_effect=MockData.disk_usage)
+@mock.patch('psutil.Process.as_dict', side_effect=MockData.as_dict)
+@mock.patch('psutil.Process.children', side_effect=MockData.children)
+@mock.patch('multiprocessing.cpu_count', return_value=MockData.cpu_count)
+def test_resource_polling(*args):
+    poll_interval = 1
+    timeout = 5
+    resource_monitor = ResourceMonitor()
+    resource_monitor.poll_interval = poll_interval
+    resource_monitor.start()
+    time.sleep(timeout)
+    resource_monitor.stop()
+
+    mock_memory = MockData.memory_info()
+    mock_resource_data = {
+        'cpu': MockData.cpu_percent(),
+        'memory': mock_memory.rss,
+        'disk': MockData.disk_usage().percent
+    }
+    mock_host_metadata = {
+        'num_cpu': MockData.cpu_count,
+        'memory': MockData.virtual_memory().total,
+        'disk_total': MockData.disk_usage().total,
+    }
+
+    for resource, value in mock_resource_data.items():
+        assert resource_monitor.monitor_metrics[resource][0] == value
+
+    for meta, value in mock_host_metadata.items():
+        assert resource_monitor.host_metadata[meta] == value
+
+
+@testsuite
+class Alpha(object):
+
+    @testcase
+    def test_memory_a(self, env, result):
+        _tmp = 'testplan' * 1024 * 1024 * (1024 // 8)  # 1GB memory
+        time.sleep(10)
+
+
+def test_resource_monitor():
+    plan = Testplan(name='plan', parse_cmdline=False,
+                    resource_monitor=True)
+
+    plan.add(MultiTest(name='multitest_x', suites=[Alpha()]))
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        plan.run()
+
+    hostname = socket.getfqdn()
+    with open(os.path.join(plan.cfg.report_dir, 'monitor.json')) as monitor_file:
+        monitor_json = json.load(monitor_file)
+    resource_monitor = load_monitor_from_json(monitor_json['data'][0])
+
+    assert hostname == resource_monitor.hostname
+    assert isinstance(resource_monitor, ResourceMonitor) is True
+    big_size = sys.getsizeof('testplan' * 1024 * 1024 * (1024 // 8))
+    assert max(resource_monitor.monitor_metrics['memory']) >= big_size
+
+    event_uuid = None
+    events = monitor_json['data'][0]['process'][0]['data'][0]['data']
+    for uuid, metadata in events['events_metadata'].items():
+        if metadata['name'] == 'multitest_x':
+            event_uuid = uuid
+    assert event_uuid is not None
+
+    event_data = events['events_data'][0]
+    assert  event_data[0] == event_uuid
+    spent_time = event_data[1][-1]['time'] - event_data[1][0]['time']
+    assert spent_time >= 10

--- a/tests/unit/testplan/common/utils/test_monitor.py
+++ b/tests/unit/testplan/common/utils/test_monitor.py
@@ -1,0 +1,73 @@
+import math
+import mock
+import time
+
+from testplan.common.utils.monitor import ResourceMonitor
+from testplan.common.utils.monitor.collectors import WindowsCollector
+
+
+class MockData(object):
+    @staticmethod
+    def fake_getfqdn():
+        return 'fake_hostname'
+
+    @staticmethod
+    def fake_pid():
+        return 10
+
+    @staticmethod
+    def fake_ppid():
+        return 1
+
+    @staticmethod
+    def fake_system():
+        return 'Windows'
+
+
+class TestMonitor(object):
+
+    @mock.patch('socket.getfqdn', side_effect=MockData.fake_getfqdn)
+    @mock.patch('os.getpid', side_effect=MockData.fake_pid)
+    @mock.patch('os.getppid', side_effect=MockData.fake_ppid)
+    def test_host_info(self, *args):
+        monitor = ResourceMonitor()
+        assert monitor.hostname == MockData.fake_getfqdn()
+        assert monitor.pid == MockData.fake_pid()
+        assert monitor.ppid == MockData.fake_ppid()
+
+    def test_monitor_thread(self):
+        monitor = ResourceMonitor()
+        monitor.poll_interval = 5
+        monitor.start()
+        assert monitor._poll.is_alive() is True
+        start_time = math.ceil(time.time())
+        monitor.stop()
+        stop_time = math.floor(time.time())
+        assert stop_time - start_time <= monitor.poll_interval
+
+    @mock.patch('platform.system', side_effect=MockData.fake_system)
+    def test_collector(self, *args):
+        monitor = ResourceMonitor()
+        assert isinstance(monitor._collector, WindowsCollector) is True
+
+    def test_dump(self):
+        monitor = ResourceMonitor()
+        monitor.start()
+        time.sleep(2*monitor.poll_interval)
+        monitor.stop()
+        metric_data = monitor.to_dict()['monitor_metrics']
+        for key in ('cpu', 'memory', 'disk'):
+            assert len(metric_data[key]) >= 1
+        new_monitor = ResourceMonitor()
+        new_monitor.load(monitor.dumps())
+
+        assert new_monitor.pid == monitor.pid
+        assert new_monitor.ppid == monitor.ppid
+        assert new_monitor.parent == monitor.parent
+        assert new_monitor.hostname == monitor.hostname
+        assert new_monitor.thread_name == monitor.thread_name
+        assert new_monitor.events_data == monitor.events_data
+        assert new_monitor.events_metadata == monitor.events_metadata
+
+        assert new_monitor.host_metadata == monitor.host_metadata
+        assert new_monitor.monitor_metrics == monitor.monitor_metrics


### PR DESCRIPTION
Add resource monitor that will export a JSON file includes:
* test and Testplan internals (events) start and stop times (seconds)
* resource utilisation per host

To run Testplan with Resource Monitor just run your Testplan script with the --resource-monitor command line argument.