### PR TITLE
Update driver UTs

### DIFF
--- a/testplan/testing/multitest/driver/fix/client.py
+++ b/testplan/testing/multitest/driver/fix/client.py
@@ -275,6 +275,7 @@ class FixClient(Driver):
             self._client.close()
             self._client = None
             self.file_logger.debug('Stopped client')
+            self._close_file_logger()
 
     def stopping(self):
         """Stops the FIX client."""

--- a/testplan/testing/multitest/driver/fix/server.py
+++ b/testplan/testing/multitest/driver/fix/server.py
@@ -171,6 +171,7 @@ class FixServer(Driver):
     def _stop_logic(self):
         if self._server:
             self._server.stop()
+        self._close_file_logger()
 
     def stopping(self):
         """Stops the FIX server."""

--- a/testplan/testing/multitest/driver/http/client.py
+++ b/testplan/testing/multitest/driver/http/client.py
@@ -276,6 +276,8 @@ class HTTPClient(Driver):
         :rtype: ``requests.models.Response`` or ``NoneType``
         """
         timeout = time.time() + (timeout or self.timeout)
+        response = None
+
         while time.time() < timeout:
             try:
                 response = self.responses.get(False)
@@ -287,6 +289,7 @@ class HTTPClient(Driver):
                 self.file_logger.debug('Received response.')
                 break
             time.sleep(self.interval)
+
         return response
 
     def flush(self):

--- a/testplan/testing/multitest/driver/http/client.py
+++ b/testplan/testing/multitest/driver/http/client.py
@@ -109,6 +109,7 @@ class HTTPClient(Driver):
         """
         super(HTTPClient, self).stopping()
         self.file_logger.debug('Stopped HTTPClient.')
+        self._close_file_logger()
 
     def aborting(self):
         """Abort logic that stops the client."""

--- a/testplan/testing/multitest/driver/http/server.py
+++ b/testplan/testing/multitest/driver/http/server.py
@@ -300,6 +300,7 @@ class HTTPServer(Driver):
         super(HTTPServer, self).stopping()
         self._stop()
         self.file_logger.debug('Stopped HTTPServer.')
+        self._close_file_logger()
 
     def aborting(self):
         """Abort logic that stops the server."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Shared PyTest fixtures."""
+
+import pytest
+
+from testplan.common.utils import path
+
+
+@pytest.fixture(scope="module")
+def runpath():
+    """
+    Yield a temporary runpath for testing. The path will be automatically
+    removed after the test.
+    """
+    with path.TemporaryDirectory() as runpath:
+        yield runpath

--- a/tests/unit/testplan/testing/multitest/driver/test_zmq.py
+++ b/tests/unit/testplan/testing/multitest/driver/test_zmq.py
@@ -1,5 +1,5 @@
 """Unit tests for the ZMQServer and ZMQClient drivers."""
-
+import os
 import time
 
 from schema import SchemaError
@@ -14,241 +14,340 @@ from testplan.common.entity.base import Environment
 TIMEOUT = 10
 
 
