### PR TITLE
Simplify Config Option propagation design.

### DIFF
--- a/doc/en/design.rst
+++ b/doc/en/design.rst
@@ -36,13 +36,11 @@ default values or user input with \*\*options after performing a validation stag
 Config objects can inherit other Config objects and alter or define additional
 ConfigOption items:
 
-  * Config instances may have parent references that are used to retrieve a
+  * Config instances may have container references that are used to retrieve a
     config option value if this is not present in the current config.
     The ``__getattr__`` method in :py:class:`~testplan.common.config.base.Config`
-    contains the rules on whether current or parent config option will be used.
-  * ``block_propagation=True`` prevents retrieving the config option from the
-    parent.
-
+    contains the rules on whether current or container config option will be
+    used.
 
 Entity
 ``````

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ REQUIRED = [
     'psutil',
     'six',
     'future',
-    'schema',
+    'schema==0.6.6',
     'pytz',
     'lxml',
     'python-dateutil',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ REQUIRED = [
     'psutil',
     'six',
     'future',
-    'schema==0.6.6',
+    'schema<0.7.0',
     'pytz',
     'lxml',
     'python-dateutil',

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -338,7 +338,7 @@ class EntityConfig(Config):
     def get_options(cls):
         """Config options for base Entity class."""
         return {
-            ConfigOption('runpath',): Or(None, str, lambda x: callable(x)),
+            ConfigOption('runpath',): Or(None, str, callable),
             ConfigOption('initial_context', default={}): dict,
             ConfigOption('path_cleanup', default=False): bool,
             ConfigOption('status_wait_timeout', default=600): int,

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -338,9 +338,7 @@ class EntityConfig(Config):
     def get_options(cls):
         """Config options for base Entity class."""
         return {
-            ConfigOption(
-                'runpath', default=None,
-                block_propagation=False): Or(None, str, lambda x: callable(x)),
+            ConfigOption('runpath',): Or(None, str, lambda x: callable(x)),
             ConfigOption('initial_context', default={}): dict,
             ConfigOption('path_cleanup', default=False): bool,
             ConfigOption('status_wait_timeout', default=600): int,
@@ -507,7 +505,8 @@ class Entity(logger.Loggable):
         if self.parent and self.parent.runpath:
             return os.path.join(self.parent.runpath, self.uid())
 
-        runpath = self.cfg.runpath
+        runpath = getattr(self.cfg, 'runpath', None)
+
         if runpath:
             return self.cfg.runpath(self) if callable(runpath) else runpath
         else:

--- a/testplan/exporters/testing/base.py
+++ b/testplan/exporters/testing/base.py
@@ -20,10 +20,8 @@ class TagFilteredExporterConfig(ExporterConfig):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption('report_tags', default=[],
-                block_propagation=False): [Use(tagging.validate_tag_value)],
-            ConfigOption('report_tags_all', default=[],
-                block_propagation=False): [Use(tagging.validate_tag_value)]
+            ConfigOption('report_tags'): [Use(tagging.validate_tag_value)],
+            ConfigOption('report_tags_all'): [Use(tagging.validate_tag_value)]
         }
 
 

--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -23,9 +23,7 @@ class JSONExporterConfig(ExporterConfig):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption(
-                'json_path', default=defaults.JSON_PATH,
-                block_propagation=False): str
+            ConfigOption('json_path'): str
         }
 
 

--- a/testplan/exporters/testing/pdf/__init__.py
+++ b/testplan/exporters/testing/pdf/__init__.py
@@ -147,9 +147,7 @@ class BasePDFExporterConfig(ExporterConfig):
     def get_options(cls):
         return {
             ConfigOption('timestamp', default=None): Or(str, None),
-            ConfigOption(
-                'pdf_style', default=defaults.PDF_STYLE,
-                block_propagation=False): Style
+            ConfigOption('pdf_style'): Style
         }
 
 
@@ -159,9 +157,7 @@ class PDFExporterConfig(BasePDFExporterConfig):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption(
-                'pdf_path', default=defaults.PDF_PATH,
-                block_propagation=False): str
+            ConfigOption('pdf_path'): str
         }
 
 
@@ -173,9 +169,7 @@ class TagFilteredPDFExporterConfig(
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption(
-                'report_dir', default=defaults.REPORT_DIR,
-                block_propagation=False): str
+            ConfigOption('report_dir'): str
         }
 
 

--- a/testplan/exporters/testing/xml/__init__.py
+++ b/testplan/exporters/testing/xml/__init__.py
@@ -216,9 +216,7 @@ class XMLExporterConfig(ExporterConfig):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption(
-                'xml_dir', default=defaults.XML_DIR,
-                block_propagation=False): str
+            ConfigOption('xml_dir'): str
         }
 
 

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -99,8 +99,9 @@ class TestRunnerConfig(RunnableConfig):
             ConfigOption('logger_level', default=logger.TEST_INFO): int,
             ConfigOption('file_log_level', default=logger.DEBUG): Or(int, None),
             ConfigOption(
-                'runpath', default=default_runpath,
-                block_propagation=False): Or(None, str, lambda x: callable(x)),
+                'runpath',
+                default=default_runpath,
+                ): Or(None, str, lambda x: callable(x)),
             ConfigOption('path_cleanup', default=True): bool,
             ConfigOption('all_tasks_local', default=False): bool,
             ConfigOption('shuffle', default=[]): list, # list of string choices
