### PR TITLE
Command Line arguments take precedence over those defined in script

### DIFF
--- a/testplan/base.py
+++ b/testplan/base.py
@@ -5,7 +5,7 @@ from .common.config import ConfigOption
 from .common.entity import (RunnableManager, RunnableManagerConfig, Resource)
 from .common.utils.callable import arity
 from .common.utils.validation import is_subclass, has_method
-from .parser import TestplanParser
+from .parser import TestplanParser, USER_SPECIFIED_ARGS
 from .runners import LocalRunner
 from .environment import Environments
 
@@ -121,16 +121,16 @@ class Testplan(RunnableManager):
         """
         self._parsed_args = self.parser.parse_args()
         self._processed_args = self.parser.process_args(self._parsed_args)
-        # Overwrite configuration options only if they are not specified
-        # programmatically. There is no easy way to know if an argument in
-        # processed_args is user command line input or a default value in the
-        # parser.
+        cmd_line_args = self._processed_args.get(USER_SPECIFIED_ARGS, set())
+
+        # Overwrite configuration options if they have been specified
+        # in command line. Or choose the programmatically defined ones.
+        # Default values are the last choice.
         for key, value in self._processed_args.items():
-            if key in options:
-                self.logger.warning('WARNING: Command line argument for '
-                    '"{}" will be overridden by the one programmatically '
-                        'defined in {} constructor'.format(key, self))
-            options.setdefault(key, value)
+            if key in cmd_line_args:
+                options[key] = value
+            else:
+                options.setdefault(key, value)
 
         return options
 

--- a/testplan/common/config/__init__.py
+++ b/testplan/common/config/__init__.py
@@ -1,3 +1,6 @@
 """TODO."""
 
-from .base import Config, ConfigOption, Configurable, validate_func
+from .base import (
+    Config, ConfigOption, Configurable,
+    validate_func, DefaultValueWrapper, DEFAULT
+)

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -8,10 +8,13 @@ import os
 import random
 import sys
 
-from testplan.common.utils import logger
 from testplan import defaults
+from testplan.common.config import DefaultValueWrapper, DEFAULT
+from testplan.common.utils import logger
 from testplan.report.testing import styles, ReportTagsAction
 from testplan.testing import listing, filtering, ordering
+
+USER_SPECIFIED_ARGS = '_user_specified_args'
 
 
 class HelpParser(argparse.ArgumentParser):
@@ -62,24 +65,26 @@ class TestplanParser(object):
 
         parser.add_argument(
             '--list', action='store_true',
-            help='Shortcut for `--info name`'
+            default=DEFAULT(False), help='Shortcut for `--info name`'
         )
 
         parser.add_argument(
-            '--info',
-            dest='test_lister',
-            metavar='TEST_INFO',
-            **listing.ListingArg.get_parser_context(default=None)
+            '--info', dest='test_lister', metavar='TEST_INFO',
+            **listing.ListingArg.get_parser_context(
+                default=DEFAULT(None, upper_end_preferred=True))
         )
 
         parser.add_argument(
             '-i', '--interactive', action='store_true', dest='interactive',
-            default=False, help='Enable interactive mode.')
+            default=DEFAULT(False), help='Enable interactive mode.'
+        )
 
         general_group = parser.add_argument_group('General')
         general_group.add_argument(
             '--runpath', type=str, metavar='PATH',
-            help='Path under which all temp files and logs will be created')
+            default=DEFAULT(None, upper_end_preferred=True),
+            help='Path under which all temp files and logs will be created'
+        )
 
         filter_group = parser.add_argument_group('Filtering')
 
@@ -89,13 +94,13 @@ class TestplanParser(object):
             help=os.linesep.join([
                 'Test filter, supports glob notation & multiple arguments.',
                 '',
-                '--pattern <Multitest Name>',
-                '--pattern <Multitest Name 1> <Multitest Name 2>',
-                '--pattern <Multitest Name 1> --pattern <Multitest Name 2>',
-                '--pattern <Multitest Name>:<Suite Name>',
-                '--pattern <Multitest Name>:<Suite Name>:<Testcase name>',
-                '--pattern <Multitest Name>:*:<Testcase name>',
-                '--pattern *:<Suite Name>:<Testcase name>',
+                '--patterns <Multitest Name>',
+                '--patterns <Multitest Name 1> <Multitest Name 2>',
+                '--patterns <Multitest Name 1> --patterns <Multitest Name 2>',
+                '--patterns <Multitest Name>:<Suite Name>',
+                '--patterns <Multitest Name>:<Suite Name>:<Testcase name>',
+                '--patterns <Multitest Name>:*:<Testcase name>',
+                '--patterns *:<Suite Name>:<Testcase name>',
             ])
         )
 
@@ -124,76 +129,85 @@ class TestplanParser(object):
         ordering_group = parser.add_argument_group('Ordering')
 
         ordering_group.add_argument(
-            '--shuffle', nargs='+', type=str, default=[],
+            '--shuffle', nargs='+', type=str, default=DEFAULT([]),
             choices=[enm.value for enm in ordering.SortType],
-            help='Shuffle execution order')
+            help='Shuffle execution order'
+        )
 
         ordering_group.add_argument(
             '--shuffle-seed', metavar='SEED', type=float,
-            default=float(random.randint(1, 9999)),
+            default=DEFAULT(float(random.randint(1, 9999))),
             help='Seed shuffle with a specific value, useful to '
-                 'reproduce a particular order.')
+                 'reproduce a particular order.'
+        )
 
         report_group = parser.add_argument_group('Reporting')
 
         report_group.add_argument(
             '--stdout-style',
             **styles.StyleArg.get_parser_context(
-                default='summary'))
+                default=DEFAULT('summary', upper_end_preferred=True))
+        )
 
         report_group.add_argument(
-            '--pdf', dest='pdf_path',
-            default=None, metavar='PATH',
+            '--pdf', dest='pdf_path', metavar='PATH',
+            default=DEFAULT(None, upper_end_preferred=True),
             help='Path for PDF report.'
         )
 
         report_group.add_argument(
-            '--json', dest='json_path',
-            default=None, metavar='PATH',
+            '--json', dest='json_path', metavar='PATH',
+            default=DEFAULT(None, upper_end_preferred=True),
             help='Path for JSON report.'
         )
 
         report_group.add_argument(
-            '--xml', dest='xml_dir',
-            default=None, metavar='DIRECTORY',
+            '--xml', dest='xml_dir', metavar='DIRECTORY',
+            default=DEFAULT(None, upper_end_preferred=True),
             help='Directory path for XML reports.'
         )
 
         report_group.add_argument(
-            '--report-dir',
-            help='Target directory for tag filtered report output.',
-            default=defaults.REPORT_DIR, metavar='PATH')
+            '--report-dir', metavar='DIRECTORY',
+            default=DEFAULT(defaults.REPORT_DIR, upper_end_preferred=True),
+            help='Target directory for tag filtered report output.'
+        )
 
         report_group.add_argument(
             '--pdf-style',
             **styles.StyleArg.get_parser_context(
-                default='extended-summary'))
+                default=DEFAULT('extended-summary', upper_end_preferred=True))
+        )
 
         report_group.add_argument(
             '-v', '--verbose', action='store_true', dest='verbose',
+            default=DEFAULT(False),
             help='Enable verbose mode that will also set the stdout-style '
                  'option to "detailed".')
+
         report_group.add_argument(
             '-d', '--debug', action='store_true', dest='debug',
+            default=DEFAULT(False),
             help='Enable debug mode.')
 
         report_group.add_argument(
             '-b', '--browse', action='store_true', dest='browse',
+            default=DEFAULT(False),
             help=('Automatically open report to browse. Must be specifed with '
                   '"--pdf" or "--json --ui" or there will be nothing to open.'))
 
         report_group.add_argument(
             '-u', '--ui', dest='ui_port', nargs='?',
-            const=defaults.WEB_SERVER_PORT, type=int,
+            const=DEFAULT(defaults.WEB_SERVER_PORT), type=int,
+            default=DEFAULT(None),
             help=('Start the web server to view the Testplan UI. A port can be '
                   'specified, otherwise defaults to {}. A JSON report will be '
                   'saved locally.').format(defaults.WEB_SERVER_PORT))
 
         report_group.add_argument(
             '--report-tags', nargs='+',
-            action=ReportTagsAction,
-            default=[],
-            metavar='REPORT_FILTER',
+            action=ReportTagsAction, metavar='REPORT_FILTER',
+            default=DEFAULT([], upper_end_preferred=True),
             help=os.linesep.join([
                 'Report filter, generates a separate report (PDF by default)',
                 'that match ANY of the given tags.',
@@ -205,9 +219,8 @@ class TestplanParser(object):
 
         report_group.add_argument(
             '--report-tags-all', nargs='+',
-            action=ReportTagsAction,
-            default=[],
-            metavar='REPORT_FILTER',
+            action=ReportTagsAction, metavar='REPORT_FILTER',
+            default=DEFAULT([], upper_end_preferred=True),
             help=os.linesep.join([
                 'Report filter, generates a separate report (PDF by default)',
                 'that match ALL of the given tags.',
@@ -219,9 +232,9 @@ class TestplanParser(object):
 
         report_group.add_argument(
             '--file-log-level',
-            choices=LogLevelAction.LEVELS.keys(),
-            default=logger.DEBUG,
             action=LogLevelAction,
+            choices=LogLevelAction.LEVELS.keys(),
+            default=DEFAULT(logger.DEBUG),
             help='Specify log level for file logs. Set to NONE to disable file '
                  'logging.')
 
@@ -244,6 +257,11 @@ class TestplanParser(object):
         to initialize the configuration.
         """
         args = dict(**vars(namespace))
