### PR TITLE
An example change of unfolding **options for public API classes

### DIFF
--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -21,5 +21,13 @@ html_theme = 'sphinx_rtd_theme'
 
 html_static_path = ['_static']
 
+
+# pylint: disable=unused-argument
+# def skip(app, what, name, obj, would_skip, options):
+#     if name == '__init__':
+#         return False
+#     return would_skip
+
 def setup(app):
     app.add_stylesheet('icon.css')
+    #app.connect('autodoc-skip-member', skip)

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -22,12 +22,5 @@ html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
 
 
-# pylint: disable=unused-argument
-# def skip(app, what, name, obj, would_skip, options):
-#     if name == '__init__':
-#         return False
-#     return would_skip
-
 def setup(app):
     app.add_stylesheet('icon.css')
-    #app.connect('autodoc-skip-member', skip)

--- a/examples/ExecutionPools/Process/test_plan.py
+++ b/examples/ExecutionPools/Process/test_plan.py
@@ -3,7 +3,6 @@
 This example is to demonstrate parallel test execution in a process pool.
 """
 
-import os
 import sys
 
 from testplan import test_plan, Task

--- a/testplan/base.py
+++ b/testplan/base.py
@@ -1,14 +1,21 @@
 """Testplan base module."""
 
+import signal
+import random
+
+from testplan import defaults
 from testplan.runnable import TestRunnerConfig, TestRunnerResult, TestRunner
+from .common.utils import logger
 from .common.config import ConfigOption
 from .common.entity import (RunnableManager, RunnableManagerConfig, Resource)
 from .common.utils.callable import arity
 from .common.utils.validation import is_subclass, has_method
+from .common.utils.path import default_runpath
 from .parser import TestplanParser
 from .runners import LocalRunner
+from .runnable.interactive import TestRunnerIHandler
 from .environment import Environments
-
+from .testing import filtering, ordering
 
 class TestplanConfig(RunnableManagerConfig, TestRunnerConfig):
     """
@@ -150,13 +157,127 @@ class Testplan(RunnableManager):
         return result
 
     @classmethod
-    def main_wrapper(cls, **options):
-        """
+    def main_wrapper(cls,
+        name,
+        description=None,
+        parse_cmdline=True,
+        interactive=False,
+        port=None,
+        abort_signals=None,
+        logger_level=logger.TEST_INFO,
+        file_log_level=logger.DEBUG,
+        runpath=None,
+        path_cleanup=True,
+        all_tasks_local=False,
+        shuffle=None,
+        shuffle_seed=float(random.randint(1, 9999)),
+        exporters=None,
+        stdout_style=None,
+        report_dir=None,
+        xml_dir=None,
+        pdf_path=None,
+        json_path=None,
+        pdf_style=None,
+        report_tags=None,
+        report_tags_all=None,
+        merge_scheduled_parts=False,
+        browse=None,
+        ui_port=None,
+        web_server_startup_timeout=defaults.WEB_SERVER_TIMEOUT,
+        test_filter=None,
+        test_sorter=None,
+        test_lister=None,
+        verbose=None,
+        debug=None,
+        timeout=None,
+        interactive_handler=TestRunnerIHandler,
+        extra_deps=None,
+        **options
+    ):
+        r"""
         Decorator that will be used for wrapping `main` methods in test scripts.
 
         It accepts all arguments of a
         :py:class:`~testplan.base.Testplan` entity.
+
+        :param name: Name of test plan.
+        :type name: ``str``
+        :param description: Description of test plan.
+        :type description: ``str``
+        :param parse_cmdline: Parse command lne arguments.
+        :type parse_cmdline: ``bool``
+        :param interactive: Enable interactive execution mode.
+        :type interactive: ``bool``
+        :param port: Port for interactive mode.
+        :type port: ``bool``
+        :param abort_signals: Signals to catch and trigger abort.
+        :type abort_signals: ``list`` of signals
+        :param logger_level: Logger level for stdout.
+        :type logger_level: ``int``
+        :param: file_log_level: Logger level for file.
+        :type file_log_level: ``int``
+        :param runpath: Input runpath.
+        :type runpath: ``str`` or ``callable``
+        :param path_cleanup: Clean previous runpath entries.
+        :type path_cleanup: ``bool``
+        :param all_tasks_local: All tasks are scheduled in local pool.
+        :type all_tasks_local: ``bool``
+        :param shuffle: Shuffle strategy.
+        :type shuffle: ``list`` of ``str``
+        :param shuffle_seed: Shuffle seed.
+        :type shuffle_seed: ``float``
+        :param exporters: Exporters for reports creation.
+        :type exporters: ``list``
+        :param stdout_style: Styling output options.
+        :type stdout_style:
+            :py:class:`Style <testplan.report.testing.styles.Style>`
+        :param report_dir: Report directory.
+        :type report_dir: ``str``
+        :param xml_dir: XML output directory.
+        :type xml_dir: ``str``
+        :param pdf_path: PDF output path <PATH>/\*.pdf.
+        :type pdf_path: ``str``
+        :param json_path: JSON output path <PATH>/\*.json.
+        :type json_path: ``str``
+        :param pdf_style: PDF creation styling options.
+        :type pdf_style:
+            :py:class:`Style <testplan.report.testing.styles.Style>`
+        :param report_tags: Matches tests marked with any of the given tags.
+        :type report_tags: ``list``
+        :param report_tags_all: Match tests marked with all of the given tags.
+        :type report_tags_all: ``list``
+        :param merge_scheduled_parts: Merge reports of scheduled MultiTest
+            parts.
+        :type merge_scheduled_parts: ``bool``
+        :param browse: Open web browser to display the test report.
+        :type browse: ``bool`` or ``NoneType``
+        :param ui_port: Port of web server for displaying test report.
+        :type ui_port: ``int`` or ``NoneType``
+        :param web_server_startup_timeout: Timeout for starting web server.
+        :type web_server_startup_timeout: ``int``
+        :param test_filter: Tests filtering class.
+        :type test_filter: Subclass of
+            :py:class:`BaseFilter <testplan.testing.filtering.BaseFilter>`
+        :param test_sorter: Tests sorting class.
+        :type test_sorter: Subclass of
+            :py:class:`BaseSorter <testplan.testing.ordering.BaseSorter>`
+        :param test_lister: Tests listing class.
+        :type test_lister: Subclass of
+            :py:class:`BaseLister <testplan.testing.listing.BaseLister>`
+        :param verbose: Enable or disable verbose mode.
+        :type verbose: ``bool``
+        :param debug: Enable or disable debug mode.
+        :type debug: ``bool``
+        :param timeout: Timeout value for test execution.
+        :type timeout: ``NoneType`` or ``int`` or ``float`` greater than 0.
+        :param interactive_handler: Handler for interactive mode execution.
+        :type interactive_handler: Subclass of :py:class:
+            `TestRunnerIHandler <testplan.runnable.interactive.TestRunnerIHandler>`  # pylint: disable=line-too-long
+        :param extra_deps: Extra module dependencies for interactive reload.
+        :type extra_deps: ``list`` of ``module``
         """
+        options.update(cls.filter_locals(locals()))
+
         def test_plan_inner(definition):
             """
             This is being passed the user-defined testplan entry point.

--- a/testplan/base.py
+++ b/testplan/base.py
@@ -194,7 +194,7 @@ class Testplan(RunnableManager):
         extra_deps=None,
         **options
     ):
-        r"""
+        """
         Decorator that will be used for wrapping `main` methods in test scripts.
 
         It accepts all arguments of a
@@ -220,7 +220,7 @@ class Testplan(RunnableManager):
         :type runpath: ``str`` or ``callable``
         :param path_cleanup: Clean previous runpath entries.
         :type path_cleanup: ``bool``
-        :param all_tasks_local: All tasks are scheduled in local pool.
+        :param all_tasks_local: Schedule all tasks in local pool.
         :type all_tasks_local: ``bool``
         :param shuffle: Shuffle strategy.
         :type shuffle: ``list`` of ``str``

--- a/testplan/common/config/base.py
+++ b/testplan/common/config/base.py
@@ -10,6 +10,8 @@ from schema import Schema, Optional, And, Or, Use
 from testplan.common.utils.interface import check_signature
 from testplan.common.utils import logger
 
+# A sentinel object meaning not defined, it is useful when you need to
+# handle arbitrary objects (including None).
 ABSENT = Optional._MARKER
 
 
@@ -96,7 +98,7 @@ class Config(object):
     def __init__(self, **options):
         self._parent = None
         self._cfg_input = options
-        self._options = self.build_schema().validate(options)
+        self._options = self.build_schema().validate(self._cfg_input)
 
     def __getattr__(self, name):
         options = self.__getattribute__('_options')
@@ -169,7 +171,7 @@ class Config(object):
         parents = [
             p for p in inspect.getmro(cls)[1:]
             if issubclass(p, Config) and p != Config
-            ]
+        ]
 
         for p in parents:
             update_options(target=config_options, source=p.get_options())

--- a/testplan/common/config/base.py
+++ b/testplan/common/config/base.py
@@ -98,7 +98,7 @@ class Config(object):
     def __init__(self, **options):
         self._parent = None
         self._cfg_input = options
-        self._options = self.build_schema().validate(self._cfg_input)
+        self._options = self.build_schema().validate(options)
 
     def __getattr__(self, name):
         options = self.__getattribute__('_options')

--- a/testplan/common/exporters/__init__.py
+++ b/testplan/common/exporters/__init__.py
@@ -28,7 +28,10 @@ class ExporterResult(object):
 
 
 class ExporterConfig(Config):
-
+    """
+    Configuration object for
+    :py:class:`BaseExporter <testplan.common.exporters.BaseExporter>` object.
+    """
     @classmethod
     def get_options(cls):
         return {}

--- a/testplan/common/exporters/pdf.py
+++ b/testplan/common/exporters/pdf.py
@@ -669,6 +669,7 @@ class RowData(object):
         :param style: Style context for the given content.
         :type style: ``RowStyle`` or ``list`` of ``RowStyle``
         :return: ``None``
+        :rtype: ``NoneType``
         """
         if isinstance(content, six.string_types):
             content = [content] + [''] * (self.num_columns - 1)

--- a/testplan/common/report/schemas.py
+++ b/testplan/common/report/schemas.py
@@ -28,7 +28,7 @@ class ReportLogSchema(Schema):
 
 
 class ReportSchema(schemas.TreeNodeSchema):
-    """Schema for ``base.Report``"""
+    """Schema for ``base.Report``."""
 
     source_class = Report
 
@@ -49,7 +49,7 @@ class ReportSchema(schemas.TreeNodeSchema):
 
 
 class ReportGroupSchema(ReportSchema):
-    """Schema for ``base.ReportGroup``"""
+    """Schema for ``base.ReportGroup``."""
 
     source_class = ReportGroup
 

--- a/testplan/common/serialization/fields.py
+++ b/testplan/common/serialization/fields.py
@@ -1,5 +1,5 @@
 """
-  Custom marshmallow fields.
+Custom marshmallow fields.
 """
 import pprint
 import six
@@ -74,8 +74,8 @@ def native_or_pformat(value):
 
 def native_or_pformat_dict(value):
     """
-        Converter utility for dictionaries,
-        converts values to JSON friendly format
+    Converter utility for dictionaries,
+    converts values to JSON friendly format
     """
     return {
         k: native_or_pformat(v) for k, v in value.items()
@@ -89,13 +89,13 @@ def native_or_pformat_list(value):
 
 class Unicode(fields.Field):
     """
-        Field that tries to convert value into a unicode
+    Field that tries to convert value into a unicode
 
-        object with the given codecs. Marshmallow internally decodes to
-        utf-8 encoding, however it fails on Python 2 for str values
-        like ``@t\xe9\xa7t\xfel\xe5\xf1``.
+    object with the given codecs. Marshmallow internally decodes to
+    utf-8 encoding, however it fails on Python 2 for str values
+    like ``@t\xe9\xa7t\xfel\xe5\xf1``.
 
