### PR TITLE
Command Line arguments take precedence over those defined in script

### DIFF
--- a/testplan/report/testing/parser.py
+++ b/testplan/report/testing/parser.py
@@ -1,7 +1,7 @@
-import argparse
+from testplan.common.utils.parser import TestplanAction
 
 
-class ReportTagsAction(argparse.Action):
+class ReportTagsAction(TestplanAction):
     """
         Argparse action for parsing multiple report tag
         arguments, builds up a list of dictionary of sets.

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -96,6 +96,7 @@ class TestRunnerConfig(RunnableConfig):
     def get_options(cls):
         return {
             'name': str,
+            ConfigOption('description', default=None): Or(str, None),
             ConfigOption('logger_level', default=logger.TEST_INFO): int,
             ConfigOption('file_log_level', default=logger.DEBUG): Or(int, None),
             ConfigOption(
@@ -614,7 +615,7 @@ class TestRunner(Runnable):
     def _invoke_exporters(self):
         # Add this logic into a ReportExporter(Runnable)
         # that will return a result containing errors
-        if self.cfg.exporters is None:
+        if self.cfg.exporters is None or len(self.cfg.exporters) == 0:
             exporters = get_default_exporters(self.cfg)
         else:
             exporters = self.cfg.exporters

--- a/testplan/testing/filtering.py
+++ b/testplan/testing/filtering.py
@@ -1,11 +1,11 @@
 """Filtering logic for Multitest, Suites and testcase methods (of Suites)"""
-import argparse
 import collections
 import operator
 import fnmatch
 
 from enum import Enum, unique
 
+from testplan.common.utils.parser import TestplanAction
 from testplan.testing import tagging
 from testplan.testing.multitest.suite import get_testsuite_name
 
@@ -295,7 +295,7 @@ class Pattern(Filter):
         return Or(*[Pattern(pattern=pattern) for pattern in patterns])
 
 
-class PatternAction(argparse.Action):
+class PatternAction(TestplanAction):
     """
     Parser action for generating Pattern filters.
     Returns a list of `Pattern` filter objects.
@@ -310,12 +310,11 @@ class PatternAction(argparse.Action):
     """
     def __call__(self, parser, namespace, values, option_string=None):
         items = getattr(namespace, self.dest) or []
-
         items.extend([Pattern(value) for value in values])
         setattr(namespace, self.dest, items)
 
 
-class TagsAction(argparse.Action):
+class TagsAction(TestplanAction):
     """
     Parser action for generating tags (any) filters.
 


### PR DESCRIPTION
* Generally, command line arguments should overwrite the corresponding
  ones defined in testplan script if they are explicitly specified by
  users, which provides flexibility for testing.
* We plan to provide public APIs with completely argument list for the
  ease of users with IDE, then this change is very important because
  the default value in API always takes precedence than that in command
  line. So, even a user does nnt explicitly assign a instance value for
  an argument in api, but specify it in command line, it has no effect.
* Also fix a typo (help message in testplan parser).