+        cmd_line_args = args.setdefault(USER_SPECIFIED_ARGS, set())
+        cmd_line_args.update({
+            key for key, value in args.items()
+            if not isinstance(value, DefaultValueWrapper)
+        })
 
         filter_args = filtering.parse_filter_args(
             parsed_args=args,
@@ -251,29 +269,39 @@ class TestplanParser(object):
 
         if filter_args:
             args['test_filter'] = filter_args
+            cmd_line_args.add('test_filter')
 
         # Cmdline supports shuffle ordering only for now
-        if 'shuffle' in args:
+        if 'shuffle' in cmd_line_args:
+            shuffle_seed = args['shuffle_seed'] \
+                if 'shuffle_seed' in cmd_line_args \
+                else args['shuffle_seed'].value,
             args['test_sorter'] = ordering.ShuffleSorter(
-                seed=args['shuffle_seed'],
+                seed=shuffle_seed,
                 shuffle_type=args['shuffle']
             )
+        else:
+            args['test_sorter'] = ordering.NoopSorter()
 
         # Set stdout style and logging level options according to
         # verbose/debug parameters. Debug output should be a superset of
         # verbose output, i.e. running with just "-d" should automatically
         # give you all "-v" output plus extra DEBUG logs.
-        if args['verbose'] or args['debug']:
+        if 'verbose' in cmd_line_args and args['verbose'] or \
+                'debug' in cmd_line_args and args['debug']:
             args['stdout_style'] = styles.Style(
                 styles.StyleEnum.ASSERTION_DETAIL,
                 styles.StyleEnum.ASSERTION_DETAIL)
-            if args['debug']:
+            cmd_line_args.add('stdout_style')
+            if 'debug' in cmd_line_args and args['debug']:
                 args['logger_level'] = logger.DEBUG
+                cmd_line_args.add('logger_level')
             else:
                 args['logger_level'] = logger.INFO
 
-        if args['list'] and 'info' not in args:
+        if 'list' in cmd_line_args and 'test_lister' not in cmd_line_args:
             args['test_lister'] = listing.NameLister()
+            cmd_line_args.add('test_lister')
 
         return args
 


### PR DESCRIPTION
* Generally, command line arguments should overwrite the corresponding
  ones defined in testplan script if they are explicitly specified by
  users, which provides flexibility for testing.
* We plan to provide public APIs with completely argument list for the
  ease of users with IDE, thus we'll set default values of optional
  arguments to be instances of ``DefaultValueWrapper``. We'd also like
  to make testplan parser taking these kind of values as default for
  arguments that are not specified in command line by users.
* Fix a typo (help message of '--patterns' in testplan parser).
* Fix a error of processing '--list' argument.