@@ -109,47 +110,32 @@ class TestRunnerConfig(RunnableConfig):
             ConfigOption(
                 'exporters', default=None): Use(get_exporters),
             ConfigOption(
-                'stdout_style', default=defaults.STDOUT_STYLE,
-                block_propagation=False): Style,
+                'stdout_style', default=defaults.STDOUT_STYLE,): Style,
             ConfigOption(
-                'report_dir', default=defaults.REPORT_DIR,
-                block_propagation=False): str,
-            ConfigOption(
-                'xml_dir', default=None,
-                block_propagation=False): Or(str, None),
-            ConfigOption(
-                'pdf_path', default=None,
-                block_propagation=False): Or(str, None),
-            ConfigOption(
-                'json_path', default=None,
-                block_propagation=False): Or(str, None),
-            ConfigOption(
-                'pdf_style', default=defaults.PDF_STYLE,
-                block_propagation=False): Style,
-            ConfigOption('report_tags', default=[],
-                block_propagation=False): [Use(tagging.validate_tag_value)],
-            ConfigOption('report_tags_all', default=[],
-                block_propagation=False): [Use(tagging.validate_tag_value)],
+                'report_dir', default=defaults.REPORT_DIR,): str,
+            ConfigOption('xml_dir', default=None,): Or(str, None),
+            ConfigOption('pdf_path', default=None,): Or(str, None),
+            ConfigOption('json_path', default=None,): Or(str, None),
+            ConfigOption('pdf_style', default=defaults.PDF_STYLE,): Style,
+            ConfigOption('report_tags', default=[]
+                         ): [Use(tagging.validate_tag_value)],
+            ConfigOption('report_tags_all', default=[]
+                         ): [Use(tagging.validate_tag_value)],
             ConfigOption('merge_scheduled_parts', default=False): bool,
             ConfigOption('browse', default=None): Or(None, bool),
             ConfigOption('ui_port', default=None): Or(None, int),
             ConfigOption('web_server_startup_timeout',
                          default=defaults.WEB_SERVER_TIMEOUT): int,
-            ConfigOption(
-                'test_filter', default=filtering.Filter(),
-                block_propagation=False): filtering.BaseFilter,
-            ConfigOption(
-                'test_sorter', default=ordering.NoopSorter(),
-                block_propagation=False): ordering.BaseSorter,
+            ConfigOption('test_filter', default=filtering.Filter()
+                        ): filtering.BaseFilter,
+            ConfigOption('test_sorter', default=ordering.NoopSorter()
+                         ): ordering.BaseSorter,
             # Test lister is None by default, otherwise Testplan would
             # list tests, not run them