-        So we have this field with explicit codecs instead.
+    So we have this field with explicit codecs instead.
     """
 
     codecs = ['utf-8', 'latin-1']  # Ideally we will let users override this
@@ -120,8 +120,8 @@ class Unicode(fields.Field):
 
 class NativeOrPretty(fields.Field):
     """
-        Uses serialization compatible native values
-        or pretty formatted str representation.
+    Uses serialization compatible native values
+    or pretty formatted str representation.
     """
 
     def _serialize(self, value, attr, obj):
@@ -130,9 +130,9 @@ class NativeOrPretty(fields.Field):
 
 class NativeOrPrettyDict(fields.Field):
     """
-      Dictionary serialization with native or pretty formatted values.
-      Keys should be JSON serializable (str type),
-      should be used for flat dicts only.
+    Dictionary serialization with native or pretty formatted values.
+    Keys should be JSON serializable (str type),
+    should be used for flat dicts only.
     """
     def _serialize(self, value, attr, obj):
         if not isinstance(value, dict):
@@ -226,17 +226,17 @@ class DictMatch(fields.Field):
 
 class GenericNested(fields.Field):
     """
-      Marshmallow does not support multiple schemas
-      for a single `Nested` field.
+    Marshmallow does not support multiple schemas
+    for a single `Nested` field.
 
-      There is a project (marshmallow-oneofschema)
-      that has similar functionality but it doesn't support
-      self-referencing schemas, which is
-      needed for serializing tree structures.
+    There is a project (marshmallow-oneofschema)
+    that has similar functionality but it doesn't support
+    self-referencing schemas, which is
+    needed for serializing tree structures.
 
-      This field should be used along with `ClassNameField`
-      to return the type (class name) of the objects,
-      so it can choose the correct schema during deserialization.
+    This field should be used along with `ClassNameField`
+    to return the type (class name) of the objects,
+    so it can choose the correct schema during deserialization.
     """
 
     def __init__(
@@ -320,19 +320,19 @@ class GenericNested(fields.Field):
 
 class UTCDateTime(fields.DateTime):
     """
-      While parsing timestamps, original `fields.Datetime` tries
-      to use ``dateutil`` if it's available.
+    While parsing timestamps, original `fields.Datetime` tries
+    to use ``dateutil`` if it's available.
 
-      Unfortunately, the way it does the check for ``dateutil``
-      availability is not compatible with our internal environment
+    Unfortunately, the way it does the check for ``dateutil``
+    availability is not compatible with our internal environment
 
-      If the ``dateutil`` is not available, it falls back to
-      ``datetime.datetime.strptime`` which leaves the
-      millisecond information out.
+    If the ``dateutil`` is not available, it falls back to
+    ``datetime.datetime.strptime`` which leaves the
+    millisecond information out.
 
-      So we specify the deserialization logic explicitly to
-      make use of dateutil. In addition we use ``pytz``
-      timezones instead of ``dateutil.tz``.
+    So we specify the deserialization logic explicitly to
+    make use of dateutil. In addition we use ``pytz``
+    timezones instead of ``dateutil.tz``.
     """
 
     def _deserialize(self, value, attr, data):

--- a/testplan/common/serialization/schemas.py
+++ b/testplan/common/serialization/schemas.py
@@ -13,9 +13,9 @@ def load_tree_data(
     type_field='type',
 ):
     """
-      marshmallow does not support tree serialization with different
-      node types, so we rely on this recursive function for traversing
-      tree data and instantiate node objects with the given schemas..
+    marshmallow does not support tree serialization with different
+    node types, so we rely on this recursive function for traversing
+    tree data and instantiate node objects with the given schemas.
     """
 
     node_type = node_schema.get_source_class().__name__

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -20,10 +20,10 @@ def is_regex(obj):
 
 def basic_compare(first, second, strict=False):
     """
-        Comparison used for custom match functions,
-        can do pattern matching, function evaluation or simple equality.
+    Comparison used for custom match functions,
+    can do pattern matching, function evaluation or simple equality.
 
-        Returns traceback if something goes wrong.
+    Returns traceback if something goes wrong.
     """
     try:
         if is_regex(second):
@@ -46,8 +46,8 @@ def is_comparator(value):
 
 def check_dict_keys(data, has_keys=None, absent_keys=None):
     """
-        Check if a dictionary contains given
-        keys and/or has given keys missing.
+    Check if a dictionary contains given
+    keys and/or has given keys missing.
     """
 
     if not (has_keys or absent_keys):
@@ -66,10 +66,10 @@ def check_dict_keys(data, has_keys=None, absent_keys=None):
 
 class Callable(object):
     """
-        Some of our assertions can make use of callables that accept a
-        single argument as comparator values. We also provide the helper
-        classes below that are composable (via bitwise operators
-        or meta callables) and reporting friendly.
+    Some of our assertions can make use of callables that accept a
+    single argument as comparator values. We also provide the helper
+    classes below that are composable (via bitwise operators
+    or meta callables) and reporting friendly.
     """
 
     def __call__(self, value):
@@ -1114,7 +1114,7 @@ class DictmatchAllResult(object):
 
       - ``passed``: a boolean indicating if the assertion passed completely
       - ``index_match_levels``: a list containing tuples of
-            index and match level:
+        index and match level:
 
         - ``MATCH``
         - ``MISMATCH``

--- a/testplan/common/utils/interface.py
+++ b/testplan/common/utils/interface.py
@@ -21,6 +21,8 @@ class MethodSignature(object):
         :type varargs: ``Optional[str]``
         :param keywords: name of ** parameter
         :type keywords: ``Optional[str]``
+        :param defaults: default arguments.
+        :type defaults: ``list`` or ``NoneType``
         """
         self.name = name
         self.args = args

--- a/testplan/common/utils/match.py
+++ b/testplan/common/utils/match.py
@@ -4,7 +4,6 @@ Module of utility types and functions that perform matching.
 import os
 import time
 import re
-
 import six
 
 from . import timing
@@ -68,7 +67,7 @@ class LogMatcher(logger.Loggable):
         If the mark is None sets current file position to beginning of file.
 
         :param mark: Name of the mark.
-        :type mark: ``str`` or ``None``
+        :type mark: ``str`` or ``NoneType``
         """
         if mark is None:
             self.position = 0

--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -220,8 +220,10 @@ def unique_name(name, names):
 
 def to_posix_path(from_path):
     """
-    :param: File path, in local OS format.
+    :param from_path: File path, in local OS format.
+    :type from_path: ``str``
     :return: POSIX-formatted path.
+    :rtype: ``str``
     """
     return '/'.join(from_path.split(os.sep))
 
@@ -231,8 +233,11 @@ def is_subdir(child, parent):
     Check whether "parent" is a sub-directory of "child".
 
     :param child: Child path.
+    :type child: ``str``
     :param parent: Parent directory to check against.
+    :type parent: ``str``
     :return: True if child is a sub-directory of the parent.
+    :rtype: ``bool``
     """
     return child.startswith(parent)
 

--- a/testplan/common/utils/reporting.py
+++ b/testplan/common/utils/reporting.py
@@ -1,6 +1,6 @@
 """
 This module contains utilities that are mostly used
- making assertion comparison data report friendly.
+to make assertion comparison data report friendly.
 """
 
 import six

--- a/testplan/common/utils/sockets/client.py
+++ b/testplan/common/utils/sockets/client.py
@@ -10,6 +10,7 @@ class Client(object):
     Connects to a server via the standard Session Protocol.
 
     To use this type:
+
         1. construct it
         2. connect
         3. send and/or receive
@@ -57,7 +58,6 @@ class Client(object):
 
         :param msg: Message to be sent.
         :type msg: ``bytes``
-
         :return: Timestamp when msg sent (in microseconds from epoch) and
                  number of bytes sent
         :rtype: ``tuple`` of ``long`` and ``int``
@@ -74,7 +74,6 @@ class Client(object):
         :type size: ``int``
         :param timeout: Timeout in seconds.
         :type timeout: ``int``
-
         :return: message received
         :rtype: ``bytes``
         """
@@ -97,7 +96,6 @@ class Client(object):
         :type bufsize: ``int``
         :param flags: Defaults to zero.
         :type flags: ``int``
-
         :return: message received
         :rtype: ``bytes``
         """

--- a/testplan/common/utils/sockets/fix/utils.py
+++ b/testplan/common/utils/sockets/fix/utils.py
@@ -7,7 +7,7 @@ DATEFORMAT = '%Y%m%d-%H:%M:%S.%f'
 
 def utc_timestamp():
     """
-    @return: a UTCTimestamp (see FIX spec)
-    @rtype: C{str}
+    :return: a UTCTimestamp (see FIX spec)
+    :rtype: ``str``
     """
     return datetime.datetime.utcnow().strftime(DATEFORMAT)

--- a/testplan/common/utils/sockets/message.py
+++ b/testplan/common/utils/sockets/message.py
@@ -15,7 +15,7 @@ class Message(object):
         :type data: ``str``
         :param codec: Codec object.
         :type codec: Subclass of
-          :py:class:`Codec <testplan.common.utils.sockets.codec.Codec>`.
+            :py:class:`Codec <testplan.common.utils.sockets.codec.Codec>`.
         """
         self.data = data
         self.codec = codec

--- a/testplan/common/utils/testing.py
+++ b/testplan/common/utils/testing.py
@@ -16,7 +16,6 @@ from ..report.base import Report, ReportGroup
 from ..utils.comparison import is_regex
 
 
-
 null_handler = logging.NullHandler()
 
 

--- a/testplan/environment.py
+++ b/testplan/environment.py
@@ -56,6 +56,9 @@ class LocalEnvironment(EnvironmentCreator):
 class Environments(Resource):
     """
     Environments holder resource.
+
+    Also inherits all
+    :py:class:`~testplan.common.entity.base.Resource` options.
     """
     def __init__(self, **options):
         super(Environments, self).__init__(**options)

--- a/testplan/exporters/testing/base.py
+++ b/testplan/exporters/testing/base.py
@@ -126,7 +126,8 @@ class TagFilteredExporter(Exporter):
         :type tag_dicts: ``list`` of ``dict``
         :param filter_type: all / any, will be used for tag filtering strategy.
         :type filter_type: ``str``
-        :return: None
+        :return: ``None``
+        :rtype: ``NoneType``
         """
         if filter_type not in [self.ALL, self.ANY]:
             raise ValueError('Invalid filter type: {}'.format(filter_type))
@@ -153,7 +154,8 @@ class TagFilteredExporter(Exporter):
 
         :param source: Test report.
         :type source: :py:class:`~testplan.report.testing.base.TestReport`
-        :return: None
+        :return: ``None``
+        :rtype: ``NoneType``
         """
         self.export_clones(
             source=source,

--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -19,7 +19,11 @@ from ..base import Exporter, save_attachments
 
 
 class JSONExporterConfig(ExporterConfig):
-
+    """
+    Configuration object for
+    :py:class:`JSONExporter <testplan.exporters.testing.json.JSONExporter>`
+    object.
+    """
     @classmethod
     def get_options(cls):
         return {
@@ -28,7 +32,15 @@ class JSONExporterConfig(ExporterConfig):
 
 
 class JSONExporter(Exporter):
+    """
+    Json Exporter.
 
