### PR TITLE
Change the behavior of exporters

### DIFF
--- a/testplan/base.py
+++ b/testplan/base.py
@@ -1,6 +1,5 @@
 """Testplan base module."""
 
-import signal
 import random
 
 from testplan import defaults
@@ -10,12 +9,11 @@ from .common.config import ConfigOption
 from .common.entity import (RunnableManager, RunnableManagerConfig, Resource)
 from .common.utils.callable import arity
 from .common.utils.validation import is_subclass, has_method
-from .common.utils.path import default_runpath
 from .parser import TestplanParser
 from .runners import LocalRunner
 from .runnable.interactive import TestRunnerIHandler
 from .environment import Environments
-from .testing import filtering, ordering
+
 
 class TestplanConfig(RunnableManagerConfig, TestRunnerConfig):
     """

--- a/testplan/exporters/testing/http/__init__.py
+++ b/testplan/exporters/testing/http/__init__.py
@@ -18,7 +18,7 @@ from ..base import Exporter
 class HTTPExporterConfig(ExporterConfig):
     """
     Configuration object for
-    :py:class:`HTTPExporter <testplan.exporters.testing.json.HTTPExporter>`
+    :py:class:`HTTPExporter <testplan.exporters.testing.http.HTTPExporter>`
     object.
     """
     @classmethod
@@ -41,12 +41,13 @@ class HTTPExporter(Exporter):
     """
     CONFIG = HTTPExporterConfig
 
-    def __init__(self, **options):
-        super(HTTPExporter, self).__init__(**options)
-
-    def export(self, source):
-
-        url = self.cfg.url
+    def _upload_report(self, url, source):
+        """
+        Upload Json report, then return the response from server with an
+        error message (if any).
+        """
+        response = None
+        errmsg = ''
 
         if len(source):
             test_plan_schema = TestReportSchema(strict=True)
@@ -60,12 +61,21 @@ class HTTPExporter(Exporter):
                     url=url, data=json.dumps(data), headers=headers)
                 response.raise_for_status()
             except requests.exceptions.RequestException as exp:
-                self.logger.exporter_info(
-                    'Failed to export to {}: {}'.format(url, exp))
-            else:
-                self.logger.exporter_info(
-                    'Test report posted to {}'.format(url))
+                errmsg = 'Failed to export to {}: {}'.format(url, exp)
+        else:
+            errmsg = (
+                'Skipping exporting test report via http for empty report:'
+                ' {}'.format(source.name))
+
+        return response, errmsg
+
+    def export(self, source):
+
+        url = self.cfg.url
+        _, errmsg = self._upload_report(url, source)
+
+        if errmsg:
+            self.logger.exporter_info(errmsg)
         else:
             self.logger.exporter_info(
-                'Skipping exporting test report via http'
-                ' for empty report: {}'.format(source.name))
+                'Test report posted to {}'.format(url))

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -620,10 +620,9 @@ class TestRunner(Runnable):
     def _invoke_exporters(self):
         # Add this logic into a ReportExporter(Runnable)
         # that will return a result containing errors
-        if self.cfg.exporters is None or len(self.cfg.exporters) == 0:
-            exporters = get_default_exporters(self.cfg)
-        else:
-            exporters = self.cfg.exporters
+        exporters = get_default_exporters(self.cfg)
+        if self.cfg.exporters:
+            exporters.extend(self.cfg.exporters)
 
         if hasattr(self._result.test_report, 'bubble_up_attachments'):
             self._result.test_report.bubble_up_attachments()


### PR DESCRIPTION
* The original behavior is that if the exporters is programmatically
  specified then arguments from command line (such as --pdf, --json)
  is ignored. Change this behavior that all those exporters can take
  effect and work independently.
* Refactor `HTTPExporter` that code for uploading report is extracted
  as a private function.
* Fix typo.