-            ConfigOption(
-                'test_lister', default=None,
-                block_propagation=False):Or(None, listing.BaseLister),
-            ConfigOption(
-                'verbose', default=False, block_propagation=False): bool,
-            ConfigOption(
-                'debug', default=False, block_propagation=False): bool,
+            ConfigOption('test_lister', default=None
+                         ):Or(None, listing.BaseLister),
+            ConfigOption('verbose', default=False): bool,
+            ConfigOption('debug', default=False): bool,
             ConfigOption(
                 'timeout', default=None): Or(
                 None, And(Or(int, float), lambda t: t >= 0)),

--- a/testplan/runners/local.py
+++ b/testplan/runners/local.py
@@ -30,6 +30,10 @@ class LocalRunner(Executor):
         # run.
         if isinstance(target, tasks.Task):
             runnable = target.materialize()
+            if not runnable.parent:
+                runnable.parent = self
+            if not runnable.cfg.parent:
+                runnable.cfg.parent = self.cfg
         elif isinstance(target, entity.Runnable):
             runnable = target
         else:

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -356,11 +356,7 @@ class Pool(Executor):
         cfg = self.cfg
 
         while cfg:
-            try:
-                options.append(cfg.denormalize())
-            except Exception as exc:
-                self.logger.error('Could not denormalize: {} - {}'.format(
-                    cfg, exc))
+            options.append(cfg.denormalize())
             cfg = cfg.parent
 
         worker.respond(response.make(Message.ConfigSending,

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -7,7 +7,6 @@ import six
 from lxml import objectify
 from schema import Or, Use, And
 
-from testplan import defaults
 from testplan.common.config import ConfigOption, validate_func
 
 from testplan.testing import filtering, ordering, tagging
@@ -90,21 +89,9 @@ class TestConfig(RunnableConfig):
             ConfigOption('after_start', default=None): start_stop_signature,
             ConfigOption('before_stop', default=None): start_stop_signature,
             ConfigOption('after_stop', default=None): start_stop_signature,
-            ConfigOption(
-                'test_filter',
-                default=filtering.Filter(),
-                block_propagation=False
-            ): filtering.BaseFilter,
-            ConfigOption(
-                'test_sorter',
-                default=ordering.NoopSorter(),
-                block_propagation=False
-            ): ordering.BaseSorter,
-            ConfigOption(
-                'stdout_style',
-                default=defaults.STDOUT_STYLE,
-                block_propagation=False
-            ): test_styles.Style,
+            ConfigOption('test_filter'): filtering.BaseFilter,
+            ConfigOption('test_sorter'): ordering.BaseSorter,
+            ConfigOption('stdout_style'): test_styles.Style,
             ConfigOption(
                 'tags',
                 default=None

--- a/tests/functional/exporters/testing/test_pdf.py
+++ b/tests/functional/exporters/testing/test_pdf.py
@@ -5,7 +5,7 @@ from testplan.testing.multitest import MultiTest, testsuite, testcase
 from testplan.testing.multitest.entries import base
 from testplan.testing.multitest.entries.schemas.base import registry
 
-from testplan import Testplan
+from testplan import Testplan, defaults
 from testplan.common.utils.testing import (
     log_propagation_disabled, argv_overridden
 )
@@ -114,6 +114,7 @@ def test_tag_filtered_pdf(tmpdir):
 
     exporter = TagFilteredPDFExporter(
         report_dir=pdf_dir,
+        pdf_style=defaults.PDF_STYLE,
         report_tags=[
             'foo',
             'baz',  # this should be skipped

--- a/tests/functional/testplan/runners/pools/test_pool_process.py
+++ b/tests/functional/testplan/runners/pools/test_pool_process.py
@@ -247,8 +247,8 @@ def test_serialization():
     plan.add_resource(pool)
     plan.schedule(target='make_serialization_mtest',
                   module='test_pool_process',
-                  path=os.path.dirname(__file__))
-
+                  path=os.path.dirname(__file__),
+                  resource='ProcPool')
     res = plan.run()
     assert res.success
 

--- a/tests/functional/testplan/runners/pools/test_runner_e2e.py
+++ b/tests/functional/testplan/runners/pools/test_runner_e2e.py
@@ -157,7 +157,7 @@ def test_process_pool_integration(
         parse_cmdline=False,
         exporters=[
             PDFExporter(pdf_path=pdf_path)
-        ]
+        ],
     )
     plan.add_resource(pool)
 

--- a/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -21,15 +21,6 @@ from testplan.testing.multitest.driver.tcp import TCPServer, TCPClient
 from testplan.common.utils.logger import TESTPLAN_LOGGER
 
 
-CUSTOM_RUNPATH = os.path.join(tempfile.gettempdir(),
-                              getpass.getuser(),
-                              'test_multitest_drivers_runpath')
-
-def runpath_maker(_):
-    """Return a custom runpath location."""
-    return CUSTOM_RUNPATH
-
-
 @testsuite
 class MySuite(object):
 
@@ -84,10 +75,10 @@ class MySuite(object):
         assert env is env.client.context
 
 
-def test_multitest_drivers():
+def test_multitest_drivers(runpath):
     """TODO."""
     for idx, opts in enumerate(
-          (dict(name='Mtest', suites=[MySuite()], runpath=runpath_maker),
+          (dict(name='Mtest', suites=[MySuite()], runpath=runpath),
            dict(name='Mtest', suites=[MySuite()]))):
         server = TCPServer(name='server')
         client = TCPClient(name='client',
@@ -105,7 +96,7 @@ def test_multitest_drivers():
         res = mtest.result
         assert res.run is True
         if idx == 0:
-            assert mtest.runpath == runpath_maker(None)
+            assert mtest.runpath == runpath
         else:
             assert mtest.runpath == default_runpath(mtest)
         assert server.runpath == os.path.join(mtest.runpath, server.uid())
@@ -114,10 +105,10 @@ def test_multitest_drivers():
         assert client.status.tag == ResourceStatus.STOPPED
 
 
-def test_multitest_drivers_in_testplan():
+def test_multitest_drivers_in_testplan(runpath):
     """TODO."""
     for idx, opts in enumerate(
-          (dict(name='MyPlan', parse_cmdline=False, runpath=runpath_maker),
+          (dict(name='MyPlan', parse_cmdline=False, runpath=runpath),
            dict(name='MyPlan', parse_cmdline=False))):
         plan = Testplan(**opts)
         server = TCPServer(name='server')
@@ -140,7 +131,7 @@ def test_multitest_drivers_in_testplan():
         res = plan.result
         assert res.run is True
         if idx == 0:
-            assert plan.runpath == runpath_maker(None)
+            assert plan.runpath == runpath
         else:
             assert plan.runpath == default_runpath(plan._runnable)
         assert mtest.runpath == os.path.join(plan.runpath, mtest.uid())

--- a/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -2,11 +2,15 @@
 
 import os
 import re
+import getpass
 import tempfile
+
+from testplan.testing.filtering import Filter
+from testplan.testing.ordering import NoopSorter
 
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 
-from testplan import Testplan
+from testplan import Testplan, defaults
 from testplan.common.entity.base import Environment, ResourceStatus
 from testplan.common.utils.context import context
 from testplan.common.utils.path import StdFiles, default_runpath
@@ -18,6 +22,7 @@ from testplan.common.utils.logger import TESTPLAN_LOGGER
 
 
 CUSTOM_RUNPATH = os.path.join(tempfile.gettempdir(),
+                              getpass.getuser(),
                               'test_multitest_drivers_runpath')
 
 def runpath_maker(_):
@@ -89,7 +94,10 @@ def test_multitest_drivers():
                            host=context(server.cfg.name, '{{host}}'),
                            port=context(server.cfg.name, '{{port}}'))
         opts.update(environment=[server, client],
-                    initial_context={'test_key': 'test_value'})
+                    initial_context={'test_key': 'test_value'},
+                    stdout_style=defaults.STDOUT_STYLE,
+                    test_filter=Filter(),
+                    test_sorter=NoopSorter())
         mtest = MultiTest(**opts)
         assert server.status.tag == ResourceStatus.NONE
         assert client.status.tag == ResourceStatus.NONE

--- a/tests/unit/testplan/common/config/test_generic_config.py
+++ b/tests/unit/testplan/common/config/test_generic_config.py
@@ -34,8 +34,8 @@ class Second(First):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption('a', default=6.0, block_propagation=False): float,
-            ConfigOption('c', default=9.0, block_propagation=False): float,
+            ConfigOption('a', default=6.0): float,
+            ConfigOption('c', default=9.0): float,
             ConfigOption('d'): lambda x: isinstance(x, (int, float))
         }
 
@@ -46,8 +46,7 @@ class Third(Second):
     def get_options(cls):
         return {
             ConfigOption(
-                'a', default=LambdaConfig(),
-                block_propagation=False): Config,
+                'a', default=LambdaConfig()): Config,
             ConfigOption('c', default=-1): lambda x: x < 0
         }
 
@@ -101,22 +100,16 @@ def test_config_inheritance():
     """Inheritance of config and schemas."""
     item = Second()
     assert (6.0, 2, 9.0) == (item.a, item.b, item.c)
-    assert item._options['a'].block_propagation == False
-    assert item._options['c'].block_propagation == False
 
     item = Second(a=5.0, b=4)
     assert (5.0, 4, 9.0) == (item.a, item.b, item.c)
-    assert item._options['c'].block_propagation == False
 
     item = Third()
     assert (0.5, 2, 2, -1) == (item.a.a, item.a.b, item.b, item.c)
     assert isinstance(item.a, LambdaConfig)
-    assert item._options['a'].block_propagation == False
-    assert item._options['c'].block_propagation == True
 
     item = Third(a=LambdaConfig(a=0.66, b=13), d=5)
     assert (0.66, 13, 2, 5) == (item.a.a, item.a.b, item.b, item.d)
-    assert item._options['c'].block_propagation == True
 
 
 class Root(Config):
@@ -125,7 +118,8 @@ class Root(Config):
     def get_options(cls):
         return {
             ConfigOption('foo', default=5): int,
-            ConfigOption('bar', default=3): int
+            ConfigOption('bar', default=3): int,
+            ConfigOption('xyz', default=1): int,
         }
 
 
@@ -134,8 +128,8 @@ class Branch(Config):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption('foo', default=50): int,
-            ConfigOption('bar', default=30, block_propagation=False): int,
+            ConfigOption('foo'): int,
+            ConfigOption('bar', default=30): int,
         }
 
 
@@ -144,94 +138,22 @@ class Leaf(Config):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption('foo', default=500, block_propagation=False): int,
-            ConfigOption('bar', default=300, block_propagation=False): int,
-            ConfigOption('baz', default='alpha'): str,
+            ConfigOption('foo'): int,
+            ConfigOption('xyz', default='100'): str,
         }
 
 
 def test_getattr_propagation():
     """
-        Attribute retrieval should try explicitly set (local)
-        values first (propagating from leaf to root), if nothing
-        is found it should try default values (also propagating from
-        leaf to root), but if attribute`block_propagation` of config option
-        is set to False, retrieve the value from parent class at first.
+        local set -> non-ABSENT default -> container(parent)
     """
     root = Root()