-def create_server(name, host, port, message_pattern):
-    server = ZMQServer(name=name,
-                       host=host,
-                       port=port,
-                       message_pattern=message_pattern)
-    server.start()
-    server._wait_started()
-    return server
+@pytest.mark.parametrize("server_message_pattern,client_message_pattern",
+                         [(zmq.PAIR, zmq.PAIR),
+                          (zmq.REP, zmq.REQ),
+                          (zmq.PUB, zmq.SUB),
+                          (zmq.PUSH, zmq.PULL)])
+def test_send_receive(server_message_pattern, client_message_pattern, runpath):
+    """Test sending message between server and client."""
+    server = ZMQServer(name='server',
+                       host='127.0.0.1',
+                       port=0,
+                       message_pattern=server_message_pattern,
+                       runpath=os.path.join(runpath, 'server'))
+    with server:
+        client = ZMQClient(name='client',
+                           hosts=[server.host],
+                           ports=[server.port],
+                           message_pattern=client_message_pattern,
+                           runpath=os.path.join(runpath, 'client'))
+
+        with client:
+            if client_message_pattern == zmq.SUB:
+                client.subscribe(b'')
+
+                # The SUB client seems to take longer to connect and results in
+                # dropped messages.
+                time.sleep(1)
+
+            if ((server_message_pattern == zmq.PAIR) or
+                (server_message_pattern == zmq.REP)):
+                send_receive_message(sender=client,
+                                     receiver=server,
+                                     data=b'Hello')
+                send_receive_message(sender=server,
+                                     receiver=client,
+                                     data=b'World')
+            else:
+                send_receive_message(sender=server,
+                                     receiver=client,
+                                     data=b'Hello World')
 
 
-def create_client(name, hosts, ports, message_pattern):
-    client = ZMQClient(name=name,
-                       hosts=hosts,
-                       ports=ports,
-                       message_pattern=message_pattern)
-    client.start()
-    client._wait_started()
-    # This will only effect Subscribe clients, necessary to subscribe to all
-    # messages.
-    client.subscribe(b'')
-    return client
+def test_create_client_with_context(runpath):
+    """
+    Test creating a client that extracts its host and port from the context.
+    """
+    env = Environment()
+    server = ZMQServer(name='server',
+                       host='127.0.0.1',
+                       port=0,
+                       message_pattern=zmq.PAIR,
+                       runpath=os.path.join(runpath, 'server'))
+    env.add(server)
+    client = ZMQClient(name='client',
+                       hosts=[context('server', '{{host}}')],
+                       ports=[context('server', '{{port}}')],
+                       message_pattern=zmq.PAIR,
+                       runpath=os.path.join(runpath, 'client'))
+    env.add(client)
 
