### PR TITLE
Remote worker start/stop in thread pool refactor

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -139,7 +139,7 @@ class Environment(object):
         for resource in self._resources.values():
             try:
                 resource.start()
-                if resource.cfg.async_start is False:
+                if not resource.cfg.async_start:
                     resource.wait(resource.STATUS.STARTED)
             except Exception as exc:
                 msg = 'While starting resource [{}]{}{}'.format(
@@ -179,7 +179,7 @@ class Environment(object):
         """
 
         for resource in self._resources.values():
-            if resource.cfg.async_start is False:
+            if not resource.cfg.async_start:
                 raise RuntimeError(
                     'Cannot start resource {} in thread pool, '
                     'its async_start attr is set to False'.format(
@@ -343,7 +343,7 @@ class EntityConfig(Config):
                 block_propagation=False): Or(None, str, lambda x: callable(x)),
             ConfigOption('initial_context', default={}): dict,
             ConfigOption('path_cleanup', default=False): bool,
-            ConfigOption('status_wait_timeout', default=3600): int,
+            ConfigOption('status_wait_timeout', default=600): int,
             ConfigOption('abort_wait_timeout', default=30): int,
             # active_loop_sleep impacts cpu usage in interactive mode
             ConfigOption('active_loop_sleep', default=0.005): float
@@ -1183,9 +1183,9 @@ class Resource(Entity):
     def restart(self, timeout=None):
         """Stop and start the resource."""
         self.stop()
-        self._wait_stopped(timeout=timeout)
+        self.wait(self.status.STOPPED)
         self.start()
-        self._wait_started(timeout=timeout)
+        self.wait(self.status.STARTED)
 
     def __enter__(self):
         self.start()

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -159,6 +159,39 @@ class Environment(object):
             else:
                 resource.wait(resource.STATUS.STARTED)
 
+    def _log_exception(self, resource, func):
+
+        def wrapper(*args, **kargs):
+            try:
+                func(*args, **kargs)
+            except Exception as exe:
+                msg = 'While executing {} of resource [{}]{}{}'.format(
+                    func.__name__, resource.cfg.name, os.linesep,
+                    format_trace(inspect.trace(), exe))
+                self.logger.error(msg)
+                self.start_exceptions[resource] = msg
+
+        return wrapper
+
+    def start_in_pool(self, pool):
+        """
+        Start all resources concurrently in thread pool.
+        """
+
+        for resource in self._resources.values():
+            if resource.cfg.async_start is False:
+                raise RuntimeError(
+                    'Cannot start resource {} in thread pool, '
+                    'its async_start attr is set to False'.format(
+                        resource))
+
+        for resource in self._resources.values():
+            pool.apply_async(self._log_exception(resource, resource.start))
+
+        # Wait resources status to be STARTED.
+        for resource in self._resources.values():
+            resource.wait(resource.STATUS.STARTED)
+
     def stop(self, reversed=False):
         """
         Stop all resources in reverse order and log exceptions.
@@ -187,6 +220,31 @@ class Environment(object):
                 continue
             elif resource.status.tag is None:
                 # Skip resources not even triggered to start.
+                continue
+            else:
+                resource.wait(resource.STATUS.STOPPED)
+
+    def stop_in_pool(self, pool, reversed=False):
+        """
+        Stop all resources in reverse order and log exceptions.
+        """
+        resources = list(self._resources.values())
+        if reversed is True:
+            resources = resources[::-1]
+
+        # Stop all resources
+        for resource in resources:
+            # Skip resources not even triggered to start.
+            if (resource.status.tag is None) or (
+                    resource.status.tag == resource.STATUS.STOPPED):
+                continue
+
+            pool.apply_async(self._log_exception(resource, resource.stop))
+
+        # Wait resources status to be STOPPED.
+        for resource in resources:
+            # Skip resources not even triggered to start.
+            if resource.status.tag is None:
                 continue
             else:
                 resource.wait(resource.STATUS.STOPPED)

--- a/testplan/common/utils/logger.py
+++ b/testplan/common/utils/logger.py
@@ -189,6 +189,8 @@ class Loggable(object):
         # take up a lot of space in the logfile. For brevity we just use
         # "testplan.<class name>" as the logger name, since class names are
         # mostly unique.
+
         logger_name = '.'.join(('testplan', self.__class__.__name__))
         self.logger = logging.getLogger(logger_name)
+
         super(Loggable, self).__init__()

--- a/testplan/common/utils/process.py
+++ b/testplan/common/utils/process.py
@@ -47,7 +47,7 @@ def kill_process(proc, timeout=5, signal_=None, output=None):
         return retcode
 
     parent = psutil.Process(proc.pid)
-    for child in parent.children():
+    for child in parent.children(recursive=True):
         try:
             child.send_signal(signal.SIGTERM)
         except Exception as exc:

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -660,11 +660,14 @@ class Pool(Executor):
         """Count how many tasks workers are requesting."""
         return sum(worker.requesting for worker in self._workers)
 
+    def _stop_workers(self):
+        self._workers.stop()
+
     def stopping(self):
         """Stop connections and workers."""
-        # TODO do we need a lock here?
+
         with self._pool_lock:
-            self._workers.stop()
+            self._stop_workers()
             for worker in self._workers:
                 worker.transport.disconnect()
 

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -247,7 +247,6 @@ class Pool(Executor):
         self._conn.parent = self
         self._pool_lock = threading.Lock()
         self._metadata = {}
-        self.make_runpath_dirs()
         self._metadata['runpath'] = self.runpath
         self._exit_loop = False
         self._start_monitor_thread = True
@@ -633,6 +632,7 @@ class Pool(Executor):
     def starting(self):
         """Starting the pool and workers."""
         # TODO do we need a lock here?
+        self.make_runpath_dirs()
         self._conn.start()
 
         for worker in self._workers:

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -345,7 +345,7 @@ def child_logic(args):
         loop.worker_loop()
 
 
-def _parse_syspath_file(filename):
+def parse_syspath_file(filename):
     """
     Read and parse the syspath file, which should contain each sys.path entry
     on a separate line. Remove the file once we have read it.
@@ -367,7 +367,7 @@ if __name__ == '__main__':
         os.chdir(ARGS.wd)
 
     if ARGS.sys_path_file:
-        sys.path = _parse_syspath_file(ARGS.sys_path_file)
+        sys.path = parse_syspath_file(ARGS.sys_path_file)
 
     if ARGS.testplan:
         sys.path.append(ARGS.testplan)

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -324,7 +324,7 @@ def child_logic(args):
         def make_runpath_dirs(self):
             self._runpath = self.cfg.runpath
 
-    transport = ZMQClient(address=args.address)
+    transport = ZMQClient(address=args.address, recv_timeout=30)
 
     if args.type == 'process_worker':
         loop = ChildLoop(

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -115,7 +115,7 @@ class ProcessWorker(Worker):
                 self.status.change(self.STATUS.STARTED)
                 return
 
-            if self._handler.poll() is not None:
+            if self._handler and self._handler.poll() is not None:
                 raise RuntimeError(
                     '{proc} process exited: {rc} (logfile = {log})'.format(
                         proc=self,

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -27,8 +27,6 @@ class ProcessWorkerConfig(WorkerConfig):
     Configuration object for
     :py:class:`~testplan.runners.pools.process.ProcessWorker` resource entity.
 
-    :param start_timeout: Timeout duration for worker to start.
-    :type start_timeout: ``int``
     :param transport: Transport class for pool/worker communication.
     :type transport: :py:class:`~testplan.runners.pools.connection.Client`
 
@@ -42,7 +40,6 @@ class ProcessWorkerConfig(WorkerConfig):
         Schema for options validation and assignment of default values.
         """
         return {
-            ConfigOption('start_timeout', default=120): int,
             ConfigOption('transport', default=ZMQClientProxy): object,
         }
 
@@ -104,7 +101,7 @@ class ProcessWorker(Worker):
         """TODO."""
         sleeper = get_sleeper(
             interval=(0.04, 0.5),
-            timeout=self.cfg.start_timeout,
+            timeout=timeout,
             raise_timeout_with_msg='Worker start timeout, logfile = {}'
                                    .format(self.outfile))
         while next(sleeper):

--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -732,7 +732,7 @@ class RemotePool(Pool):
         # self._workers.stop()
 
     def _start_thread_pool(self):
-        size = self.cfg.size
+        size = len(self._instances)
         try:
             if size > 2:
                 self.pool = ThreadPool(5 if size > 5 else size)


### PR DESCRIPTION
A couple of changes:

- add start/stop_in_pool methods to Environment class to start/stop resources in threadpool.
- add try-except when we fetch result from remote host