### PR TITLE
Fix HTTP exporter test for python 3.4

### DIFF
--- a/tests/functional/exporters/testing/test_http.py
+++ b/tests/functional/exporters/testing/test_http.py
@@ -1,121 +1,109 @@
-import os
 import json
 import threading
-import tempfile
 
+import pytest
 from six.moves.BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
 
-from testplan.testing.multitest import MultiTest, testsuite, testcase
-
+from testplan.testing import multitest
 from testplan import Testplan
-from testplan.common.utils.testing import (
-    log_propagation_disabled, argv_overridden
-)
+from testplan.common.utils.testing import argv_overridden
 from testplan.exporters.testing import HTTPExporter
-from testplan.common.utils.logger import TESTPLAN_LOGGER
-
-data_file = tempfile.mkstemp()[1]
 
 
 class PostHandler(BaseHTTPRequestHandler):
+    """Handles POST requests by extracting JSON data and storing in a queue."""
+
+    post_data = []
 
     def do_POST(self):
-        # Handle request, load JSON data and save it to file
+        """Handle request, load JSON data and store it in a queue."""
         assert 'application/json' in self.headers['Content-Type'].lower()
-        self.data_string = self.rfile.read(int(self.headers['Content-Length']))
-        data = json.loads(self.data_string)
+        content_length = int(self.headers['Content-Length'])
 
-        with open(data_file, 'w') as fp:
-            json.dump(data, fp)
+        # self.rfile is opened in binary mode so we need to .decode() the
+        # contents into a unicode string.
+        data_string = self.rfile.read(content_length).decode()
+        self.post_data.append(json.loads(data_string))
 
         self.send_response(200)
         self.send_header('Content-Type', 'application/json')
         self.end_headers()
 
 
-@testsuite
+@multitest.testsuite
 class Alpha(object):
 
-    @testcase
+    @multitest.testcase
     def test_comparison(self, env, result):
         result.equal(1, 1, 'equality description')
 
-    @testcase
+    @multitest.testcase
     def test_membership(self, env, result):
         result.contain(1, [1, 2, 3])
 
 
-@testsuite
+@multitest.testsuite
 class Beta(object):
 
-    @testcase
+    @multitest.testcase
     def test_failure(self, env, result):
         result.equal(1, 2, 'failing assertion')
         result.equal(5, 10)
 
-    @testcase
+    @multitest.testcase
     def test_error(self, env, result):
         raise Exception('foo')
 
 
-def test_http_exporter(tmpdir):
+@pytest.fixture(scope="module")
+def http_server():
     """
-    HTTP Exporter should send a json report to the given `http_url`.
+    Yields an HTTP server object, which stores JSON data from received POST
+    requests in a .post_data queue.
     """
+    PostHandler.post_data = []
     server = HTTPServer(("", 0), PostHandler)
-    http_url = 'http://localhost:{}'.format(server.server_port)
     start_thread = threading.Thread(target=server.serve_forever)
     start_thread.daemon = True
     start_thread.start()
 
-    if os.path.exists(data_file):
-        os.remove(data_file)
+    yield server
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        plan = Testplan(
-            name='plan', parse_cmdline=False,
-            exporters=HTTPExporter(url=http_url)
-        )
-        multitest_1 = MultiTest(name='Primary', suites=[Alpha()])
-        multitest_2 = MultiTest(name='Secondary', suites=[Beta()])
-        plan.add(multitest_1)
-        plan.add(multitest_2)
-        plan.run()
-
-    assert os.path.exists(data_file)
-    assert os.stat(data_file).st_size > 0
-    os.remove(data_file)
-
-    shutdown_thread = threading.Thread(target=server.serve_forever)
-    shutdown_thread.daemon = True
-    shutdown_thread.start()
+    server.shutdown()
+    start_thread.join()
 
 
-def test_implicit_exporter_initialization(tmpdir):
+def test_http_exporter(http_server):
+    """
+    HTTP Exporter should send a json report to the given `http_url`.
+    """
+    http_url = 'http://localhost:{}'.format(http_server.server_port)
+
+    plan = Testplan(
+        name='plan', parse_cmdline=False,
+        exporters=HTTPExporter(url=http_url))
+    multitest_1 = multitest.MultiTest(name='Primary', suites=[Alpha()])
+    multitest_2 = multitest.MultiTest(name='Secondary', suites=[Beta()])
+    plan.add(multitest_1)
+    plan.add(multitest_2)
+    plan.run()
+
+    assert len(PostHandler.post_data) == 1
+    PostHandler.post_data.pop()
+
+
+def test_implicit_exporter_initialization(http_server):
     """
     An implicit exporting should be done if `http_url` is available
     via cmdline args but no exporters were declared programmatically.
     """
-    server = HTTPServer(("", 0), PostHandler)
-    http_url = 'http://localhost:{}'.format(server.server_port)
-    start_thread = threading.Thread(target=server.serve_forever)
-    start_thread.daemon = True
-    start_thread.start()
+    http_url = 'http://localhost:{}'.format(http_server.server_port)
 
-    if os.path.exists(data_file):
-        os.remove(data_file)
+    with argv_overridden('--http', http_url):
+        plan = Testplan(name='plan')
+        multitest_1 = multitest.MultiTest(name='Primary', suites=[Alpha()])
+        plan.add(multitest_1)
+        plan.run()
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        with argv_overridden('--http', http_url):
-            plan = Testplan(name='plan')
-            multitest_1 = MultiTest(name='Primary', suites=[Alpha()])
-            plan.add(multitest_1)
-            plan.run()
-
-    assert os.path.exists(data_file)
-    assert os.stat(data_file).st_size > 0
-    os.remove(data_file)
-
-    shutdown_thread = threading.Thread(target=server.serve_forever)
-    shutdown_thread.daemon = True
-    shutdown_thread.start()
+    assert len(PostHandler.post_data) == 1
+    PostHandler.post_data.pop()


### PR DESCRIPTION
Need to explicitly decode bytes to unicode before parsing
JSON from a string in python versions between 3.0-3.6.
Enhance test to store parsed JSON in-memory instead of
writing to a temp file and use a shared HTTP server fixture.