### PR TITLE
Import testplan before PIL in example

### DIFF
--- a/examples/Attachments/test_plan.py
+++ b/examples/Attachments/test_plan.py
@@ -4,10 +4,9 @@ import tempfile
 import os
 import sys
 
-from PIL import Image, ImageDraw
-
 import testplan
 from testplan.testing import multitest
+from PIL import Image, ImageDraw
 
 
 @multitest.testsuite


### PR DESCRIPTION
In the attachments example, import the testplan package before importing
the third-party PIL package. This ensures that dependencies can be loaded
automatically when testplan is first imported.