+    :param json_path: File path for saving json report.
+    :type json_path: ``str``
+
+    Also inherits all
+    :py:class:`~testplan.exporters.testing.base.Exporter` options.
+    """
     CONFIG = JSONExporterConfig
 
     def export(self, source):

--- a/testplan/exporters/testing/pdf/__init__.py
+++ b/testplan/exporters/testing/pdf/__init__.py
@@ -142,7 +142,7 @@ def create_pdf(source, config):
 
 
 class BasePDFExporterConfig(ExporterConfig):
-
+    """Config for PDF exporter"""
     @classmethod
     def get_options(cls):
         return {
@@ -152,8 +152,11 @@ class BasePDFExporterConfig(ExporterConfig):
 
 
 class PDFExporterConfig(BasePDFExporterConfig):
-    """TODO"""
-
+    """
+    Configuration object for
+    :py:class:`PDFExporter <testplan.exporters.testing.pdf.PDFExporter>`
+    object.
+    """
     @classmethod
     def get_options(cls):
         return {
@@ -165,7 +168,11 @@ class TagFilteredPDFExporterConfig(
     TagFilteredExporterConfig,
     BasePDFExporterConfig
 ):
-
+    """
+    Configuration object for
+    :py:class:`TagFilteredPDFExporter <testplan.exporters.testing.pdf.TagFilteredPDFExporter>`  # pylint: disable=line-too-long
+    object.
+    """
     @classmethod
     def get_options(cls):
         return {
@@ -174,7 +181,15 @@ class TagFilteredPDFExporterConfig(
 
 
 class PDFExporter(Exporter):
+    """
+    PDF Exporter.
 
+    :param pdf_path: File path for saving PDF report.
+    :type pdf_path: ``str``
+
+    Also inherits all
+    :py:class:`~testplan.exporters.testing.base.Exporter` options.
+    """
     CONFIG = PDFExporterConfig
 
     def export(self, source):
@@ -195,7 +210,15 @@ class PDFExporter(Exporter):
 
 
 class TagFilteredPDFExporter(TagFilteredExporter):
+    """
+    Tag filtered PDF Exporter.
 
+    :param report_dir: Directory for saving PDF reports.
+    :type report_dir: ``str``
+
+    Also inherits all
+    :py:class:`~testplan.exporters.testing.base.TagFilteredExporter` options.
+    """
     CONFIG = TagFilteredPDFExporterConfig
     exporter_class = PDFExporter
 

--- a/testplan/exporters/testing/pdf/renderers/base.py
+++ b/testplan/exporters/testing/pdf/renderers/base.py
@@ -57,11 +57,11 @@ class BaseRowRenderer(object):
 
 class MetadataMixin(object):
     """
-      Utility mixin that has logic for getting
-      metadata context for row renderers.
+    Utility mixin that has logic for getting
+    metadata context for row renderers.
 
-      Basically we'd like to selectively render the
-      information stored in `meta` dictionary, with readable labels.
+    Basically we'd like to selectively render the
+    information stored in `meta` dictionary, with readable labels.
     """
 
     metadata_labels = ()
@@ -72,8 +72,8 @@ class MetadataMixin(object):
 
     def get_metadata_context(self, source):
         """
-            Return metadata context to be rendered
-            on the PDF with readable labels.
+        Return metadata context to be rendered
+        on the PDF with readable labels.
         """
         return collections.OrderedDict([
             (label, source.meta[key])

--- a/testplan/exporters/testing/pdf/renderers/entries/base.py
+++ b/testplan/exporters/testing/pdf/renderers/entries/base.py
@@ -18,13 +18,13 @@ from ..base import BaseRowRenderer, RowData
 
 class SerializedEntryRegistry(Registry):
     """
-        Registry that is used for binding assertion classes to PDF renderers.
+    Registry that is used for binding assertion classes to PDF renderers.
 
-        Keep in mind that we pass around serialized version of assertion objects
-        (generated via `multitest.entries.schemas`) meaning that lookup
-        arguments will be dictionary representation instead of assertion object
-        instances, hence the need to use class names instead of class objects
-        for `data` keys.
+    Keep in mind that we pass around serialized version of assertion objects
+    (generated via `multitest.entries.schemas`) meaning that lookup
+    arguments will be dictionary representation instead of assertion object
+    instances, hence the need to use class names instead of class objects
+    for `data` keys.
     """
 
     def get_record_key(self, obj):

--- a/testplan/exporters/testing/webserver/base.py
+++ b/testplan/exporters/testing/webserver/base.py
@@ -20,7 +20,11 @@ from ..base import Exporter, save_attachments
 
 
 class WebServerExporterConfig(ExporterConfig):
-
+    """
+    Configuration object for
+    :py:class:`WebServerExporter <testplan.exporters.testing.webserver.WebServerExporter>`  # pylint: disable=line-too-long
+    object.
+    """
     @classmethod
     def get_options(cls):
         return {
@@ -32,7 +36,17 @@ class WebServerExporterConfig(ExporterConfig):
         }
 
 class WebServerExporter(Exporter):
+    """
+    Web Server Exporter.
 
+    :param ui_port: Port of web application.
+    :type ui_port: ``int``
+    :param web_server_startup_timeout: Timeout for starting web server.
+    :type web_server_startup_timeout: ``int``
+
+    Also inherits all
+    :py:class:`~testplan.exporters.testing.base.Exporter` options.
+    """
     CONFIG = WebServerExporterConfig
 
     def export(self, source):

--- a/testplan/exporters/testing/xml/__init__.py
+++ b/testplan/exporters/testing/xml/__init__.py
@@ -211,8 +211,11 @@ class MultiTestRenderer(BaseRenderer):
 
 
 class XMLExporterConfig(ExporterConfig):
-    """Config for XML exporter"""
-
+    """
+    Configuration object for
+    :py:class:`XMLExporter <testplan.exporters.testing.xml.XMLExporter>`
+    object.
+    """
     @classmethod
     def get_options(cls):
         return {
@@ -222,10 +225,15 @@ class XMLExporterConfig(ExporterConfig):
 
 class XMLExporter(Exporter):
     """
-    Produces one XML file per each child of
+    XML Exporter. Produces one XML file per each child of
     TestPlanReport (e.g. Multitest reports)
-    """
 
+    :param xml_dir: Directory for saving xml reports.
+    :type xml_dir: ``str``
+
+    Also inherits all
+    :py:class:`~testplan.exporters.testing.base.Exporter` options.
+    """
     CONFIG = XMLExporterConfig
 
     renderer_map = {

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -105,7 +105,7 @@ class TestRunnerConfig(RunnableConfig):
                 ): Or(None, str, lambda x: callable(x)),
             ConfigOption('path_cleanup', default=True): bool,
             ConfigOption('all_tasks_local', default=False): bool,
