### PR TITLE
Fix race condition in parallel MTest example

### DIFF
--- a/examples/Multitest/Parallel/parallel_tasks.py
+++ b/examples/Multitest/Parallel/parallel_tasks.py
@@ -28,8 +28,23 @@ class SampleTest(object):
     """
 
     def __init__(self):
-        self._test_g2_1_done = threading.Event()
+        # A Barrier is a synchronisation primitive which allows a fixed number
+        # of threads (in our case, 2) to wait for each other. We use it here
+        # to demonstrate that testcases are run concurrently and how they may
+        # be synchronised with each other.
+        #
+        # Note that on Python 3 you can use the Barrier class from the standard
+        # library:
+        # https://docs.python.org/3.7/library/threading.html#barrier-objects .
+        # Here we use a backported Barrier provided by Testplan, which works
+        # on both Python 2 and 3.
         self._barrier = thread_utils.Barrier(2)
+
+        # The Event synchronisation primitive allows one thread to signal to
+        # another that is waiting on the first thread to do some work. We use
+        # it here to demonstrate another way testcases within the same
+        # execution group may be synchronised with each other.
+        self._test_g2_1_done = threading.Event()
 
     @testcase(execution_group='first')
     def test_g1_1(self, env, result):

--- a/testplan/common/utils/thread.py
+++ b/testplan/common/utils/thread.py
@@ -71,3 +71,51 @@ def interruptible_join(thread, timeout=None):
             'Thread {thr} timed out after {timeout} seconds.'
             .format(thr=thread, timeout=timeout))
 
+
+class Barrier(object):
+    """
+    Implements a re-usable, two-phase barrier. Allows a fixed number of threads
+    to wait for each other to reach a certain point.
+
+    For python >= 3.2 you can just use
+    threading.Barrier instead, this class is provided for
+    compatibility with Python 2.
+
+    :param n: Number of threads to wait for at the barrier.
+    :type n: ``int``
+    """
+
+    def __init__(self, n):
+        self.n = n
+        self._count = 0
+        self._mutex = threading.Lock()
+        self._turnstile = threading.Semaphore(0)
+        self._turnstile2 = threading.Semaphore(0)
+
+    def wait(self):
+        """Wait for all threads to reach the barrier before returning."""
+        self._phase1()
+        self._phase2()
+
+    def _phase1(self):
+        """
+        Phase 1: waits for all threads to reach this point and increment the
+        count.
+        """
+        with self._mutex:
+            self._count += 1
+            if self._count == self.n:
+                for _ in range(self.n):
+                    self._turnstile.release()
+
+        self._turnstile.acquire()
+
+    def _phase2(self):
+        """Phase 2: resets the count so that the barrier can be reused."""
+        with self._mutex:
+            self._count -= 1
+            if self._count == 0:
+                for _ in range(self.n):
+                    self._turnstile2.release()
+
+        self._turnstile2.acquire()


### PR DESCRIPTION
Should not rely on time.sleep for synchronisation - use Barrier and
Event primitives instead. Add a Lock to protect the shared refcounts
counter inside the ExclusiveResourceManager driver.