-    assert (root.foo, root.bar) == (5, 3)
+    assert (root.foo, root.bar, root.xyz) == (5, 3, 1)
 
     branch_1 = Branch()
-    # foo -> branch default, bar -> branch default
-    assert (branch_1.foo, branch_1.bar) == (50, 30)
-
     branch_1.parent = root
-    # foo -> branch default, bar -> root default
-    assert (branch_1.foo, branch_1.bar) == (50, 3)
-
-    branch_2 = Branch(foo=15)
-    # foo -> branch local, bar -> branch default
-    assert (branch_2.foo, branch_2.bar) == (15, 30)
-
-    branch_2.parent = root
-    # foo -> branch local, bar -> root default
-    assert (branch_2.foo, branch_2.bar) == (15, 3)
-
-    branch_3 = Branch(bar=40)
-    # foo -> branch default, bar -> branch local
-    assert (branch_3.foo, branch_3.bar) == (50, 40)
-
-    branch_3.parent = root
-    # foo -> branch default, bar -> branch local
-    assert (branch_3.foo, branch_3.bar) == (50, 40)
-
-    branch_4 = Branch(foo=123, bar=333)
-    # foo -> branch local, bar -> branch local
-    assert (branch_4.foo, branch_4.bar) == (123, 333)
-
-    branch_4.parent = root
-    # foo -> branch local, bar -> branch local
-    assert (branch_4.foo, branch_4.bar) == (123, 333)
+    assert (branch_1.foo, branch_1.bar, branch_1.xyz) == (5, 30, 1)
 
     leaf_1 = Leaf()
