### PR TITLE
Log full stack for local materialization errors

### DIFF
--- a/testplan/runners/local.py
+++ b/testplan/runners/local.py
@@ -56,7 +56,7 @@ class LocalRunner(Executor):
                         result = TestResult()
                         result.report = TestGroupReport(name=next_uid)
                         result.report.status_override = Status.ERROR
-                        result.report.logger.critical(
+                        result.report.logger.exception(
                             'Exception for {} on {} execution: {}'.format(
                                 next_uid, self, exc))
                         self._results[next_uid] = result


### PR DESCRIPTION
logger.exception automatically includes the formatted traceback when called in the except: branch of an exception handler.

Fixes https://github.com/Morgan-Stanley/testplan/issues/218