### PR TITLE
A small fix for HTTPExporter

### DIFF
--- a/testplan/exporters/testing/http/__init__.py
+++ b/testplan/exporters/testing/http/__init__.py
@@ -25,7 +25,7 @@ class HTTPExporterConfig(ExporterConfig):
     def get_options(cls):
         return {
             ConfigOption('url', default=None): Or(None,
-                Regex(r'^http[s]?://[\w\d_-]+(:\d{2,5})?$', flags=re.I))
+                Regex(r'^http[s]?://[\w\d_-]+(:\d{2,5})?.+$', flags=re.I))
         }
 
 
@@ -53,7 +53,7 @@ class HTTPExporter(Exporter):
             test_plan_schema = TestReportSchema(strict=True)
             data = test_plan_schema.dump(source).data
             headers = {
-                'Content-Type': 'application/json; charset=UTF-8',
+                'Content-Type': 'application/json',
                 'Accept': 'application/json, text/javascript, */*; q=0.01'
             }
             try:


### PR DESCRIPTION
* Fix the regular expression of the url where the report is posted.
* In HTTP header, the content type should not accept "charset"
  field -- that is an extended feature of some web server.