-    # foo -> leaf default, bar -> leaf default, baz -> leaf default
-    assert (leaf_1.foo, leaf_1.bar, leaf_1.baz) == (500, 300, 'alpha')
-
-    leaf_2 = Leaf(foo=111)
-    # foo -> leaf local, bar -> leaf default, baz -> leaf default
-    assert (leaf_2.foo, leaf_2.bar, leaf_2.baz) == (111, 300, 'alpha')
-
-    leaf_3 = Leaf(bar=222)
-    # foo -> leaf default, bar -> leaf local, baz -> leaf default
-    assert (leaf_3.foo, leaf_3.bar, leaf_3.baz) == (500, 222, 'alpha')
-
-    leaf_2.parent = branch_2
-    # foo -> leaf local, bar -> root default, baz -> leaf default
-    assert (leaf_2.foo, leaf_2.bar, leaf_2.baz) == (111, 3, 'alpha')
-
-    leaf_2 = Leaf(foo=111)
-    leaf_2.parent = branch_3
-    # foo -> leaf local, bar -> branch local, baz -> leaf default
-    assert (leaf_2.foo, leaf_2.bar, leaf_2.baz) == (111, 40, 'alpha')
-
-    leaf_3.parent = branch_2
-    # foo -> branch local, bar -> leaf local, baz -> leaf default
-    assert (leaf_3.foo, leaf_3.bar, leaf_3.baz) == (15, 222, 'alpha')
-
-    leaf_3 = Leaf(bar=222)
-    leaf_3.parent = branch_3
-    # foo -> branch default, bar -> leaf local, baz -> leaf default
-    assert (leaf_3.foo, leaf_3.bar, leaf_3.baz) == (50, 222, 'alpha')
-
-    leaf_4 = Leaf(baz='beta')
-    # foo -> leaf default, bar -> leaf default, baz -> leaf local
-    assert (leaf_4.foo, leaf_4.bar, leaf_4.baz) == (500, 300, 'beta')
-
-    leaf_4.parent = branch_2
-    # foo -> branch local, bar -> root default, baz -> leaf local
-    assert (leaf_4.foo, leaf_4.bar, leaf_4.baz) == (15, 3, 'beta')
-
-    leaf_4 = Leaf(baz='beta')
-    leaf_4.parent = branch_3
-    # foo -> branch default, bar -> branch local, baz -> leaf local
-    assert (leaf_4.foo, leaf_4.bar, leaf_4.baz) == (50, 40, 'beta')
+    leaf_1.parent = branch_1
+    assert (leaf_1.foo, leaf_1.bar, leaf_1.xyz) == (5, 30, '100')


### PR DESCRIPTION
- Remove the usage of block_propagation
- Remove the usage of DefaultValueWrapper
- For overlapping config options between container and entity class (e.g
  runpath, stdout_style, test_sorter, test_filter etc.), set default
  value to ABSENT for entity class
- A config option will take the these value in descending precendence:
        user specifed -> non-ABSENT default -> parent value