### PR TITLE
Close file logger after tests are run

### DIFF
--- a/testplan/common/utils/logger.py
+++ b/testplan/common/utils/logger.py
@@ -160,6 +160,7 @@ def configure_file_logger(level, runpath):
         TESTPLAN_LOGGER.error('Cannot open log file at %s for writing: %s',
                               logfile_path,
                               err)
+        return None
     else:
         file_handler.setLevel(level)
         formatter = logging.Formatter(_LOGFILE_FORMAT)
@@ -167,6 +168,7 @@ def configure_file_logger(level, runpath):
         TESTPLAN_LOGGER.addHandler(file_handler)
 
         TESTPLAN_LOGGER.debug('Enabled logging to file: %s', logfile_path)
+        return file_handler
 
 
 class Loggable(object):

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -256,6 +256,7 @@ class TestRunner(Runnable):
             name=self.cfg.name, uid=self.cfg.name)
         self._configure_stdout_logger()
         self._web_server_thread = None
+        self._file_log_handler = None
 
     @property
     def report(self):
@@ -427,6 +428,7 @@ class TestRunner(Runnable):
         self._add_step(self._record_end)  # needs to happen before export
         self._add_step(self._invoke_exporters)
         self._add_step(self._post_exporters)
+        self._add_step(self._close_file_logger)
 
     def _wait_ongoing(self):
         # TODO: if a pool fails to initialize we could reschedule the tasks.
@@ -665,5 +667,16 @@ class TestRunner(Runnable):
         if self.cfg.file_log_level is None:
             self.logger.debug('Not enabling file logging')
         else:
-            logger.configure_file_logger(self.cfg.file_log_level,
-                                         self.runpath)
+            self._file_log_handler = logger.configure_file_logger(
+                self.cfg.file_log_level, self.runpath)
+
+    def _close_file_logger(self):
+        """
+        Closes the file logger, releasing all file handles. This is necessary to
+        avoid permissions errors on Windows.
+        """
+        if self._file_log_handler is not None:
+            self._file_log_handler.flush()
+            self._file_log_handler.close()
+            logger.TESTPLAN_LOGGER.removeHandler(self._file_log_handler)
+            self._file_log_handler = None


### PR DESCRIPTION
Fixes the permissions issue seen when running the tests on Windows, it cannot remove the testplan.log file since the file handler is never closed. And it's a good practice anyway to always close file handles.