### PR TITLE
Refactor basicAssertionUtils

### DIFF
--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/BasicAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/BasicAssertion.js
@@ -18,7 +18,7 @@ import {prepareBasicContent} from './basicAssertionUtils';
  * |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|
  * | preContent    | rightContent  |
  * |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|
- * | postContent                   |
+ * | postTitle                     |
  * |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|
  * | postContent                   |
  * |_______________________________|

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/basicAssertionUtils.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/basicAssertionUtils.js
@@ -4,6 +4,451 @@ import {hashCode} from '../../Common/utils';
 /** @module basicAssertionUtils */
 
 /**
+ * Content required to render a basic assertion. The content is rendered by the
+ * BasicAssertion component, refer to that component for a diagram of how each
+ * content section is displayed.
+ *
+ * @typedef {Object} AssertionContent
+ * @property {object|string|null} preTitle - Content above the assertion title
+ * @property {object|string|null} preContent - Content between the preTitle and
+ *                                             the title
+ * @property {object|string|null} leftTitle - Left side of the title
+ * @property {object|string|null} rightTitle - Right side of the title
+ * @property {object|string|null} leftContent - Left side of the main content
+ * @property {object|string|null} rightContent - Right side of the main content
+ * @property {object|string|null} postTitle - Content immediately below the
+ *                                            title
+ * @property {object|string|null} postContent - Final content of assertion
+ */
+
+/**
+ * Prepare the content for the Log assertion.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for Log assertion
+ * @private
+ */
+function prepareLogContent(assertion, defaultContent) {
+  const preContent = (
+    <span>
+      {assertion.message !== undefined ? assertion.message : null}
+     </span>
+  );
+
+  return {
+    ...defaultContent,
+    preContent: preContent,
+    leftTitle: null,
+    rightTitle: null,
+  };
+}
+
+/**
+ * Prepare the content for the Equal assertion.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for Equal assertion
+ * @private
+ */
+function prepareEqualContent(assertion, defaultContent) {
+  const leftContent = <span>{assertion.second}</span>;
+
+  return {
+    ...defaultContent,
+    leftContent: leftContent,
+  };
+}
+
+/**
+ * Prepare the content for the NotEqual assertion.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for NotEqual assertion
+ * @private
+ */
+function prepareNotEqualContent(assertion, defaultContent) {
+  const leftContent = <span>&lt;not&gt; {assertion.second}</span>;
+
+  return {
+    ...defaultContent,
+    leftContent: leftContent,
+  };
+}
+
+/**
+ * Prepare the content for comparison assertions (lessThan,
+ * greaterThan etc.).
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for comparison assertion
+ * @private
+ */
+function prepareComparisonContent(assertion, defaultContent) {
+    const leftContent = (
+      <span>value {assertion.label} {assertion.second}</span>
+    );
+
+  return {
+    ...defaultContent,
+    leftContent: leftContent,
+  };
+}
+
+/**
+ * Prepare the content for the IsClose assertion.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for IsClose assertion
+ * @private
+ */
+function prepareIsCloseContent(assertion, defaultContent) {
+  const leftContent = (
+    <span>
+      value {assertion.label} {assertion.second}
+      &nbsp;within rel_tol={assertion.rel_tol} or abs_tol={assertion.abs_tol}
+    </span>
+  );
+
+  return {
+    ...defaultContent,
+    leftContent: leftContent,
+  };
+}
+
+/**
+ * Prepare the content for the IsTrue assertion.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for IsTrue assertion
+ * @private
+ */
+function prepareIsTrueContent(assertion, defaultContent) {
+  const leftContent = <span>value is True</span>;
+  const rightContent = (
+    <span>{assertion.passed ? `True` : `False`}</span>
+  );
+
+  return {
+    ...defaultContent,
+    leftContent: leftContent,
+    rightContent: rightContent,
+  };
+}
+
+/**
+ * Prepare the content for the IsFalse assertion.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for IsFalse assertion
+ * @private
+ */
+function prepareIsFalseContent(assertion, defaultContent) {
+  const leftContent = <span>value is False</span>;
+  const rightContent = (
+    <span>{assertion.passed ? `False` : `True`}</span>
+  );
+
+  return {
+    ...defaultContent,
+    leftContent: leftContent,
+    rightContent: rightContent,
+  };
+}
+
+/**
+ * Prepare the content for the Fail assertion.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for Fail assertion
+ * @private
+ */
+function prepareFailContent(assertion, defaultContent) {
+  return {
+    ...defaultContent,
+    leftTitle: null,
+    rightTitle: null,
+    leftContent: null,
+    rightContent: null,
+  };
+}
+
+/**
+ * Prepare the content for the Contain assertion.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for Contain assertion
+ * @private
+ */
+function prepareContainContent(assertion, defaultContent) {
+  const leftContent = <span>{assertion.member} &lt;in&gt; value</span>;
+  const rightContent = <span>{assertion.container}</span>;
+  return {
+    ...defaultContent,
+    leftContent: leftContent,
+    rightContent: rightContent,
+  };
+}
+
+/**
+ * Prepare the content for the NotContain assertion.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for NotContain assertion
+ * @private
+ */
+function prepareNotContainContent(assertion, defaultContent) {
+  const leftContent = (
+    <span>{assertion.member} &lt;not in&gt; value</span>
+  );
+  const rightContent = <span>{assertion.container}</span>;
+
+  return {
+    ...defaultContent,
+    leftContent: leftContent,
+    rightContent: rightContent,
+  };
+}
+
+/**
+ * Prepare the content for the LineDiff assertion.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for LineDiff assertion
+ * @private
+ */
+function prepareLineDiffContent(assertion, defaultContent) {
+  const uid = hashCode(JSON.stringify(assertion));
+  const leftContent = (
+    <span>
+      {
+        assertion.delta.map(
+          (line, index) => {
+            return (
+              <span
+                key={"LineDiffleftContent" + uid + index}
+                style={{ whiteSpace: 'pre' }}
+              >
+                {line}
+              </span>
+            );
+          }
+        )
+      }
+    </span>
+  );
+  const leftTitle = (
+    <span>{!assertion.passed ? 'Differences:' : 'No differences.'}</span>
+  );
+
+  return {
+    ...defaultContent,
+    leftContent: leftContent,
+    rightContent: null,
+    leftTitle: leftTitle,
+    rightTitle: null,
+  };
+}
+
+/*
+ * Prepare the content for the ExceptionRaised and ExceptionNotRaised
+ * assertions.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for exception assertion
+ * @private
+ */
+function prepareExceptionContent(assertion, defaultContent) {
+  const leftContent = <span>{assertion.expected_exceptions}</span>;
+  const rightContent = (
+    <span>
+      {assertion.raised_exception[0]} (value: {assertion.raised_exception[1]})
+    </span>
+  );
+  const leftTitle = <span>Expected exceptions:</span>;
+  const rightTitle = <span>Raised exceptions:</span>;
+
+  return {
+    ...defaultContent,
+    leftContent: leftContent,
+    rightContent: rightContent,
+    leftTitle: leftTitle,
+    rightTitle: rightTitle,
+  };
+}
+
+/*
+ * Prepare the content for the RegexMatch, RegexMatchNotExists, RegexSearch,
+ * RegexSearchNotExists and RegexFindIter assertions.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for regex assertion
+ * @private
+ */
+function prepareRegexContent(assertion, defaultContent) {
+  const assertionString = assertion.string;
+  let reconstructedString = [];
+  let prevIdx = 0;
+  const uid = hashCode(JSON.stringify(assertion)).toString();
+
+  assertion.match_indexes.forEach(index => {
+    reconstructedString.push(
+      <span key={uid + index + '0'}>
+        {assertionString.slice(prevIdx, index[0])}
+      </span>
+    );
+    reconstructedString.push(
+      <span
+        style={{ backgroundColor: 'rgba(0, 123, 255, .5)' }}
+        key={uid + index + '1'}
+      >
+        {assertionString.slice(index[0], index[1])}
+      </span>
+    );
+    prevIdx = index[1];
+  });
+
+  reconstructedString.push(
+    <span key={uid + prevIdx}>
+      {assertionString.slice(prevIdx)}
+    </span>
+  );
+
+  const leftContent = (
+    <div>
+      <span>{assertion.pattern}</span>
+      <span>
+        {
+          assertion.condition && (
+            <div key={assertion.uid}>
+              <br/>
+              <strong>Condition:</strong>
+              <br/>
+              <span>{assertion.condition}</span>
+            </div>
+          )
+        }
+      </span>
+    </div>
+  );
+  const rightContent = (
+    <span style={{ whiteSpace: 'pre' }}>
+      {reconstructedString}
+    </span>
+  );
+  const leftTitle = <span>Pattern:</span>;
+  const rightTitle = <span>String:</span>;
+
+  return {
+    ...defaultContent,
+    leftContent: leftContent,
+    rightContent: rightContent,
+    leftTitle: leftTitle,
+    rightTitle: rightTitle,
+  };
+}
+
+/**
+ * Prepare the content for the RegexMatchLine assertion.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for RegexMatchLine assertion
+ * @private
+ */
+function prepareRegexMatchLineContent(assertion, defaultContent) {
+  const assertionString = assertion.string.split('\n');
+  const uid = hashCode(JSON.stringify(assertion));
+  const reconstructedString = assertion.match_indexes.map((index) => (
+      <span
+        key={uid + index}
+        style={{ backgroundColor: 'rgba(0, 123, 255, .5)' }}
+      >
+        {assertionString[index[0]].slice(index[1], index[2]) + '\n'}
+      </span>
+  ));
+
+  const leftContent = <span>{assertion.pattern}</span>;
+  const rightContent = (
+    <span style={{ whiteSpace: 'pre' }}>
+      {reconstructedString}
+    </span>
+  );
+  const leftTitle = <span>Pattern:</span>;
+  const rightTitle = <span>String:</span>;
+
+  return {
+    ...defaultContent,
+    leftContent: leftContent,
+    rightContent: rightContent,
+    leftTitle: leftTitle,
+    rightTitle: rightTitle,
+  };
+}
+
+/**
+ * Prepare the content for the XMLCheck assertion.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for XMLCheck assertion
+ * @private
+ */
+function prepareXMLCheckContent(assertion, defaultContent) {
+  const leftContent = <span>{assertion.xpath}</span>;
+  const rightContent = (
+    <span style={{ whiteSpace: 'pre' }}>
+      {assertion.xml.replace(/ {12}/g, '')}
+    </span>
+  );
+  const leftTitle = <span>Expected XPath:</span>;
+  const rightTitle = <span>XML:</span>;
+
+  return {
+    ...defaultContent,
+    leftContent: leftContent,
+    rightContent: rightContent,
+    leftTitle: leftTitle,
+    rightTitle: rightTitle,
+  };
+}
+
+/**
+ * Prepare the content for the EqualSlices and EqualExcludesSlices
+ * assertions.
+ * @param {object} assertion
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for equal slices assertion
+ * @private
+ */
+function prepareEqualSlicesContent(assertion, defaultContent) {
+  const preTitle = <span>Slices:</span>;
+  const preContent = (
+    <Fragment>
+      <span style={{ whiteSpace: 'pre' }}>
+        {assertion.data.map(slice => slice[0]).join('\n')}
+      </span>
+      <hr />
+    </Fragment>
+  );
+  const leftContent = (
+    <span>[{prepareSliceLists(assertion.expected, assertion.data)}]</span>
+  );
+  const rightContent = (
+    <span>[{prepareSliceLists(assertion.actual, assertion.data)}]</span>
+  );
+  const leftTitle = <span>Expected:</span>;
+  const rightTitle = <span>Value:</span>;
+
+  return {
+    ...defaultContent,
+    preTitle: preTitle,
+    preContent: preContent,
+    leftContent: leftContent,
+    rightContent: rightContent,
+    leftTitle: leftTitle,
+    rightTitle: rightTitle,
+  };
+}
+
+/**
  * Return a list of span components that wrap the elements of the list.
  * Each element is colored:
  *  - green if it falls in the slice and it matches the expected value,
@@ -43,21 +488,14 @@ function prepareSliceLists(list, data) {
 }
 
 /**
- * Return a span component to display DictCheck & FixCheck assertions.
- * E.g.:
- *
- * Existence check: [26, 22, 11]
- * Absence check: [444, 555]
- *
- * Values of the list will be red if they fail to make the existence/absence
- * conditions.
- *
+ * Prepare the content for the DictCheck and FixCheck assertions.
  * @param {object} assertion
- * @returns {object}
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for dict match assertion
  * @private
  */