-def stop_devices(devices):
-    for device in devices:
-        device.stop()
-        device._wait_stopped()
+    assert server.port is None
+
+    with env:
+        assert server.port != 0
+        assert client.ports != 0
+        send_receive_message(sender=client,
+                             receiver=server,
+                             data=b'Hello World')
+
+
+def test_one_request_many_reply(runpath):
+    """Test connecting a request client to two reply servers."""
+    server1 = ZMQServer(name='server1',
+                        host='127.0.0.1',
+                        port=0,
+                        message_pattern=zmq.REP,
+                        runpath=os.path.join(runpath, 'server1'))
+    server2 = ZMQServer(name='server2',
+                        host='127.0.0.1',
+                        port=0,
+                        message_pattern=zmq.REP,
+                        runpath=os.path.join(runpath, 'server2'))
+
+    with server1, server2:
+        client = ZMQClient(name='client',
+                           hosts=[server1.host, server2.host],
+                           ports=[server1.port, server2.port],
+                           message_pattern=zmq.REQ,
+                           runpath=os.path.join(runpath, 'client'))
+
+        with client:
+            send_receive_message(
+                sender=client, receiver=server1, data=b'Hello 1')
+            send_receive_message(
+                sender=server1, receiver=client, data=b'World 1')
+            send_receive_message(
+                sender=client, receiver=server2, data=b'Hello 2')
+            send_receive_message(
+                sender=server2, receiver=client, data=b'World 2')
+
+
+def test_many_request_one_reply(runpath):
+    """Test connecting two request clients to a reply server."""
+    server = ZMQServer(name='server',
+                       host='127.0.0.1',
+                       port=0,
+                       message_pattern=zmq.REP,
+                       runpath=os.path.join(runpath, 'server'))
+
+    with server:
+        client1 = ZMQClient(name='client1',
+                            hosts=[server.host],
+                            ports=[server.port],
+                            message_pattern=zmq.REQ,
+                            runpath=os.path.join(runpath, 'client1'))
+        client2 = ZMQClient(name='client2',
+                            hosts=[server.host],
+                            ports=[server.port],
+                            message_pattern=zmq.REQ,
+                            runpath=os.path.join(runpath, 'client2'))
+
+        with client1, client2:
+            send_receive_message(
+                sender=client1, receiver=server, data=b'Hello 1')
+            send_receive_message(
+                sender=server, receiver=client1, data=b'World 1')
+            send_receive_message(
+                sender=client2, receiver=server, data=b'Hello 2')
+            send_receive_message(
+                sender=server, receiver=client2, data=b'World 2')
+
+
+def test_one_publish_many_subscribe(runpath):
+    """Test connecting two subscribe clients to one publish server."""
+    server = ZMQServer(name='server',
+                       host='127.0.0.1',
+                       port=0,
+                       message_pattern=zmq.PUB,
+                       runpath=os.path.join(runpath, 'server'))
+
+    with server:
+        client1 = ZMQClient(name='client1',
+                            hosts=[server.host],
+                            ports=[server.port],
+                            message_pattern=zmq.SUB,
+                            runpath=os.path.join(runpath, 'client1'))
+        client2 = ZMQClient(name='client2',
+                            hosts=[server.host],
+                            ports=[server.port],
+                            message_pattern=zmq.SUB,
+                            runpath=os.path.join(runpath, 'client2'))
+
+        with client1, client2:
+            for client in (client1, client2):
+                client.subscribe(b'')
+
+            # The SUB client seems to take longer to connect and results in
+            # dropped messages.
+            time.sleep(1)
+
+            data = b'Hello World'
+            server.send(data=data, timeout=TIMEOUT)
+            recv1 = client1.receive(timeout=TIMEOUT)
+            recv2 = client2.receive(timeout=TIMEOUT)
+
+            assert data == recv1
+            assert data == recv2
+
+
+def test_many_publish_one_subscribe(runpath):
+    """Test connecting one subscribe client to two publish servers."""
+    server1 = ZMQServer(name='server1',
+                        host='127.0.0.1',
+                        port=0,
+                        message_pattern=zmq.PUB,
+                        runpath=os.path.join(runpath, 'server1'))
+    server2 = ZMQServer(name='server2',
+                        host='127.0.0.1',
+                        port=0,
+                        message_pattern=zmq.PUB,
+                        runpath=os.path.join(runpath, 'server2'))
+
+    with server1, server2:
+        client = ZMQClient(name='client',
+                           hosts=[server1.host, server2.host],
+                           ports=[server1.port, server2.port],
+                           message_pattern=zmq.SUB,
+                           runpath=os.path.join(runpath, 'client'))
+
+        with client:
+            client.subscribe(b'')
+
+            # The SUB client seems to take longer to connect and results in
+            # dropped messages.
+            time.sleep(1)
+
+            data1 = b'Hello'
+            data2 = b'World'
+            server1.send(data=data1, timeout=TIMEOUT)
+            recv1 = client.receive(timeout=TIMEOUT)
+            server2.send(data=data2, timeout=TIMEOUT)
+            recv2 = client.receive(timeout=TIMEOUT)
+            assert data1 == recv1
+            assert data2 == recv2
+
+
+def test_many_push_one_pull(runpath):
+    """Test connecting one pull client to two push servers."""
+    server1 = ZMQServer(name='server1',
+                        host='127.0.0.1',
+                        port=0,
+                        message_pattern=zmq.PUSH,
+                        runpath=os.path.join(runpath, 'server1'))
+    server2 = ZMQServer(name='server2',
+                        host='127.0.0.1',
+                        port=0,
+                        message_pattern=zmq.PUSH,
+                        runpath=os.path.join(runpath, 'server2'))
+
+    with server1, server2:
+        client = ZMQClient(name='client',
+                           hosts=[server1.host, server2.host],
+                           ports=[server1.port, server2.port],
+                           message_pattern=zmq.PULL,
+                           runpath=os.path.join(runpath, 'client'))
+
+        with client:
+            time.sleep(1)
+
+            data1 = b'Hello'
+            data2 = b'World'
+            server1.send(data=data1, timeout=TIMEOUT)
+            recv1 = client.receive(timeout=TIMEOUT)
+            server2.send(data=data2, timeout=TIMEOUT)
+            recv2 = client.receive(timeout=TIMEOUT)
+            assert data1 == recv1
+            assert data2 == recv2
+
+
+def test_message_pattern_type():
+    """Test schema errors are raised for incorrect pattern types.."""
+    server_args = {
+        'name':'server',
+        'host':'localhost',
+        'port': 0,
+    }
+
+    with pytest.raises(SchemaError):
+        ZMQServer(message_pattern=zmq.REQ, **server_args)
+
+    with pytest.raises(SchemaError):
+        ZMQServer(message_pattern=zmq.SUB,**server_args)
+
+    with pytest.raises(SchemaError):
+        ZMQServer(message_pattern=zmq.PULL, **server_args)
+
+    client_args = {
+        'name':'client',
+        'hosts': ['localhost'],
+        'ports': [0],
+        'connect_at_start': False,
+    }
+
+    with pytest.raises(SchemaError):
+        ZMQClient(message_pattern=zmq.REP, **client_args)
+
+    with pytest.raises(SchemaError):
+        ZMQClient(message_pattern=zmq.PUB, **client_args)
+
+    with pytest.raises(SchemaError):
+        ZMQClient(message_pattern=zmq.PUSH, **client_args)
+
+
+def test_subscribe(runpath):
+    """Test subscribing to a particular data format."""
+    server = ZMQServer(name='server',
+                       host='127.0.0.1',
+                       port=0,
+                       message_pattern=zmq.PUB,
+                       runpath=os.path.join(runpath, 'server'))
+
+    with server:
+        client = ZMQClient(name='client',
+                           hosts=[server.host],
+                           ports=[server.port],
+                           message_pattern=zmq.SUB,
+                           runpath=os.path.join(runpath, 'client'))
+
+        with client:
+            client.subscribe(b'Hello')
+            time.sleep(1)
+
+            data1 = b'Hello World'
+            data2 = b'random message'
+            server.send(data=data1, timeout=TIMEOUT)
+            recv = client.receive(timeout=TIMEOUT)
+            assert data1 == recv
+            server.send(data=data2, timeout=TIMEOUT)
+            with pytest.raises(TimeoutException):
+                client.receive(timeout=0.2)
+
+
+def test_flush(runpath):
+    """Test flushing the client receive queue."""
+    server = ZMQServer(name='server',
+                       host='127.0.0.1',
+                       port=0,
+                       message_pattern=zmq.PAIR,
+                       runpath=os.path.join(runpath, 'server'))
+
+    with server:
+        client = ZMQClient(name='client',
+                           hosts=[server.host],
+                           ports=[server.port],
+                           message_pattern=zmq.PAIR,
+                           runpath=os.path.join(runpath, 'client'))
+
+        with client:
+            client.send(data=b'Hello World', timeout=TIMEOUT)
+            server.receive(timeout=TIMEOUT)
+            server.send(data=b'Hello client', timeout=TIMEOUT)
+            client.flush()
+
+            with pytest.raises(TimeoutException):
+                client.receive(timeout=0.2)
 
 
 def send_receive_message(sender, receiver, data):
     """
+    Utility function to send a mesage from sender to receiver and assert it
+    is received correctly.
+
     Sender ---data---> Receiver
     """
     sender.send(data=data, timeout=TIMEOUT)
     recv = receiver.receive(timeout=TIMEOUT)
     assert recv == data
 