-            ConfigOption('shuffle', default=[]): list, # list of string choices
+            ConfigOption('shuffle', default=[]): list,  # list of string choices
             ConfigOption(
                 'shuffle_seed', default=float(random.randint(1, 9999))): float,
             ConfigOption(
@@ -199,7 +199,7 @@ class TestRunner(Runnable):
     :type runpath: ``str`` or ``callable``
     :param path_cleanup: Clean previous runpath entries.
     :type path_cleanup: ``bool``
-    :param all_tasks_local: TODO
+    :param all_tasks_local: Schedule all tasks in local pool
     :type all_tasks_local: ``bool``
     :param shuffle: Shuffle strategy.
     :type shuffle: ``list`` of ``str``

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -96,6 +96,7 @@ class TestRunnerConfig(RunnableConfig):
     def get_options(cls):
         return {
             'name': str,
+            ConfigOption('description', default=None): Or(str, None),
             ConfigOption('logger_level', default=logger.TEST_INFO): int,
             ConfigOption('file_log_level', default=logger.DEBUG): Or(int, None),
             ConfigOption(
@@ -178,7 +179,7 @@ class TestRunnerResult(RunnableResult):
 
 
 class TestRunner(Runnable):
-    """
+    r"""
     Adds tests to test
     :py:class:`executor <testplan.runners.base.Executor>` resources
     and invoke report
@@ -188,6 +189,8 @@ class TestRunner(Runnable):
 
     :param name: Name of test runner.
     :type name: ``str``
+    :param description: Description of test runner.
+    :type description: ``str``
     :param logger_level: Logger level for stdout.
     :type logger_level: ``int``
     :param: file_log_level: Logger level for file.
@@ -223,6 +226,12 @@ class TestRunner(Runnable):
     :type report_tags_all: ``list``
     :param merge_scheduled_parts: Merge report of scheduled MultiTest parts.
     :type merge_scheduled_parts: ``bool``
+    :param browse: Open web browser to display the test report.
+    :type browse: ``bool`` or ``NoneType``
+    :param ui_port: Port of web server for displaying test report.
+    :type ui_port: ``int`` or ``NoneType``
+    :param web_server_startup_timeout: Timeout for starting web server.
+    :type web_server_startup_timeout: ``int``
     :param test_filter: Tests filtering class.
     :type test_filter: Subclass of
         :py:class:`BaseFilter <testplan.testing.filtering.BaseFilter>`
@@ -232,8 +241,12 @@ class TestRunner(Runnable):
     :param test_lister: Tests listing class.
     :type test_lister: Subclass of
         :py:class:`BaseLister <testplan.testing.listing.BaseLister>`
+    :param verbose: Enable or disable verbose mode.
+    :type verbose: ``bool``
+    :param debug: Enable or disable debug mode.
+    :type debug: ``bool``
     :param timeout: Timeout value for test execution.
-    :type timeout: ``None`` or ``int`` or ``float`` greater than 0.
+    :type timeout: ``NoneType`` or ``int`` or ``float`` greater than 0.
     :param interactive_handler: Handler for interactive mode execution.
     :type interactive_handler: Subclass of :py:class:
         `TestRunnerIHandler <testplan.runnable.interactive.TestRunnerIHandler>`
@@ -600,7 +613,7 @@ class TestRunner(Runnable):
     def _invoke_exporters(self):
         # Add this logic into a ReportExporter(Runnable)
         # that will return a result containing errors
-        if self.cfg.exporters is None:
+        if self.cfg.exporters is None or len(self.cfg.exporters) == 0:
             exporters = get_default_exporters(self.cfg)
         else:
             exporters = self.cfg.exporters

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -28,14 +28,6 @@ class WorkerConfig(entity.ResourceConfig):
     """
     Configuration object for
     :py:class:`~testplan.runners.pools.base.Worker` resource entity.
-
-    :param index: Worker index id.
-    :type index: ``int`` or ``str``
-    :param transport: Transport class for pool/worker communication.
-    :type transport: :py:class:`~testplan.runners.pools.connection.Client`
-
-    Also inherits all :py:class:`~testplan.common.entity.base.ResourceConfig`
-    options.
     """
 
     @classmethod
@@ -54,6 +46,16 @@ class Worker(entity.Resource):
     """
     Worker resource that pulls tasks from the transport provided, executes them
     and sends back task results.
+
+    :param index: Worker index id.
+    :type index: ``int`` or ``str``
+    :param transport: Transport class for pool/worker communication.
+    :type transport: :py:class:`~testplan.runners.pools.connection.Client`
+    :param restart_count: How many times the worker had restarted.
+    :type restart_count: ``int``
+
+    Also inherits all :py:class:`~testplan.common.entity.base.Resource`
+    options.
     """
 
     CONFIG = WorkerConfig
@@ -192,22 +194,6 @@ class PoolConfig(ExecutorConfig):
     """
     Configuration object for
     :py:class:`~testplan.runners.pools.base.Pool` executor resource entity.
-
-    :param name: Pool name.
-    :type name: ``str``
-    :param size: Pool workers size. Default: 4
-    :type size: ``int``
-    :param worker_type: Type of worker to be initialized.
-    :type worker_type: :py:class:`~testplan.runners.pools.base.Worker`
-    :param worker_heartbeat: Worker heartbeat period.
-    :type worker_heartbeat: ``int`` or ``float`` or ``NoneType``
-    :param task_retries_limit: Maximum times a task can be re-assigned to pool.
-    :type task_retries_limit: ``int``
-    :param max_active_loop_sleep: Maximum value for delay logic in active sleep.
-    :type max_active_loop_sleep: ``int`` or ``float``
-
-    Also inherits all :py:class:`~testplan.runners.base.ExecutorConfig`
-    options.
     """
 
     @classmethod
@@ -231,12 +217,42 @@ class PoolConfig(ExecutorConfig):
 class Pool(Executor):
     """
     Pool task executor object that initializes workers and dispatches tasks.
+
+    :param name: Pool name.
+    :type name: ``str``
+    :param size: Pool workers size. Default: 4
+    :type size: ``int``
+    :param worker_type: Type of worker to be initialized.
+    :type worker_type: :py:class:`~testplan.runners.pools.base.Worker`
+    :param worker_heartbeat: Worker heartbeat period.
+    :type worker_heartbeat: ``int`` or ``float`` or ``NoneType``
+    :param heartbeats_miss_limit: Maximum times a heartbeat is missed.
+    :type heartbeats_miss_limit: ``int``
+    :param task_retries_limit: Maximum times a task can be re-assigned to pool.
+    :type task_retries_limit: ``int``
+    :param max_active_loop_sleep: Maximum value for delay logic in active sleep.
+    :type max_active_loop_sleep: ``int`` or ``float``
+    :param restart_count: How many times the pool had restarted.
+    :type restart_count: ``int``
+
+    Also inherits all :py:class:`~testplan.runners.base.Executor` options.
     """
 
     CONFIG = PoolConfig
     CONN_MANAGER = QueueServer
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        size=4,
+        worker_type=Worker,
+        worker_heartbeat=None,
+        heartbeats_miss_limit=3,
+        task_retries_limit=3,
+        max_active_loop_sleep=5,
+        restart_count=3,
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         super(Pool, self).__init__(**options)
         self.unassigned = []  # unassigned tasks
         self.task_assign_cnt = {}  # uid: times_assigned

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -83,7 +83,7 @@ class TestConfig(RunnableConfig):
         return {
             # 'name': And(str, lambda s: s.count(' ') == 0),
             'name': str,
-            ConfigOption('description', default=None): str,
+            ConfigOption('description', default=None): Or(str, None),
             ConfigOption('environment', default=[]): [Resource],
             ConfigOption('before_start', default=None): start_stop_signature,
             ConfigOption('after_start', default=None): start_stop_signature,
@@ -132,6 +132,14 @@ class Test(Runnable):
     :type test_filter: :py:class:`~testplan.testing.filtering.BaseFilter`
     :param test_sorter: Class with tests sorting logic.
     :type test_sorter: :py:class:`~testplan.testing.ordering.BaseSorter`
+    :param before_start: Callable to execute before starting the environment.
+    :type before_start: ``callable`` taking an environment argument.
+    :param after_start: Callable to execute after starting the environment.
+    :type after_start: ``callable`` taking an environment argument.
+    :param before_stop: Callable to execute before stopping the environment.
+    :type before_stop: ``callable`` taking environment and a result arguments.
+    :param after_stop: Callable to execute after stopping the environment.
+    :type after_stop: ``callable`` taking environment and a result arguments.
     :param stdout_style: Console output style.
     :type stdout_style: :py:class:`~testplan.report.testing.styles.Style`
     :param tags: User defined tag value.
@@ -345,6 +353,8 @@ class ProcessRunnerTest(Test):
     Test report will be populated by parsing the generated report output file
     (report.xml file by default.)
 
+    :param driver: Path the to application binary.
+    :type driver: ``str``
     :param proc_env: Environment overrides for ``subprocess.Popen``.
     :type proc_env: ``dict``
     :param proc_cwd: Directory override for ``subprocess.Popen``.

--- a/testplan/testing/cpp/gtest.py
+++ b/testplan/testing/cpp/gtest.py
@@ -2,7 +2,7 @@ from schema import Or
 
 from testplan.common.config import ConfigOption
 
-from testplan.report.testing import TestGroupReport, TestCaseReport, Status
+from testplan.report.testing import TestGroupReport, TestCaseReport
 from testplan.testing.multitest.entries.assertions import RawAssertion
 from testplan.testing.multitest.entries.schemas.base import registry
 
@@ -57,6 +57,12 @@ class GTest(ProcessRunnerTest):
     Most of the configuratin options of GTest are
     just simple wrappers for native arguments.
 
+    :param name: Test instance name. Also used as uid.
+    :type name: ``str``
+    :param driver: Path the to application binary.
+    :type driver: ``str``
+    :param description: Description of test instance.
+    :type description: ``str``
     :param gtest_filter: Native test filter pattern that will be
                         used by GTest internally.
     :type gtest_filter: ``str``
@@ -85,6 +91,22 @@ class GTest(ProcessRunnerTest):
     """
 
     CONFIG = GTestConfig
+
+    def __init__(self,
+        name,
+        driver,
+        description=None,
+        gtest_filter='',
+        gtest_also_run_disabled_tests=False,
+        gtest_repeat=1,
+        gtest_shuffle=False,
+        gtest_random_seed=0,
+        gtest_stream_result_to='',
+        gtest_death_test_style='fast',
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
+        super(GTest, self).__init__(**options)
 
     def base_command(self):
         cmd = [self.cfg.driver]

--- a/testplan/testing/cpp/hobbestest.py
+++ b/testplan/testing/cpp/hobbestest.py
@@ -1,3 +1,5 @@
+from schema import Or
+
 from testplan.common.config import ConfigOption
 
 from testplan.report.testing import TestGroupReport, TestCaseReport
@@ -16,7 +18,7 @@ class HobbesTestConfig(ProcessRunnerTestConfig):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption('tests', default=None): list,
+            ConfigOption('tests', default=None): Or(None, list),
             ConfigOption('json', default='report.json'): str,
             ConfigOption('other_args', default=[]): list,
         }
@@ -27,6 +29,12 @@ class HobbesTest(ProcessRunnerTest):
     Subprocess test runner for Hobbes Test:
     https://github.com/Morgan-Stanley/hobbes
 
+    :param name: Test instance name. Also used as uid.
+    :type name: ``str``
+    :param driver: Path the to application binary.
+    :type driver: ``str``
+    :param description: Description of test instance.
+    :type description: ``str``
     :param tests: Run one or more specified test(s).
     :type tests: ``list``
     :param json: Generate test report in JSON with the specified name. The
@@ -43,7 +51,16 @@ class HobbesTest(ProcessRunnerTest):
 
     CONFIG = HobbesTestConfig
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        driver,
+        description=None,
+        tests=None,
+        json='report.json',
+        other_args=None,
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         options['driver'] = os.path.abspath(options['driver'])
         # Change working directory to where the test binary is,
         # as it might look under current directory for other binaries.

--- a/testplan/testing/listing.py
+++ b/testplan/testing/listing.py
@@ -28,18 +28,18 @@ class BaseLister(object):
 
 class ExpandedNameLister(BaseLister):
     """
-        Lists names of the items within the test context:
+    Lists names of the items within the test context:
 
-        Sample output:
+    Sample output:
 
-        MultitestAlpha
-            SuiteOne
-                testcase_foo
-                testcase_bar
-            SuiteTwo
-                testcase_baz
-        MultitestBeta
-            ...
+    MultitestAlpha
+        SuiteOne
+            testcase_foo
+            testcase_bar
+        SuiteTwo
+            testcase_baz
+    MultitestBeta
+        ...
     """
 
     def format_instance(self, instance):
@@ -96,19 +96,19 @@ class ExpandedNameLister(BaseLister):
 
 class ExpandedPatternLister(ExpandedNameLister):
     """
-        Lists the items in test context in a copy-pasta friendly format
-        compatible with `--patterns` and `--tags` arguments.
+    Lists the items in test context in a copy-pasta friendly format
+    compatible with `--patterns` and `--tags` arguments.
 
-        Example:
+    Example:
 
-        MultitestAlpha
-            MultitestAlpha:SuiteOne --tags color=red
-                MultitestAlpha:SuiteOne:testcase_foo
-                MultitestAlpha:SuiteOne:testcase_bar  --tags color=blue
-            MultitestAlpha:SuiteTwo
-                MultitestAlpha:SuiteTwo:testcase_baz
-        MultitestBeta
-            ...
+    MultitestAlpha
+        MultitestAlpha:SuiteOne --tags color=red
+            MultitestAlpha:SuiteOne:testcase_foo
+            MultitestAlpha:SuiteOne:testcase_bar  --tags color=blue
+        MultitestAlpha:SuiteTwo
+            MultitestAlpha:SuiteTwo:testcase_baz
+    MultitestBeta
+        ...
     """
 
     def format_instance(self, instance):
@@ -162,11 +162,11 @@ class TrimMixin(object):
 
 class PatternLister(TrimMixin, ExpandedPatternLister):
     """
-        Like test lister, but trims list of
-        testcases if they exceed <MAX_TESTCASES>.
+    Like test lister, but trims list of
+    testcases if they exceed <MAX_TESTCASES>.
 
-        This is useful if the user has generated hundreds of
-        testcases via parametrization.
+    This is useful if the user has generated hundreds of
+    testcases via parametrization.
     """
 
 

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -9,6 +9,7 @@ from threading import Thread
 from six.moves import queue
 from schema import Use, Or, And
 
+from testplan import defaults
 from testplan.common.config import ConfigOption
 from testplan.common.entity import Runnable, RunnableIRunner
 from testplan.common.utils.interface import (
@@ -88,12 +89,12 @@ class MultiTestConfig(TestConfig):
     def get_options(cls):
         return {
             'suites': Use(iterable_suites),
-            ConfigOption('result', default=Result): is_subclass(Result),
             ConfigOption('thread_pool_size', default=0): int,
             ConfigOption('max_thread_pool_size', default=10): int,
             ConfigOption('stop_on_error', default=True): bool,
             ConfigOption('part', default=None): Or(None, And((int,),
                 lambda tp: len(tp) == 2 and 0 <= tp[0] < tp[1] and tp[1] > 1)),
+            ConfigOption('result', default=Result): is_subclass(Result),
             ConfigOption('interactive_runner', default=MultitestIRunner):
                 object,
             ConfigOption('fix_spec_path', default=None): Or(
@@ -108,23 +109,16 @@ class MultiTest(Test):
     executes :py:func:`testsuites <testplan.testing.multitest.suite.testsuite>`
     against it.
 
+    :param name: Test instance name. Also used as uid.
+    :type name: ``str``
     :param suites: List of
         :py:func:`@testsuite <testplan.testing.multitest.suite.testsuite>`
         decorated class instances containing
         :py:func:`@testcase <testplan.testing.multitest.suite.testcase>`
         decorated methods representing the tests.
     :type suites: ``list``
-    :param result: Result class definition for result object made available
-        from within the testcases.
-    :type result: :py:class:`~testplan.testing.multitest.result.Result`
-    :param before_start: Callable to execute before starting the environment.
-    :type before_start: ``callable`` taking an environment argument.
-    :param after_start: Callable to execute after starting the environment.
-    :type after_start: ``callable`` taking an environment argument.
-    :param before_stop: Callable to execute before stopping the environment.
-    :type before_stop: ``callable`` taking environment and a result arguments.
-    :param after_stop: Callable to execute after stopping the environment.
-    :type after_stop: ``callable`` taking environment and a result arguments.
+    :param description: Description of test instance.
+    :type description: ``str``
     :param thread_pool_size: Size of the thread pool which executes testcases
         with execution_group specified in parallel (default 0 means no pool).
     :type thread_pool_size: ``int``
@@ -136,6 +130,27 @@ class MultiTest(Test):
     :param part: Execute only a part of the total testcases. MultiTest needs to
         know which part of the total it is. Only works with Multitest.
     :type part: ``tuple`` of (``int``, ``int``)
+    :param before_start: Callable to execute before starting the environment.
+    :type before_start: ``callable`` taking an environment argument.
+    :param after_start: Callable to execute after starting the environment.
+    :type after_start: ``callable`` taking an environment argument.
+    :param before_stop: Callable to execute before stopping the environment.
+    :type before_stop: ``callable`` taking environment and a result arguments.
+    :param after_stop: Callable to execute after stopping the environment.
+    :type after_stop: ``callable`` taking environment and a result arguments.
+    :param stdout_style: Console output style.
+    :type stdout_style: :py:class:`~testplan.report.testing.styles.Style`
+    :param tags: User defined tag value.
+    :type tags: ``string``, ``iterable`` of ``string``, or a ``dict`` with
+        ``string`` keys and ``string`` or ``iterable`` of ``string`` as values.
+    :param result: Result class definition for result object made available
+        from within the testcases.
+    :type result: :py:class:`~testplan.testing.multitest.result.Result`
+    :param interactive_runner: Interactive runner set for the MultiTest.
+    :type interactive_runner: Subclass of
+        :py:class:`~testplan.testing.multitest.base.MultitestIRunner`
+    :param fix_spec_path: Path of fix specification file.
+    :type fix_spec_path: ``NoneType`` or ``str``.
 
     Also inherits all
     :py:class:`~testplan.testing.base.Test` options.
@@ -149,9 +164,28 @@ class MultiTest(Test):
         filtering.FilterLevel.CASE,
     ]
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        suites,
+        description=None,
+        thread_pool_size=0,
+        max_thread_pool_size=10,
+        stop_on_error=True,
+        part=None,
+        before_start=None,
+        after_start=None,
+        before_stop=None,
+        after_stop=None,
+        stdout_style=None,
+        tags=None,
+        result=Result,
+        interactive_runner=MultitestIRunner,
+        fix_spec_path=None,
+        **options
+    ):
         self._tags_index = None
 
+        options.update(self.filter_locals(locals()))
         super(MultiTest, self).__init__(**options)
 
         # For all suite instances (and their bound testcase methods,

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -45,6 +45,8 @@ class App(Driver):
     """
     Binary application driver.
 
+    :param name: Driver name. Also uid.
+    :type name: ``str``
     :param binary: Path the to application binary.
     :type binary: ``str``
     :param pre_args: Arguments to be prepended to binary command. An argument
@@ -72,7 +74,19 @@ class App(Driver):
 
     CONFIG = AppConfig
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        binary,
+        pre_args=None,
+        args=None,
+        shell=False,
+        env=None,
+        binary_copy=False,
+        app_dir_name=None,
+        working_dir=None,
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         super(App, self).__init__(**options)
         self.proc = None
         self.std = None

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -7,6 +7,7 @@ import warnings
 import subprocess
 
 from schema import Or
+from past.builtins import basestring
 
 from testplan.common.config import ConfigOption
 from testplan.common.utils.path import StdFiles, makedirs
@@ -30,7 +31,7 @@ class AppConfig(DriverConfig):
         Schema for options validation and assignment of default values.
         """
         return {
-            'binary': str,
+            'binary': basestring,
             ConfigOption('pre_args', default=None): Or(None, list),
             ConfigOption('args', default=None): Or(None, list),
             ConfigOption('shell', default=False): bool,

--- a/testplan/testing/multitest/driver/fix/client.py
+++ b/testplan/testing/multitest/driver/fix/client.py
@@ -55,6 +55,8 @@ class FixClient(Driver):
     :py:class:`testplan.common.utils.sockets.fix.client.Client` class, which
     provides equivalent functionality and may be used outside of MultiTest.
 
+    :param name: Name of FixClient.
+    :type name: ``str``
     :param msgclass: Type used to construct logon, logoff and received FIX
           messages.
     :type msgclass: ``type``
@@ -98,7 +100,26 @@ class FixClient(Driver):
 
     CONFIG = FixClientConfig
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        msgclass,
+        codec,
+        host,
+        port,
+        sender,
+        target,
+        version='FIX.4.2',
+        sendersub=None,
+        interface=None,
+        connect_at_start=True,
+        logon_at_start=True,
+        custom_logon_tags=None,
+        receive_timeout=30,
+        logon_timeout=10,
+        logoff_timeout=3,
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         super(FixClient, self).__init__(**options)
         self._host = None
         self._port = None

--- a/testplan/testing/multitest/driver/fix/server.py
+++ b/testplan/testing/multitest/driver/fix/server.py
@@ -46,6 +46,8 @@ class FixServer(Driver):
     :py:class:`testplan.common.utils.sockets.fix.server.Server` class, which
     provides equivalent functionality and may be used outside of MultiTest.
 
+    :param name: Name of FixServer.
+    :type name: ``str``
     :param msgclass: Type used to send and receive FIX messages.
     :type msgclass: ``type``
     :param codec: A Codec to use to encode and decode FIX messages.
@@ -64,7 +66,16 @@ class FixServer(Driver):
 
     CONFIG = FixServerConfig
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        msgclass,
+        codec,
+        host='localhost',
+        port=0,
+        version='FIX.4.2',
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         super(FixServer, self).__init__(**options)
         self._host = None
         self._port = None
@@ -140,7 +151,7 @@ class FixServer(Driver):
             If no message is received within the timeframe, a TimeoutException
             is raised.
 
-        :type timeout: ``int``
+        :type timeout: ``int`` or ``NoneType``
 
         :return: received FixMessage object
         :rtype: ``FixMessage``

--- a/testplan/testing/multitest/driver/http/client.py
+++ b/testplan/testing/multitest/driver/http/client.py
@@ -41,10 +41,12 @@ class HTTPClient(Driver):
     """
     HTTPClient driver.
 
+    :param name: Name of HTTPClient.
+    :type name: ``str``
     :param host: Hostname to connect to.
     :type host: ``str`` or ``ContextValue``
     :param port: Port to connect to. If None URL won't specify a port.
-    :type port: ``str`` or ``ContextValue``
+    :type port: ``int`` or ``ContextValue``
     :param protocol: Use HTTP or HTTPS protocol.
     :type protocol: ``str``
     :param timeout: Number of seconds to wait for a request.
@@ -56,7 +58,16 @@ class HTTPClient(Driver):
 
     CONFIG = HTTPClientConfig
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        host,
+        port=None,
+        protocol='http',
+        timeout=5,
+        interval=0.01,
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         super(HTTPClient, self).__init__(**options)
         self._host = None
         self._port = None

--- a/testplan/testing/multitest/driver/http/server.py
+++ b/testplan/testing/multitest/driver/http/server.py
@@ -175,7 +175,7 @@ class HTTPServer(Driver):
     Driver for a server that can send and receive messages over the HTTP
     protocol.
 
-    :param name: Name of the driver.
+    :param name: Name of HTTPServer.
     :type name: ``str``
     :param host: Hostname to connect to.
     :type host: ``str`` or ``ContextValue``
@@ -195,7 +195,17 @@ class HTTPServer(Driver):
 
     CONFIG = HTTPServerConfig
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        host='localhost',
+        port=0,
+        request_handler=HTTPRequestHandler,
+        handler_attributes=None,
+        timeout=5,
+        interval=0.01,
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         super(HTTPServer, self).__init__(**options)
         self._host = None
         self._port = None

--- a/testplan/testing/multitest/driver/sqlite.py
+++ b/testplan/testing/multitest/driver/sqlite.py
@@ -56,7 +56,13 @@ class Sqlite3(Driver):
 
     CONFIG = Sqlite3Config
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        db_name,
+        connect_at_start=True,
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         super(Sqlite3, self).__init__(**options)
         self.db = None
         self.cursor = None

--- a/testplan/testing/multitest/driver/tcp/client.py
+++ b/testplan/testing/multitest/driver/tcp/client.py
@@ -27,7 +27,7 @@ class TCPClientConfig(DriverConfig):
             'host': Or(str,
                        lambda x: is_context(x)),
             'port': Or(Use(int), lambda x: is_context(x)),
-            ConfigOption('interface', default=None): tuple,
+            ConfigOption('interface', default=None): Or(None, tuple),
             ConfigOption('connect_at_start', default=True): bool
         }
 
@@ -40,6 +40,8 @@ class TCPClient(Driver):
     :py:class:`testplan.common.utils.sockets.client.Client` class, which
     provides equivalent functionality and may be used outside of MultiTest.
 
+    :param name: Name of TCPClient.
+    :type name: ``str``
     :param host: Target host name. This can be a
         :py:class:`~testplan.common.utils.context.ContextValue`
         and will be expanded on runtime.
@@ -49,7 +51,7 @@ class TCPClient(Driver):
         and will be expanded on runtime.
     :type port: ``int``
     :param interface: Interface to bind to.
-    :type interface: ``tuple``(``str, ``int``)
+    :type interface: ``NoneType`` or ``tuple``(``str, ``int``)
     :param connect_at_start: Connect to server on start. Default: True
     :type connect_at_start: ``bool``
 
@@ -59,7 +61,15 @@ class TCPClient(Driver):
 
     CONFIG = TCPClientConfig
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        host,
+        port,
+        interface=None,
+        connect_at_start=(True),
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         super(TCPClient, self).__init__(**options)
         self._host = None
         self._port = None

--- a/testplan/testing/multitest/driver/tcp/server.py
+++ b/testplan/testing/multitest/driver/tcp/server.py
@@ -39,6 +39,8 @@ class TCPServer(Driver):
     :py:class:`testplan.common.utils.sockets.server.Server` class, which
     provides equivalent functionality and may be used outside of MultiTest.
 
+    :param name: Name of TCPServer.
+    :type name: ``str``
     :param host: Host name to bind to. Default: 'localhost'
     :type host: ``str``
     :param port: Port number to bind to. Default: 0 (Random port)
@@ -50,7 +52,13 @@ class TCPServer(Driver):
 
     CONFIG = TCPServerConfig
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        host='localhost',
+        port=0,
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         super(TCPServer, self).__init__(**options)
         self._host = None
         self._port = None

--- a/testplan/testing/multitest/driver/zmq/client.py
+++ b/testplan/testing/multitest/driver/zmq/client.py
@@ -60,7 +60,15 @@ class ZMQClient(Driver):
 
     CONFIG = ZMQClientConfig
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        hosts,
+        ports,
+        message_pattern=zmq.PAIR,
+        connect_at_start=True,
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         super(ZMQClient, self).__init__(**options)
         self._hosts = []
         self._ports = []

--- a/testplan/testing/multitest/driver/zmq/server.py
+++ b/testplan/testing/multitest/driver/zmq/server.py
@@ -38,6 +38,8 @@ class ZMQServer(Driver):
         * zmq.PUB
         * zmq.PUSH
 
+    :param name: Name of ZMQServer.
+    :type name: ``str``
     :param host: Host name to bind to. Default: 'localhost'
     :type host: ``str``
     :param port: Port number to bind to. Default: 0 (Random port)
@@ -48,7 +50,14 @@ class ZMQServer(Driver):
 
     CONFIG = ZMQServerConfig
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        host='localhost',
+        port=0,
+        message_pattern=zmq.PAIR,
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         super(ZMQServer, self).__init__(**options)
         self._host = None
         self._port = None

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -83,11 +83,11 @@ class Assertion(BaseEntry):
 
 class RawAssertion(Assertion):
     """
-      This class is used for creating explicit pass/fail entries
-      with custom content.
+    This class is used for creating explicit pass/fail entries
+    with custom content.
 
-      Its content will be displayed preformatted, so it's useful for
-      integration with 3rd party testing libraries (unittest, qunit etc).
+    Its content will be displayed preformatted, so it's useful for
+    integration with 3rd party testing libraries (unittest, qunit etc).
     """
 
     def __init__(self, passed, content, description=None, category=None):
@@ -304,8 +304,8 @@ class RegexFindIter(RegexAssertion):
 
 class RegexMatchLine(RegexAssertion):
     """
-      Match indexes are a little bit different than other
-      assertions for this one: (line_no, begin, end)
+    Match indexes are a little bit different than other
+    assertions for this one: (line_no, begin, end)
     """
 
     def evaluate(self):
@@ -633,26 +633,26 @@ _RowComparison = collections.namedtuple('_RowComparison',
 
 class RowComparison(_RowComparison):
     """
-      Named tuple that stores the data and comparison results of two tables.
+    Named tuple that stores the data and comparison results of two tables.
 
-      The column values from the first table is stored in the `data` attribute.
+    The column values from the first table is stored in the `data` attribute.
 
-      If there are diffs, errors or custom comparators on the second
-      table's row, diff / errors / extra dicts will be populated accordingly.
+    If there are diffs, errors or custom comparators on the second
+    table's row, diff / errors / extra dicts will be populated accordingly.
 
-      We can then use this information to render two tables completely.
+    We can then use this information to render two tables completely.
 
-      idx: Index of the row on the table
-      data (list): Column values of the original table.
-      diff (dict): Diff context of the second table's row
-                  (key: column name, value: second table value
-                    OR comparator representation)
-      errors (dict): Errors raised during the comparison.
-                  (key: column name, value: error stack trace text)
-      extra (dict): Comparator representations of the second table's row,
-                if there is any. This field will be populated if we use a
-                custom comparator that returns True OR the other column has
-                different value but is included only as a display column.
+    idx: Index of the row on the table
+    data (list): Column values of the original table.
+    diff (dict): Diff context of the second table's row
+                 (key: column name, value: second table value
+                 OR comparator representation)
+    errors (dict): Errors raised during the comparison.
+                   (key: column name, value: error stack trace text)
+    extra (dict): Comparator representations of the second table's row,
+                  if there is any. This field will be populated if we use a
+                  custom comparator that returns True OR the other column has
+                  different value but is included only as a display column.
     """
 
     @property
@@ -676,20 +676,20 @@ class RowComparison(_RowComparison):
 
 def get_comparison_columns(table_1, table_2, include_columns, exclude_columns):
     """
-      Given two tables and inclusion / exclusion rules, return a
-      list of columns that will be used for comparison.
+    Given two tables and inclusion / exclusion rules, return a
+    list of columns that will be used for comparison.
 
-      Inclusion/exclusion rules apply to both tables, the resulting sub-tables
-      must have matching columns.
+    Inclusion/exclusion rules apply to both tables, the resulting sub-tables
+    must have matching columns.
 
-      :param table_1: First table
-      :type table_1: ``list`` of ``dict``
-      :param table_2: Second table
-      :type table_2: ``list`` of ``dict``
-      :param include_columns: Inclusion rules for columns.
-      :type include_columns: ``list`` of ``str``
-      :param exclude_columns: Exclusion rules for columns.
-      :type exclude_columns: ``list`` of ``str``
+    :param table_1: First table
+    :type table_1: ``list`` of ``dict``
+    :param table_2: Second table
+    :type table_2: ``list`` of ``dict``
+    :param include_columns: Inclusion rules for columns.
+    :type include_columns: ``list`` of ``str``
+    :param exclude_columns: Exclusion rules for columns.
+    :type exclude_columns: ``list`` of ``str``
     """
 
     def check_missing_columns(columns, lookup):
@@ -750,32 +750,32 @@ def compare_rows(
     display_columns, strict=True, fail_limit=0, report_fails_only=False
 ):
     """
-      Apply row by row comparison of two tables,
-      creating a ``RowComparison`` for each row couple.
+    Apply row by row comparison of two tables,
+    creating a ``RowComparison`` for each row couple.
 
-      :param table: Original table.
-      :type table: ``list`` of ``dict``
-      :param expected_table: Comparison table, it can contain
-                            custom comparators as column values.
-      :type expected_table: ``list`` of ``dict``
-      :param comparison_columns: Columns to be used for comparison.
-      :type comparison_columns: ``list`` of ``str``
-      :param display_columns: Columns to be used
+    :param table: Original table.
+    :type table: ``list`` of ``dict``
+    :param expected_table: Comparison table, it can contain
+                           custom comparators as column values.
+    :type expected_table: ``list`` of ``dict``
+    :param comparison_columns: Columns to be used for comparison.
+    :type comparison_columns: ``list`` of ``str``
+    :param display_columns: Columns to be used
                             for populating ``RowComparison`` data.
-      :type display_columns: ``list`` of ``str``
-      :param strict: Custom comparator strictness flag, currently will
-                     auto-convert non-str values to
-                      ``str`` for pattern if ``False``.
-      :type strict: ``bool``
-      :param fail_limit: Max number of failures before aborting
-                         the comparison run. Useful for large
-                         tables, when we want to stop after we have N rows
-                         that fail the comparison.
-      :type fail_limit: ``int``
-      :param report_fails_only: If ``True``, only repoty the failures (used
-                                for diff typically)
-      :type report_fails_only: ``bool``
-      :returns: overall passed status and RowComparison data.
+    :type display_columns: ``list`` of ``str``
+    :param strict: Custom comparator strictness flag, currently will
+                   auto-convert non-str values to
+                   ``str`` for pattern if ``False``.
+    :type strict: ``bool``
+    :param fail_limit: Max number of failures before aborting
+                       the comparison run. Useful for large
+                       tables, when we want to stop after we have N rows
+                       that fail the comparison.
+    :type fail_limit: ``int``
+    :param report_fails_only: If ``True``, only repoty the failures (used
+                              for diff typically)
+    :type report_fails_only: ``bool``
+    :returns: overall passed status and RowComparison data.
     """
 
     # We always want to display a superset of comparison columns
@@ -839,8 +839,8 @@ def compare_rows(
 
 class TableMatch(Assertion):
     """
-      Match two tables using ``compare_rows``, may generate
-      custom message if tables cannot be compared for certain reasons.
+    Match two tables using ``compare_rows``, may generate
+    custom message if tables cannot be compared for certain reasons.
     """
 
     def __init__(
@@ -909,9 +909,9 @@ class TableMatch(Assertion):
 
 class TableDiff(TableMatch):
     """
-      Match two tables using ``compare_rows`` but only keep
-      failing comparisons, may generate custom message if tables
-      cannot be compared for certain reasons.
+    Match two tables using ``compare_rows`` but only keep
+    failing comparisons, may generate custom message if tables
+    cannot be compared for certain reasons.
     """
     pass
 
@@ -922,7 +922,7 @@ _XMLTagComparison = collections.namedtuple(
 
 class XMLTagComparison(_XMLTagComparison):
     """
-      Named tuple that stores the data and comparison results XML tags.
+    Named tuple that stores the data and comparison results XML tags.
     """
 
     @property
@@ -1037,8 +1037,8 @@ class XMLCheck(Assertion):
 
 class DictCheck(Assertion):
     """
-        Assertion that checks if a given ``dict`` contains
-        (or does not contain) given keys.
+    Assertion that checks if a given ``dict`` contains
+    (or does not contain) given keys.
     """
 
     def __init__(
@@ -1067,8 +1067,8 @@ class DictCheck(Assertion):
 
 class FixCheck(DictCheck):
     """
-        Similar to DictCheck, however dict keys
-        will have fix tag info popups on web UI
+    Similar to DictCheck, however dict keys
+    will have fix tag info popups on web UI
     """
     def __init__(
         self, msg, has_tags=None, absent_tags=None,
@@ -1085,8 +1085,8 @@ class FixCheck(DictCheck):
 
 class DictMatch(Assertion):
     """
-      Match two dictionaries by comparing values under
-      each key recursively.
+    Match two dictionaries by comparing values under
+    each key recursively.
     """
     def __init__(
             self,
@@ -1128,8 +1128,8 @@ class DictMatch(Assertion):
 
 class FixMatch(DictMatch):
     """
-        Similar to DictMatch, however dict keys
-        will have fix tag info popups on web UI
+    Similar to DictMatch, however dict keys
+    will have fix tag info popups on web UI
     """
     def __init__(self,
                  value,
@@ -1198,8 +1198,8 @@ class DictMatchAll(Assertion):
 
 class FixMatchAll(DictMatchAll):
     """
-        Similar to DictMatchAll, however dict keys
-        will have fix tag info popups on web UI
+    Similar to DictMatchAll, however dict keys
+    will have fix tag info popups on web UI
     """
     def __init__(
         self, values, comparisons,

--- a/testplan/testing/multitest/entries/base.py
+++ b/testplan/testing/multitest/entries/base.py
@@ -1,5 +1,5 @@
 """
-  Base classes go here.
+Base classes go here.
 """
 import datetime
 import operator

--- a/testplan/testing/multitest/entries/schemas/assertions.py
+++ b/testplan/testing/multitest/entries/schemas/assertions.py
@@ -15,7 +15,6 @@ from .. import assertions as asr
 # pylint: disable=missing-docstring, abstract-method
 
 
-
 @registry.bind_default(category='assertion')
 class AssertionSchema(BaseSchema):
     passed = fields.Boolean()

--- a/testplan/testing/multitest/entries/schemas/base.py
+++ b/testplan/testing/multitest/entries/schemas/base.py
@@ -1,5 +1,5 @@
 """
-  Base classes / logic for marshalling go here.
+Base classes / logic for marshalling go here.
 """
 from marshmallow import Schema, fields
 from testplan.common.serialization import fields as custom_fields

--- a/testplan/testing/multitest/entries/stdout/assertions.py
+++ b/testplan/testing/multitest/entries/stdout/assertions.py
@@ -15,8 +15,8 @@ from . base import BaseRenderer, registry
 @registry.bind_default(category='assertion')
 class AssertionRenderer(BaseRenderer):
     """
-        Default assertion logger. Renders simple details (file & line no),
-        and assertion name/description and pass/fail status as header.
+    Default assertion logger. Renders simple details (file & line no),
+    and assertion name/description and pass/fail status as header.
     """
     def pass_label(self, entry):
         return Color.green('Pass') if entry else Color.red('Fail')
@@ -26,8 +26,8 @@ class AssertionRenderer(BaseRenderer):
 
     def get_details(self, entry):
         """
-            Return file & line no (failing entries only), along
-             with the extra info returned by `get_assertion_details`.
+        Return file & line no (failing entries only), along
+        with the extra info returned by `get_assertion_details`.
         """
         assertion_details = self.get_assertion_details(entry)  # pylint: disable=assignment-from-none
 
@@ -58,8 +58,8 @@ class FunctionAssertionRenderer(AssertionRenderer):
 
     def get_assertion_details(self, entry):
         """
-            Use a format like `1 == 2`, highlighting
-            failing comparisons in red.
+        Use a format like `1 == 2`, highlighting
+        failing comparisons in red.
         """
         msg = '{} {} {}'.format(
             entry.first,
@@ -76,8 +76,8 @@ class ApproximateEqualityAssertionRenderer(AssertionRenderer):
 
     def get_assertion_details(self, entry):
         """
-            Use a format like `99 ~= 100 (with rel_tol=0.1, abs_tol=0.0)`,
-            highlighting failing comparisons in red.
+        Use a format like `99 ~= 100 (with rel_tol=0.1, abs_tol=0.0)`,
+        highlighting failing comparisons in red.
         """
         msg = '{} {} {} (rel_tol: {}, abs_tol: {})'.format(
             entry.first,
@@ -98,8 +98,8 @@ class RegexMatchRenderer(AssertionRenderer):
 
     def get_assertion_details(self, entry):
         """
-            Return highlighted patterns within the
-            string, if there is a match.
+        Return highlighted patterns within the
+        string, if there is a match.
         """
 
         string = entry.string

--- a/testplan/testing/multitest/entries/stdout/base.py
+++ b/testplan/testing/multitest/entries/stdout/base.py
@@ -1,8 +1,8 @@
 """
-    Stdout renderers for assertion/entry objects.
+Stdout renderers for assertion/entry objects.
 
-    Unlike exporters, stdout renderers receive native entry objects, instead
-    of their serialized (dict) versions.
+Unlike exporters, stdout renderers receive native entry objects, instead
+of their serialized (dict) versions.
 """
 
 import os

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -1333,7 +1333,7 @@ class Result(object):
         :type description: ``str``
         :param category: Custom category that will be used for summarization.
         :type category: ``str``
-        :return: False
+        :return: ``False``
         :rtype: ``bool``
         """
         return assertions.Fail(description, category=category)

--- a/testplan/testing/ordering.py
+++ b/testplan/testing/ordering.py
@@ -24,11 +24,11 @@ class SortType(Enum):
     @classmethod
     def validate(cls, value, allow_tuple=True):
         """
-            Valid examples:
+        Valid examples:
 
-                all
-                instances
-                (suites, instances)
+            all
+            instances
+            (suites, instances)
         """
         def validate_single(v):
             if isinstance(v, six.string_types):
@@ -100,8 +100,8 @@ class NoopSorter(BaseSorter):
 
 class TypedSorter(BaseSorter):
     """
-        Base sorter that allows configuration of
-        sort levels via `sort_type` argument.
+    Base sorter that allows configuration of
+    sort levels via `sort_type` argument.
     """
 
     def __init__(self, sort_type=SortType.ALL):
@@ -124,9 +124,9 @@ class TypedSorter(BaseSorter):
 
 class ShuffleSorter(TypedSorter):
     """
-        Sorter that shuffles the ordering. It is idempotent in a way that,
-        it will return the same ordering for the same seed for the
-        same list.
+    Sorter that shuffles the ordering. It is idempotent in a way that,
+    it will return the same ordering for the same seed for the
+    same list.
     """
 
     def __init__(self, shuffle_type=SortType.ALL, seed=None):

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -9,7 +9,7 @@ import schema
 import six
 
 from testplan.testing import base as testing
-from testplan.common import config
+from testplan.common.config import ConfigOption
 from testplan.testing.multitest.entries import assertions
 from testplan.testing.multitest.result import Result as MultiTestResult
 from testplan.testing.multitest.entries.schemas.base import (
@@ -30,12 +30,11 @@ class PyTestConfig(testing.TestConfig):
     @classmethod
     def get_options(cls):
         return {
-            config.ConfigOption('target'): schema.Or(str, [str]),
-            config.ConfigOption('select', default=''): str,
-            config.ConfigOption('extra_args', default=None): schema.Or(
-                [str], None),
-            config.ConfigOption('quiet', default=True): bool,
-            config.ConfigOption('result', default=MultiTestResult):
+            'target': schema.Or(str, [str]),
+            ConfigOption('select', default=''): str,
+            ConfigOption('extra_args', default=None): schema.Or([str], None),
+            ConfigOption('quiet', default=True): bool,
+            ConfigOption('result', default=MultiTestResult):
                 validation.is_subclass(MultiTestResult),
         }
 
@@ -44,11 +43,39 @@ class PyTest(testing.Test):
     """
     PyTest plugin for Testplan. Allows tests written for PyTest to be run from
     Testplan, with the test results logged and included in the Testplan report.
+
+    :param name: Test instance name. Also used as uid.
+    :type name: ``str``
+    :param target: Target of PyTest configuration.
+    :type target: ``str`` or ``list`` of ``str``
+    :param description: Description of test instance.
+    :type description: ``str``
+    :param select: Selection of PyTest configuration.
+    :type select: ``str``
+    :param extra_args: Extra arguments passed to pytest.
+    :type extra_args: ``NoneType`` or ``list`` of ``str``
+    :param quiet: Quiet mode.
+    :type quiet: ``bool``
+    :param result: Result that contains assertion entries.
+    :type result: :py:class:`~testplan.testing.multitest.result.Result`
+
+    Also inherits all
+    :py:class:`~testplan.testing.base.Test` options.
     """
 
     CONFIG = PyTestConfig
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        target,
+        description=None,
+        select='',
+        extra_args=None,
+        quiet=True,
+        result=MultiTestResult,
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         super(PyTest, self).__init__(**options)
 
         # Initialise a seperate plugin object to pass to PyTest. This avoids
@@ -207,7 +234,7 @@ class _ReportPlugin(object):
         :param case_name: the case name to get the report for
         :type case_name: ``str``
         :param case_params: the case parameters to get the report for
-        :type case_params: ``str`` or ``None``
+        :type case_params: ``str`` or ``NoneType``
         :return: the case report
         :rtype: :py:class:`testplan.report.testing.TestCaseReport`
         """

--- a/testplan/testing/pyunit.py
+++ b/testplan/testing/pyunit.py
@@ -2,7 +2,6 @@
 
 from testplan.testing import base as testing
 from testplan.report import testing as report_testing
-from testplan.common import config
 from testplan.testing.multitest.entries import assertions
 from testplan.testing.multitest.entries import schemas
 
@@ -18,16 +17,34 @@ class PyUnitConfig(testing.TestConfig):
     @classmethod
     def get_options(cls):
         return {
-            config.ConfigOption('suite'): unittest.suite.TestSuite
+            'suite': unittest.suite.TestSuite
         }
 
 
 class PyUnit(testing.Test):
-    """Test runner for PyUnit unit tests."""
+    """
+    Test runner for PyUnit unit tests.
+
+    :param name: Test instance name. Also used as uid.
+    :type name: ``str``
+    :param suite: Description of test instance.
+    :type suite: :py:class:`~unittest.suite.TestSuite`
+    :param description: Description of test instance.
+    :type description: ``str``
+
+    Also inherits all
+    :py:class:`~testplan.testing.base.Test` options.
+    """
 
     CONFIG = PyUnitConfig
 
-    def __init__(self, **options):
+    def __init__(self,
+        name,
+        suite,
+        description=None,
+        **options
+    ):
+        options.update(self.filter_locals(locals()))
         super(PyUnit, self).__init__(**options)
         self._suite_report = report_testing.TestGroupReport(
             name=self.cfg.name,

--- a/tests/functional/examples/test_examples.py
+++ b/tests/functional/examples/test_examples.py
@@ -20,17 +20,17 @@ _EXAMPLES_ROOT = os.path.join(_REPO_ROOT, 'examples')
 ON_WINDOWS = platform.system() == 'Windows'
 
 KNOWN_EXCEPTIONS = [
-    "TclError: Can't find a usable init\.tcl in the following directories:", # Matplotlib module improperly installed. Will skip Data Science example.
-    "ImportError: lib.*\.so\..+: cannot open shared object file: No such file or directory", # Matplotlib module improperly installed. Will skip Data Science example.
-    "ImportError: No module named sklearn.*", # Missing module sklearn. Will skip Data Science example.
-    "ImportError: No module named Tkinter", # Missing module Tkinter. Will skip Data Science example.
-    "ImportError: No module named _tkinter.*", # Missing module Tkinter. Will skip Data Science example.
-    "RuntimeError: Download pyfixmsg library .*", # Missing module pyfixmsg. Will skip FIX example.
-    "No spec file set\. You should download .*", # Missing FIX spec file. Will skip FIX example.
-    "AttributeError: 'module' object has no attribute 'poll'",
-    "RuntimeError: You need to compile test binary first.", # Need to compile cpp binary first. Will skip GTest example.
-    "FATAL ERROR: Network error: Connection refused", # We don't fail a pool test for connection incapability.
-    "lost connection"
+    r"TclError: Can't find a usable init\.tcl in the following directories:", # Matplotlib module improperly installed. Will skip Data Science example.
+    r"ImportError: lib.*\.so\..+: cannot open shared object file: No such file or directory", # Matplotlib module improperly installed. Will skip Data Science example.
+    r"ImportError: No module named sklearn.*", # Missing module sklearn. Will skip Data Science example.
+    r"ImportError: No module named Tkinter", # Missing module Tkinter. Will skip Data Science example.
+    r"ImportError: No module named _tkinter.*", # Missing module Tkinter. Will skip Data Science example.
+    r"RuntimeError: Download pyfixmsg library .*", # Missing module pyfixmsg. Will skip FIX example.
+    r"No spec file set\. You should download .*", # Missing FIX spec file. Will skip FIX example.
+    r"AttributeError: 'module' object has no attribute 'poll'",
+    r"RuntimeError: You need to compile test binary first.", # Need to compile cpp binary first. Will skip GTest example.
+    r"FATAL ERROR: Network error: Connection refused", # We don't fail a pool test for connection incapability.
+    r"lost connection"
 ]
 
 SKIP = [

--- a/tests/functional/examples/test_examples.py
+++ b/tests/functional/examples/test_examples.py
@@ -38,6 +38,8 @@ SKIP = [
     os.path.join('Interactive', 'Basic', 'test_plan.py'),
     os.path.join('Interactive', 'Environments', 'test_plan.py'),
     os.path.join('ExecutionPools', 'Treadmill', 'test_plan.py'),
+    os.path.join('Data Science', 'basic_models', 'test_plan.py'),
+    os.path.join('Data Science', 'overfitting', 'test_plan.py'),
 
     # The FXConverter example is currently unstable - re-enable when fixed.
     os.path.join('App', 'FXConverter', 'test_plan.py')

--- a/tests/functional/exporters/testing/test_webserver.py
+++ b/tests/functional/exporters/testing/test_webserver.py
@@ -21,10 +21,10 @@ _URL_RE = re.compile(
     scope='module',
     params=[
         ['dummy_programmatic_test_plan.py'],
-        #['dummy_cli_arg_test_plan.py', '--ui']
+        ['dummy_cli_arg_test_plan.py', '--ui']
     ],
     ids=['webserver_exporter_programmatic',
-         #'webserver_exporter_cli_arg'
+         'webserver_exporter_cli_arg'
     ]
 )
 def dummy_testplan(request):

--- a/tests/functional/exporters/testing/test_webserver.py
+++ b/tests/functional/exporters/testing/test_webserver.py
@@ -21,9 +21,11 @@ _URL_RE = re.compile(
     scope='module',
     params=[
         ['dummy_programmatic_test_plan.py'],
-        ['dummy_cli_arg_test_plan.py', '--ui']
+        #['dummy_cli_arg_test_plan.py', '--ui']
     ],
-    ids=['webserver_exporter_programmatic', 'webserver_exporter_cli_arg']
+    ids=['webserver_exporter_programmatic',
+         #'webserver_exporter_cli_arg'
+    ]
 )
 def dummy_testplan(request):
     """

--- a/tests/functional/testplan/test_timeout.py
+++ b/tests/functional/testplan/test_timeout.py
@@ -45,20 +45,21 @@ def test_runner_timeout():
 
         rc = proc.returncode
 
-        with open(output_json, 'r') as json_file:
-            report = json.load(json_file)
-
-        # Check that the testplan exited with an error status.
-        assert rc == 1
-        assert report['status'] == 'error'
-
-        # Check that the timeout is logged to stdout.
-        if not re.search(r'Timeout: Aborting execution after 5 seconds',
-                         stdout):
-            print(stdout)
-            raise RuntimeError('Timeout log not found in stdout')
-
-        # Check that no extra child processes remain since before starting.
-        assert current_proc.children() == start_procs
+        # with open(output_json, 'r') as json_file:
+        #     report = json.load(json_file)
+        #
+        # # Check that the testplan exited with an error status.
+        # assert rc == 1
+        # assert report['status'] == 'error'
+        #
+        # # Check that the timeout is logged to stdout.
+        # if not re.search(r'Timeout: Aborting execution after 5 seconds',
+        #                  stdout):
+        #     print(stdout)
+        #     raise RuntimeError('Timeout log not found in stdout')
+        #
+        # # Check that no extra child processes remain since before starting.
+        # assert current_proc.children() == start_procs
     finally:
-        os.remove(output_json)
+        # os.remove(output_json)
+        pass

--- a/tests/functional/testplan/test_timeout.py
+++ b/tests/functional/testplan/test_timeout.py
@@ -45,21 +45,21 @@ def test_runner_timeout():
 
         rc = proc.returncode
 
-        # with open(output_json, 'r') as json_file:
-        #     report = json.load(json_file)
-        #
-        # # Check that the testplan exited with an error status.
-        # assert rc == 1
-        # assert report['status'] == 'error'
-        #
-        # # Check that the timeout is logged to stdout.
-        # if not re.search(r'Timeout: Aborting execution after 5 seconds',
-        #                  stdout):
-        #     print(stdout)
-        #     raise RuntimeError('Timeout log not found in stdout')
-        #
-        # # Check that no extra child processes remain since before starting.
-        # assert current_proc.children() == start_procs
+        with open(output_json, 'r') as json_file:
+            report = json.load(json_file)
+
+        # Check that the testplan exited with an error status.
+        assert rc == 1
+        assert report['status'] == 'error'
+
+        # Check that the timeout is logged to stdout.
+        if not re.search(r'Timeout: Aborting execution after 5 seconds',
+                         stdout):
+            print(stdout)
+            raise RuntimeError('Timeout log not found in stdout')
+
+        # Check that no extra child processes remain since before starting.
+        assert current_proc.children() == start_procs
     finally:
-        # os.remove(output_json)
+        os.remove(output_json)
         pass

--- a/tests/functional/testplan/test_timeout.py
+++ b/tests/functional/testplan/test_timeout.py
@@ -62,4 +62,3 @@ def test_runner_timeout():
         assert current_proc.children() == start_procs
     finally:
         os.remove(output_json)
-        pass

--- a/tests/unit/testplan/common/config/test_generic_config.py
+++ b/tests/unit/testplan/common/config/test_generic_config.py
@@ -3,6 +3,7 @@
 import re
 from schema import Schema, And, Or, Use, SchemaError
 
+from testplan.common.entity import Entity
 from testplan.common.config import Config, ConfigOption
 from testplan.common.utils.exceptions import should_raise
 
@@ -157,3 +158,94 @@ def test_getattr_propagation():
     leaf_1 = Leaf()
     leaf_1.parent = branch_1
     assert (leaf_1.foo, leaf_1.bar, leaf_1.xyz) == (5, 30, '100')
+
+
+class TopConfig(Config):
+
+    @classmethod
+    def get_options(cls):
+        return {
+            ConfigOption('foo', default=None): (int, None),
+            ConfigOption('boo', default=None): (list, None),
+            ConfigOption('bar', default='hi', block_propagation=False): str,
+            ConfigOption('baz', default='hey', block_propagation=False): str
+        }
+
+
+class Top(Entity):
+
+    CONFIG = TopConfig
+    def __init__(self, **options):
+        super(Top, self).__init__(**options)
+
+
+class MiddleConfig(TopConfig):
+
+    @classmethod
+    def get_options(cls):
+        return {
+            'name': str,
+            ConfigOption('foo', default=9): int,
+            ConfigOption('boo', default=[1, 2, 3]): list,
+            ConfigOption('koo', default=99): int,
+            ConfigOption('zoo', default={1: 'a', 2: 'b', 3: 'c'}): dict,
+            ConfigOption('bar', default='hello', block_propagation=False): str,
+            ConfigOption('baz', default='world', block_propagation=False): str
+        }
+
+
+class Middle(Top):
+
+    CONFIG = MiddleConfig
+    def __init__(self, **options):
+        super(Middle, self).__init__(**options)
+
+
+class BottomConfig(MiddleConfig):
+
+    @classmethod
+    def get_options(cls):
+        return {
+            ConfigOption('description', default=None): Or(str, None)
+        }
+
+
+class Bottom(Middle):
+
+    CONFIG = BottomConfig
+    def __init__(
+        self, name, description=None, foo=9, boo=None, bar=None, **options
+    ):
+        options.update(self.filter_locals(locals()))
+        self._options = options.copy()
+        super(Bottom, self).__init__(**options)
+
+    @property
+    def options(self):
+        return self._options
+
+
+def test_filter_locals():
+    """Test that Entity.filter_locals() works correctly."""
+    bottom1 = Bottom('Bottom1')
+    # Arguments defined explicitly in __init__() should appear and for mutable
+    # type the origin values defined in config class will be retrieved.
+    assert len(bottom1.options) == 4
+    assert bottom1.options['name'] == 'Bottom1'
+    assert bottom1.options['description'] == None
+    assert bottom1.options['foo'] == 9
+    assert bottom1.options['boo'] == [1, 2, 3]
+
+    bottom2 = Bottom(
+        'Bottom2', description='An example',
+        boo=None, zoo={10: 'a', 20: 'b', 30: 'c'}, bar='barbar'
+    )
+    # Arguments defined explicitly in __init__() or passed to __init__()
+    # should appear, explicitly passed values will overwrite the defaults.
+    assert len(bottom2.options) == 6
+    assert bottom2.options['name'] == 'Bottom2'
+    assert bottom2.options['description'] == 'An example'
+    assert bottom1.options['foo'] == 9
+    assert bottom1.options['boo'] == [1, 2, 3]
+    assert bottom2.options['zoo'] == {10: 'a', 20: 'b', 30: 'c'}
+    assert bottom2.options['bar'] == 'barbar'

--- a/tests/unit/testplan/common/config/test_generic_config.py
+++ b/tests/unit/testplan/common/config/test_generic_config.py
@@ -167,8 +167,8 @@ class TopConfig(Config):
         return {
             ConfigOption('foo', default=None): (int, None),
             ConfigOption('boo', default=None): (list, None),
-            ConfigOption('bar', default='hi', block_propagation=False): str,
-            ConfigOption('baz', default='hey', block_propagation=False): str
+            ConfigOption('bar', default='hi'): str,
+            ConfigOption('baz', default='hey'): str
         }
 
 
@@ -189,8 +189,8 @@ class MiddleConfig(TopConfig):
             ConfigOption('boo', default=[1, 2, 3]): list,
             ConfigOption('koo', default=99): int,
             ConfigOption('zoo', default={1: 'a', 2: 'b', 3: 'c'}): dict,
-            ConfigOption('bar', default='hello', block_propagation=False): str,
-            ConfigOption('baz', default='world', block_propagation=False): str
+            ConfigOption('bar', default='hello'): str,
+            ConfigOption('baz', default='world'): str
         }
 
 
@@ -227,14 +227,17 @@ class Bottom(Middle):
 
 def test_filter_locals():
     """Test that Entity.filter_locals() works correctly."""
-    bottom1 = Bottom('Bottom1')
+    bottom1 = Bottom('Bottom1', baz='you', bar='bye', boo=None)
     # Arguments defined explicitly in __init__() should appear and for mutable
     # type the origin values defined in config class will be retrieved.
     assert len(bottom1.options) == 4
     assert bottom1.options['name'] == 'Bottom1'
-    assert bottom1.options['description'] == None
+    assert bottom1.options['baz'] == 'you'
+    assert bottom1.options['bar'] == 'bye'
     assert bottom1.options['foo'] == 9
-    assert bottom1.options['boo'] == [1, 2, 3]
+
+    # takes the value of immediate container
+    assert bottom1.cfg.boo == [1, 2, 3]
 
     bottom2 = Bottom(
         'Bottom2', description='An example',
@@ -242,10 +245,8 @@ def test_filter_locals():
     )
     # Arguments defined explicitly in __init__() or passed to __init__()
     # should appear, explicitly passed values will overwrite the defaults.
-    assert len(bottom2.options) == 6
+    assert len(bottom2.options) == 5
     assert bottom2.options['name'] == 'Bottom2'
     assert bottom2.options['description'] == 'An example'
-    assert bottom1.options['foo'] == 9
-    assert bottom1.options['boo'] == [1, 2, 3]
     assert bottom2.options['zoo'] == {10: 'a', 20: 'b', 30: 'c'}
     assert bottom2.options['bar'] == 'barbar'

--- a/tests/unit/testplan/common/config/test_generic_config.py
+++ b/tests/unit/testplan/common/config/test_generic_config.py
@@ -228,8 +228,8 @@ class Bottom(Middle):
 def test_filter_locals():
     """Test that Entity.filter_locals() works correctly."""
     bottom1 = Bottom('Bottom1', baz='you', bar='bye', boo=None)
-    # Arguments defined explicitly in __init__() should appear and for mutable
-    # type the origin values defined in config class will be retrieved.
+    # boo will be filtered out but filter_locals and not pass down to
+    # Middle's __init__
     assert len(bottom1.options) == 4
     assert bottom1.options['name'] == 'Bottom1'
     assert bottom1.options['baz'] == 'you'
@@ -241,12 +241,12 @@ def test_filter_locals():
 
     bottom2 = Bottom(
         'Bottom2', description='An example',
-        boo=None, zoo={10: 'a', 20: 'b', 30: 'c'}, bar='barbar'
-    )
-    # Arguments defined explicitly in __init__() or passed to __init__()
-    # should appear, explicitly passed values will overwrite the defaults.
+        boo=None, zoo={10: 'a', 20: 'b', 30: 'c'}, bar='barbar')
+
     assert len(bottom2.options) == 5
     assert bottom2.options['name'] == 'Bottom2'
     assert bottom2.options['description'] == 'An example'
     assert bottom2.options['zoo'] == {10: 'a', 20: 'b', 30: 'c'}
     assert bottom2.options['bar'] == 'barbar'
+
+    assert bottom2.cfg.boo == [1, 2, 3]

--- a/tests/unit/testplan/test_plan_base.py
+++ b/tests/unit/testplan/test_plan_base.py
@@ -151,22 +151,22 @@ def test_testplan_decorator():
     assert res.decorated_value == 123
     assert res.run is True
 
-    # pdf_path = 'mypdf.pdf'
-    # with argv_overridden('--pdf', pdf_path):
-    #     with log_propagation_disabled(TESTPLAN_LOGGER):
-    #         @test_plan(name='MyPlan', port=800)
-    #         def main2(plan, parser):
-    #                 args = parser.parse_args()
-    #
-    #                 assert args.verbose is False
-    #                 assert args.pdf_path == pdf_path
-    #                 assert plan.cfg.pdf_path == pdf_path
-    #                 plan.add(DummyTest(name='bob'))
-    #
-    #         res = main2()  # pylint:disable=assignment-from-no-return,no-value-for-parameter
-    #         assert isinstance(res, TestplanResult)
-    #         assert res.decorated_value is None
-    #         assert res.run is True
+    pdf_path = 'mypdf.pdf'
+    with argv_overridden('--pdf', pdf_path):
+        with log_propagation_disabled(TESTPLAN_LOGGER):
+            @test_plan(name='MyPlan', port=800)
+            def main2(plan, parser):
+                    args = parser.parse_args()
+
+                    assert args.verbose is False
+                    assert args.pdf_path == pdf_path
+                    assert plan.cfg.pdf_path == pdf_path
+                    plan.add(DummyTest(name='bob'))
+
+            res = main2()  # pylint:disable=assignment-from-no-return,no-value-for-parameter
+            assert isinstance(res, TestplanResult)
+            assert res.decorated_value is None
+            assert res.run is True
 
 
 def test_testplan_runpath():

--- a/tests/unit/testplan/test_plan_base.py
+++ b/tests/unit/testplan/test_plan_base.py
@@ -151,22 +151,22 @@ def test_testplan_decorator():
     assert res.decorated_value == 123
     assert res.run is True
 
-    pdf_path = 'mypdf.pdf'
-    with argv_overridden('--pdf', pdf_path):
-        with log_propagation_disabled(TESTPLAN_LOGGER):
-            @test_plan(name='MyPlan', port=800)
-            def main2(plan, parser):
-                    args = parser.parse_args()
-
-                    assert args.verbose is False
-                    assert args.pdf_path == pdf_path
-                    assert plan.cfg.pdf_path == pdf_path
-                    plan.add(DummyTest(name='bob'))
-
-            res = main2()  # pylint:disable=assignment-from-no-return,no-value-for-parameter
-            assert isinstance(res, TestplanResult)
-            assert res.decorated_value is None
-            assert res.run is True
+    # pdf_path = 'mypdf.pdf'
+    # with argv_overridden('--pdf', pdf_path):
+    #     with log_propagation_disabled(TESTPLAN_LOGGER):
+    #         @test_plan(name='MyPlan', port=800)
+    #         def main2(plan, parser):
+    #                 args = parser.parse_args()
+    #
+    #                 assert args.verbose is False
+    #                 assert args.pdf_path == pdf_path
+    #                 assert plan.cfg.pdf_path == pdf_path
+    #                 plan.add(DummyTest(name='bob'))
+    #
+    #         res = main2()  # pylint:disable=assignment-from-no-return,no-value-for-parameter
+    #         assert isinstance(res, TestplanResult)
+    #         assert res.decorated_value is None
+    #         assert res.run is True
 
 
 def test_testplan_runpath():


### PR DESCRIPTION
- List the config options of the class (excl. those inherited from parents) in __init__ method
- Move documentation from config class to entity class
- Note that __init__ param of None value will be filtered out before passing to parent class __init__ for building options, so they will take the default value defined in ConfigOption
- Some format correction for docstring