### PR TITLE
Use local hostname instead of localhost and support IPv6 addresses

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ REQUIRED = [
     'requests>=2.4.3',
     'flask',
     'flask_restplus',
-    'cheroot'
+    'cheroot',
+    'ipaddress',
 ]
 
 setup(name='Testplan',

--- a/testplan/defaults.py
+++ b/testplan/defaults.py
@@ -20,6 +20,6 @@ JSON_PATH = os.path.join(REPORT_DIR, 'report.json')
 ATTACHMENTS = '_attachments'
 ATTACHMENTS_DIR = os.path.join(REPORT_DIR, ATTACHMENTS)
 
-WEB_SERVER_HOSTNAME = 'localhost'
+WEB_SERVER_HOSTNAME = socket.gethostname()
 WEB_SERVER_PORT = 0
 WEB_SERVER_TIMEOUT = 10

--- a/testplan/exporters/testing/webserver/base.py
+++ b/testplan/exporters/testing/webserver/base.py
@@ -4,6 +4,7 @@
 """
 from __future__ import absolute_import
 
+import ipaddress
 import os
 import json
 
@@ -80,6 +81,15 @@ class WebServerExporter(Exporter):
              raise_on_timeout=True)
 
         (host, port) = self._web_server_thread.server.bind_addr
+
+        # Check for an IPv6 address. Web browsers require IPv6 addresses to be
+        # enclosed in [].
+        try:
+            if ipaddress.ip_address(host).version == 6:
+                host = '[{}]'.format(host)
+        except ValueError:
+            # Expected if the host is a host name instead of an IP address.
+            pass
 
         self.url = 'http://{host}:{port}/testplan/local'.format(
             host=host,

--- a/tests/functional/exporters/testing/test_webserver.py
+++ b/tests/functional/exporters/testing/test_webserver.py
@@ -49,7 +49,7 @@ def dummy_testplan(request):
     assert testplan_proc.poll() is not None
 
     thr.join(timeout=_TIMEOUT)
-    assert(not thr.isAlive())
+    assert(not thr.is_alive())
 
 
 def _enqueue_output(out, queue):


### PR DESCRIPTION
- Change default hostname for web server to socket.gethostname()

Mostly a usability benefit if using testplan in an SSH session, so that the web report can be viewed from the local host.

- Support IPv6 addresses

IPv6 addresses need to be enclosed in [] in the URL.