-
-def server_client_logic(server_message_pattern, client_message_pattern):
-    server = create_server('server', '127.0.0.1', 0, server_message_pattern)
-    client = create_client('client', [server.host], [server.port],
-                           client_message_pattern)
-    if client_message_pattern == zmq.SUB:
-        # The SUB client seems to take longer to connect and results in dropped
-        # messages.
-        time.sleep(1)
-
-    if ((server_message_pattern == zmq.PAIR) or
-        (server_message_pattern == zmq.REP)):
-        send_receive_message(sender=client, receiver=server, data=b'Hello')
-        send_receive_message(sender=server, receiver=client, data=b'World')
-    else:
-        send_receive_message(sender=server, receiver=client,
-                             data=b'Hello World')
-
-    stop_devices([client, server])
-
-
-def test_create_client_with_context():
-    rcxt = Environment()
-    server = ZMQServer(name='server', host='127.0.0.1', port=0,
-                       message_pattern=zmq.PAIR)
-    rcxt.add(server)
-    client = ZMQClient(name='client', hosts=[context('server', '{{host}}')],
-                       ports=[context('server', '{{port}}')],
-                       message_pattern=zmq.PAIR)
-    rcxt.add(client)
-
-    assert server.port is None
-    for item in rcxt:
-        item.start()
-        item._wait_started()
-    assert server.port != 0
-    assert client.ports != 0
-
-    send_receive_message(sender=client, receiver=server, data=b'Hello World')
-    stop_devices(reversed(list(rcxt)))
-
-
-def test_pair_send_recv():
-    server_client_logic(server_message_pattern=zmq.PAIR,
-                        client_message_pattern=zmq.PAIR)
-
-
-def test_request_reply():
-    server_client_logic(server_message_pattern=zmq.REP,
-                        client_message_pattern=zmq.REQ)
-
-
-def test_one_request_many_reply():
-    server1 = create_server('server1', '127.0.0.1', 0, zmq.REP)
-    server2 = create_server('server2', '127.0.0.1', 0, zmq.REP)
-    client = create_client('client', [server1.host, server2.host],
-                           [server1.port, server2.port], zmq.REQ)
-
-    send_receive_message(sender=client, receiver=server1, data=b'Hello 1')
-    send_receive_message(sender=server1, receiver=client, data=b'World 1')
-    send_receive_message(sender=client, receiver=server2, data=b'Hello 2')
-    send_receive_message(sender=server2, receiver=client, data=b'World 2')
-
-    stop_devices([server1, server2, client])
-
-
-def test_many_request_one_reply():
-    server = create_server('server', '127.0.0.1', 0, zmq.REP)
-    client1 = create_client('client1', [server.host], [server.port], zmq.REQ)
-    client2 = create_client('client2', [server.host], [server.port], zmq.REQ)
-
-    send_receive_message(sender=client1, receiver=server, data=b'Hello 1')
-    send_receive_message(sender=server, receiver=client1, data=b'World 1')
-    send_receive_message(sender=client2, receiver=server, data=b'Hello 2')
-    send_receive_message(sender=server, receiver=client2, data=b'World 2')
-
-    stop_devices([server, client1, client2])
-
-
-def test_publish_subscribe():
-    server_client_logic(server_message_pattern=zmq.PUB,
-                        client_message_pattern=zmq.SUB)
-
-
-def test_one_publish_many_subscribe():
-    server = create_server('server', '127.0.0.1', 0, zmq.PUB)
-    client1 = create_client('client1', [server.host], [server.port], zmq.SUB)
-    client2 = create_client('client2', [server.host], [server.port], zmq.SUB)
-    # The SUB client seems to take longer to connect and results in dropped
-    # messages.
-    time.sleep(1)
-
-    data = b'Hello World'
-    server.send(data=data, timeout=TIMEOUT)
-    recv1 = client1.receive(timeout=TIMEOUT)
-    recv2 = client2.receive(timeout=TIMEOUT)
-
-    assert data == recv1
-    assert data == recv2
-
-    stop_devices([server, client1, client2])
-
-
-def test_many_publish_one_subscribe():
-    server1 = create_server('server1', '127.0.0.1', 0, zmq.PUB)
-    server2 = create_server('server2', '127.0.0.1', 0, zmq.PUB)
-    client = create_client('client', [server1.host, server2.host],
-                           [server1.port, server2.port], zmq.SUB)
-    # The SUB client seems to take longer to connect and results in dropped
-    # messages.
-    time.sleep(1)
-
-    data1 = b'Hello'
-    data2 = b'World'
-    server1.send(data=data1, timeout=TIMEOUT)
-    recv1 = client.receive(timeout=TIMEOUT)
-    server2.send(data=data2, timeout=TIMEOUT)
-    recv2 = client.receive(timeout=TIMEOUT)
-    assert data1 == recv1
-    assert data2 == recv2
-
-    stop_devices([server1, server2, client])
-
-
-def test_push_pull():
-    server_client_logic(server_message_pattern=zmq.PUSH,
-                        client_message_pattern=zmq.PULL)
-
-
-def test_many_push_one_pull():
-    server1 = create_server('server1', '127.0.0.1', 0, zmq.PUSH)
-    server2 = create_server('server2', '127.0.0.1', 0, zmq.PUSH)
-    client = create_client('client', [server1.host, server2.host],
-                           [server1.port, server2.port], zmq.PULL)
-    time.sleep(1)
-
-    data1 = b'Hello'
-    data2 = b'World'
-    server1.send(data=data1, timeout=TIMEOUT)
-    recv1 = client.receive(timeout=TIMEOUT)
-    server2.send(data=data2, timeout=TIMEOUT)
-    recv2 = client.receive(timeout=TIMEOUT)
-    assert data1 == recv1
-    assert data2 == recv2
-
-    stop_devices([server1, server2, client])
-
-
-def test_message_pattern_type():
-    server_args = {'name':'server',
-                   'host':'localhost',
-                   'port':0}
-    pytest.raises(SchemaError, ZMQServer,
-                  kwargs=dict(server_args, **{'message_pattern':zmq.REQ}))
-    pytest.raises(SchemaError, ZMQServer,
-                  kwargs=dict(server_args, **{'message_pattern':zmq.SUB}))
-    pytest.raises(SchemaError, ZMQServer,
-                  kwargs=dict(server_args, **{'message_pattern':zmq.PULL}))
-    client_args = {'name':'client',
-                   'hosts':['localhost'],
-                   'ports':[0],
-                   'connect_at_start':False}
-    pytest.raises(SchemaError, ZMQClient,
-                  kwargs=dict(client_args, **{'message_pattern':zmq.REP}))
-    pytest.raises(SchemaError, ZMQClient,
-                  kwargs=dict(client_args, **{'message_pattern':zmq.PUB}))
-    pytest.raises(SchemaError, ZMQClient,
-                  kwargs=dict(client_args, **{'message_pattern':zmq.PUSH}))
-
-
-def test_subscribe():
-    server = create_server('server', '127.0.0.1', 0, zmq.PUB)
-    client = create_client('client', [server.host], [server.port], zmq.SUB)
-    client.unsubscribe(b'')
-    client.subscribe(b'Hello')
-    time.sleep(1)
-
-    data1 = b'Hello World'
-    data2 = b'random message'
-    server.send(data= data1, timeout=TIMEOUT)
-    recv = client.receive(timeout=TIMEOUT)
-    assert data1 == recv
-    server.send(data=data2, timeout=TIMEOUT)
-    with pytest.raises(TimeoutException):
-        client.receive(timeout=0.2)
-
-    stop_devices([server, client])
-
-
-def test_flush():
-    server = create_server('server', '127.0.0.1', 0, zmq.PAIR)
-    client = create_client('client', [server.host], [server.port], zmq.PAIR)
-
-    client.send(data=b'Hello World', timeout=TIMEOUT)
-    server.receive(timeout=TIMEOUT)
-    server.send(data=b'Hello client', timeout=TIMEOUT)
-    client.flush()
-
-    with pytest.raises(TimeoutException):
-        client.receive(timeout=0.2)
-
-    stop_devices([server, client])


### PR DESCRIPTION
* Update driver UTs to use a unique temporary runpath to avoid clashing with other tests running on the same server
* Use fixtures in driver UTs for common test setup/teardown
* Close open log files when drivers stop