-function prepareDictCheckContent(assertion) {
-  return (
+function prepareDictCheckContent(assertion, defaultContent) {
+  const preContent = (
     <span>
       Existence check:
       [{assertion.has_keys.map((key, index) =>
@@ -82,75 +520,13 @@ function prepareDictCheckContent(assertion) {
         </span>).reduce((prev, curr) => [prev, ', ', curr])}]
     </span>
   );
-}
 
-/**
- * Return a span component that wraps the checked string of Regex assertions
- * where matches will be highlighted.
- *
- * @param {object} assertion
- * @returns {Array}
- * @private
- */
-function prepareRegexContent(assertion) {
-  const assertionString = assertion.string;
-  let reconstructedString = [];
-  let prevIdx = 0;
-
-  let uid = hashCode(JSON.stringify(assertion)).toString();
-
-  assertion.match_indexes.forEach(index => {
-    reconstructedString.push(
-      <span key={uid + index + '0'}>
-        {assertionString.slice(prevIdx, index[0])}
-      </span>
-    );
-    reconstructedString.push(
-      <span
-        style={{ backgroundColor: 'rgba(0, 123, 255, .5)' }}
-        key={uid + index + '1'}
-      >
-        {assertionString.slice(index[0], index[1])}
-      </span>
-    );
-    prevIdx = index[1];
-  });
-
-  reconstructedString.push(
-    <span key={uid + prevIdx}>
-      {assertionString.slice(prevIdx)}
-    </span>
-  );
-
-  return reconstructedString;
-}
-
-/**
- *  Return a span component that wraps the checked string of RegexMatchLine
- *  assertion where matches will be highlighted.
- *
- * @param {object} assertion
- * @returns {Array}
- * @private
- */
-function prepareRegexMatchLineContent(assertion) {
-  let assertionString = assertion.string.split('\n');
-  let reconstructedString = [];
-
-  let uid = hashCode(JSON.stringify(assertion));
-
-  assertion.match_indexes.forEach(index => {
-    reconstructedString.push(
-      <span
-        key={uid + index}
-        style={{ backgroundColor: 'rgba(0, 123, 255, .5)' }}
-      >
-        {assertionString[index[0]].slice(index[1], index[2]) + '\n'}
-      </span>
-    );
-  });
-
-  return reconstructedString;
+  return {
+    ...defaultContent,
+    preContent: preContent,
+    leftTitle: null,
+    rightTitle: null,
+  };
 }
 
 /*
@@ -159,10 +535,11 @@ function prepareRegexMatchLineContent(assertion) {
  * the filetype and e.g. render image files inline.
  *
  * @param {object} assertion
- * @returns {object}
+ * @param {AssertionContent} defaultContent
+ * @return {AssertionContent} Content for attachment assertion
  * @private
  */
-function prepareAttachmentContent(assertion) {
+function prepareAttachmentContent(assertion, defaultContent) {
   const paths = window.location.pathname.split('/');
   let downloadLink;
 
@@ -185,37 +562,25 @@ function prepareAttachmentContent(assertion) {
   }
 
   return {
-    preTitle: null,
-    preContent: null,
+    ...defaultContent,
     leftTitle: null,
     rightTitle: null,
     leftContent: downloadLink,
     rightContent: null,
-    postTitle: null,
-    postContent: null,
-  }
+  };
 }
 
 /**
  * Prepare the contents of the BasicAssertion component.
  *
  * @param {object} assertion
- * @returns {{
- *    preTitle: object|string|null,
- *    preContent: object|string|null,
- *    leftTitle: object|string|null,
- *    rightTitle: object|string|null,
- *    leftContent: object|string|null,
- *    rightContent: object|string|null,
- *    postTitle: object|string|null,
- *    postContent: object|string|null
- * }}
+ * @returns {AssertionContent} Content for the assertion based on its type.
  * @public
  */
 function prepareBasicContent(assertion) {
-  // This is a long function with lots of if elses, however I think it shows
-  // what it is doing a clearly and simply as it can
-  let content = {
+  // Default content for a basic assertion. Specific assertion types will
+  // modify this content.
+  const defaultContent = {
     preTitle: null,
     preContent: null,
     leftTitle: 'Expected:',
@@ -224,176 +589,84 @@ function prepareBasicContent(assertion) {
     rightContent: assertion.first,
     postTitle: null,
     postContent: null,
-  };
-
-  var uid = hashCode(JSON.stringify(assertion));
-
-  if (assertion.type === 'Log') {
-    content['preContent'] = (
-      <span>
-        {assertion.message !== undefined ? assertion.message : null}
-      </span>
-    );
-    content['leftTitle'] = null;
-    content['rightTitle'] = null;
-
-  } else if (assertion.type === 'Equal') {
-    content['leftContent'] = <span>{assertion.second}</span>;
-
-  } else if (assertion.type === 'NotEqual') {
-    content['leftContent'] = <span>&lt;not&gt; {assertion.second}</span>;
-
-  } else if (['Greater', 'GreaterEqual', 'Less', 'LessEqual']
-    .indexOf(assertion.type) >= 0) {
-    content['leftContent'] =
-      <span>value {assertion.label} {assertion.second}</span>;
-
-  } else if (assertion.type === 'IsClose') {
-    content['leftContent'] =
-      <span>
-        value {assertion.label} {assertion.second}
-        &nbsp;within rel_tol={assertion.rel_tol} or abs_tol={assertion.abs_tol}
-      </span>;
-
-  } else if (assertion.type === 'IsTrue') {
-    content['leftContent'] = <span>value is True</span>;
-    content['rightContent'] =
-      <span>{assertion.passed ? `True` : `False`}</span>;
-
-  } else if (assertion.type === 'IsFalse') {
-    content['leftContent'] = <span>value is False</span>;
-    content['rightContent'] =
-      <span>{assertion.passed ? `False` : `True`}</span>;
-
-  } else if (assertion.type === 'Fail') {
-    content['leftContent'] = null;
-    content['rightContent'] = null;
-    content['leftTitle'] = null;
-    content['rightTitle'] = null;
-
-  } else if (assertion.type === 'Contain') {
-    content['leftContent'] = <span>{assertion.member} &lt;in&gt; value</span>;
-    content['rightContent'] = <span>{assertion.container}</span>;
-
-  } else if (assertion.type === 'NotContain') {
-    content['leftContent'] =
-      <span>{assertion.member} &lt;not in&gt; value</span>;
-    content['rightContent'] = <span>{assertion.container}</span>;
-
-  } else if (assertion.type === 'LineDiff') {
-    content['leftContent'] =
-      <span>
-        {assertion.delta.map(
-          (line, index) => {
-            return (
-              <span
-                key={"LineDiffleftContent"+uid+index}
-                style={{ whiteSpace: 'pre' }}
-              >
-                {line}
-              </span>
-            );
-          }
-        )}
-      </span>;
-    content['rightContent'] = null;
-    content['leftTitle'] =
-      <span>{!assertion.passed ? 'Differences:' : 'No differences.'}</span>;
-    content['rightTitle'] = null;
-
-  } else if (['ExceptionRaised', 'ExceptionNotRaised']
-    .indexOf(assertion.type) >= 0
-  ) {
-    content['leftContent'] = <span>{assertion.expected_exceptions}</span>;
-    content['rightContent'] =
-      <span>
-        {assertion.raised_exception[0]} (value: {assertion.raised_exception[1]})
-      </span>;
-    content['leftTitle'] = <span>Expected exceptions:</span>;
-    content['rightTitle'] = <span>Raised exceptions:</span>;
-
-  } else if (
-    [
-      'RegexMatch',
-      'RegexMatchNotExists',
-      'RegexSearch',
-      'RegexSearchNotExists',
-      'RegexFindIter'
-    ].indexOf(assertion.type) >= 0
-  ) {
-    content['leftContent'] = (
-        <div>
-            <span>{assertion.pattern}</span>
-            <span>
-                {
-                    assertion.condition &&
-                    (
-                     <div key={assertion.uid}>
-                        <br/>
-                        <strong>Condition:</strong>
-                        <br/>
-                        <span>{assertion.condition}</span>
-                     </div>
-                    )
-                 }
-            </span>
-        </div>
-    );
-    content['rightContent'] =
-      <span style={{ whiteSpace: 'pre' }}>
-        {prepareRegexContent(assertion)}
-      </span>;
-    content['leftTitle'] = <span>Pattern:</span>;
-    content['rightTitle'] = <span>String:</span>;
-
-  } else if (assertion.type === 'RegexMatchLine') {
-    content['leftContent'] = <span>{assertion.pattern}</span>;
-    content['rightContent'] =
-      <span style={{ whiteSpace: 'pre' }}>
-        {prepareRegexMatchLineContent(assertion)}
-      </span>;
-    content['leftTitle'] = <span>Pattern:</span>;
-    content['rightTitle'] = <span>String:</span>;
-
-  } else if (assertion.type === 'XMLCheck') {
-    content['leftContent'] = <span>{assertion.xpath}</span>;
-    content['rightContent'] =
-      <span style={{ whiteSpace: 'pre' }}>
-        {assertion.xml.replace(/ {12}/g, '')}
-      </span>;
-    content['leftTitle'] = <span>Expected XPath:</span>;
-    content['rightTitle'] = <span>XML:</span>;
-
-  } else if (
-    ['EqualSlices', 'EqualExcludeSlices'].indexOf(assertion.type) >= 0
-  ) {
-    content['preTitle'] = <span>Slices:</span>;
-    content['preContent'] =
-      <Fragment>
-        <span style={{ whiteSpace: 'pre' }}>
-          {assertion.data.map(slice => slice[0]).join('\n')}
-        </span>
-        <hr />
-      </Fragment>;
-    content['leftContent'] =
-      <span>[{prepareSliceLists(assertion.expected, assertion.data)}]</span>;
-    content['rightContent'] =
-      <span>[{prepareSliceLists(assertion.actual, assertion.data)}]</span>;
-    content['leftTitle'] = <span>Expected:</span>;
-    content['rightTitle'] = <span>Value:</span>;
-
-  } else if (['DictCheck', 'FixCheck'].indexOf(assertion.type) >= 0) {
-    content['leftTitle'] = null;
-    content['rightTitle'] = null;
-    content['preContent'] = prepareDictCheckContent(assertion);
-  } else if (assertion.type === 'Attachment') {
-    content = prepareAttachmentContent(assertion);
   }
 
-  return content;
-}
+  // Fan out to the relevant function to prepare content for each assertion
+  // type.
+  switch (assertion.type) {
+    case 'Log':
+      return prepareLogContent(assertion, defaultContent);
 
+    case 'Equal':
+      return prepareEqualContent(assertion, defaultContent);
+
+    case 'NotEqual':
+      return prepareNotEqualContent(assertion, defaultContent);
+
+    case 'Greater':
+    case 'GreaterEqual':
+    case 'Less':
+    case 'LessEqual':
+      return prepareComparisonContent(assertion, defaultContent);
+
+    case 'IsClose':
+      return prepareIsCloseContent(assertion, defaultContent);
+
+    case 'IsTrue':
+      return prepareIsTrueContent(assertion, defaultContent);
+
+    case 'IsFalse':
+      return prepareIsFalseContent(assertion, defaultContent);
+
+    case 'Fail':
+      return prepareFailContent(assertion, defaultContent);
+
+    case 'Contain':
+      return prepareContainContent(assertion, defaultContent);
+
+    case 'NotContain':
+      return prepareNotContainContent(assertion, defaultContent);
+
+    case 'LineDiff':
+      return prepareLineDiffContent(assertion, defaultContent);
+
+    case 'ExceptionRaised':
+    case 'ExceptionNotRaised':
+      return prepareExceptionContent(assertion, defaultContent);
+
+
+    case 'RegexMatch':
+    case 'RegexMatchNotExists':
+    case 'RegexSearch':
+    case 'RegexSearchNotExists':
+    case 'RegexFindIter':
+      return prepareRegexContent(assertion, defaultContent);
+
+    case 'RegexMatchLine':
+      return prepareRegexMatchLineContent(assertion, defaultContent);
+
+
+    case 'XMLCheck':
+      return prepareXMLCheckContent(assertion, defaultContent);
+
+    case 'EqualSlices':
+    case 'EqualExcludeSlices':
+      return prepareEqualSlicesContent(assertion, defaultContent);
+
+
+    case 'DictCheck':
+    case 'FixCheck':
+      return prepareDictCheckContent(assertion, defaultContent);
+
+    case 'Attachment':
+      return prepareAttachmentContent(assertion, defaultContent);
+
+    default:
+      return defaultContent;
+  }
+}
 
 export {
   prepareBasicContent,
 };
+


### PR DESCRIPTION
Refactor if/else spaghetti into switch cases so that the
basic assertions are easier to extend and maintain.