### PR TITLE
Fix an issue of config option of exporters

### DIFF
--- a/testplan/common/config/base.py
+++ b/testplan/common/config/base.py
@@ -113,7 +113,8 @@ class Config(object):
         if self.parent:
             return getattr(self.parent, name)
         else:
-            raise AttributeError('Name: {}'.format(name))
+            raise AttributeError(
+                'Attribute "{}" not found in {}'.format(name, self))
 
     def __repr__(self):
         return '{}{}'.format(self.__class__.__name__,

--- a/testplan/exporters/testing/http/__init__.py
+++ b/testplan/exporters/testing/http/__init__.py
@@ -24,8 +24,8 @@ class HTTPExporterConfig(ExporterConfig):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption('url', default=None): Or(None,
-                Regex(r'^http[s]?://[\w\d_-]+(:\d{2,5})?.+$', flags=re.I))
+            ConfigOption('url'):
+                Regex(r'^http[s]?://[\w\d_-]+(:\d{2,5})?.+$', flags=re.I)
         }
 
 
@@ -46,8 +46,7 @@ class HTTPExporter(Exporter):
 
     def export(self, source):
 
-        if self.cfg.url is None:
-            raise ValueError('`url` cannot be None.')
+        url = self.cfg.url
 
         if len(source):
             test_plan_schema = TestReportSchema(strict=True)
@@ -58,14 +57,14 @@ class HTTPExporter(Exporter):
             }
             try:
                 response = requests.post(
-                    url=self.cfg.url, data=json.dumps(data), headers=headers)
+                    url=url, data=json.dumps(data), headers=headers)
                 response.raise_for_status()
             except requests.exceptions.RequestException as exp:
                 self.logger.exporter_info(
-                    'Failed to export to {}: {}'.format(self.cfg.url, exp))
+                    'Failed to export to {}: {}'.format(url, exp))
             else:
                 self.logger.exporter_info(
-                    'Test report posted to {}'.format(self.cfg.url))
+                    'Test report posted to {}'.format(url))
         else:
             self.logger.exporter_info(
                 'Skipping exporting test report via http'

--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -45,26 +45,25 @@ class JSONExporter(Exporter):
 
     def export(self, source):
 
-        if self.cfg.json_path is None:
-            raise ValueError('`json_path` cannot be None.')
+        json_path = self.cfg.json_path
 
         if len(source):
             test_plan_schema = TestReportSchema(strict=True)
             data = test_plan_schema.dump(source).data
 
             # Save the Testplan report.
-            with open(self.cfg.json_path, 'w') as json_file:
+            with open(json_path, 'w') as json_file:
                 json.dump(data, json_file)
 
             # Save any attachments.
             attachments_dir = os.path.join(
-                os.path.dirname(self.cfg.json_path),
+                os.path.dirname(json_path),
                 defaults.ATTACHMENTS
             )
             save_attachments(report=source, directory=attachments_dir)
 
             self.logger.exporter_info(
-                'JSON generated at {}'.format(self.cfg.json_path))
+                'JSON generated at {}'.format(json_path))
         else:
             self.logger.exporter_info(
                 'Skipping JSON creation'

--- a/testplan/exporters/testing/pdf/__init__.py
+++ b/testplan/exporters/testing/pdf/__init__.py
@@ -194,15 +194,14 @@ class PDFExporter(Exporter):
 
     def export(self, source):
 
-        if self.cfg.pdf_path is None:
-            raise ValueError('`pdf_path` cannot be None.')
+        pdf_path = self.cfg.pdf_path
 
         if len(source):
             create_pdf(source, self.cfg)
             TESTPLAN_LOGGER.exporter_info(
-                'PDF generated at {}'.format(self.cfg.pdf_path))
+                'PDF generated at {}'.format(pdf_path))
             self.url = 'file:{}'.format(
-                pathname2url(os.path.abspath(self.cfg.pdf_path)))
+                pathname2url(os.path.abspath(pdf_path)))
         else:
             TESTPLAN_LOGGER.exporter_info(
                 'Skipping PDF creation'

--- a/testplan/exporters/testing/webserver/base.py
+++ b/testplan/exporters/testing/webserver/base.py
@@ -52,9 +52,6 @@ class WebServerExporter(Exporter):
 
     def export(self, source):
         """Serve the web UI locally for our test report."""
-        if self.cfg.ui_port is None:
-            raise ValueError('`ui_port` cannot be None.')
-
         if not len(source):
             self.logger.exporter_info(
                 'Skipping starting web server'

--- a/testplan/exporters/testing/xml/__init__.py
+++ b/testplan/exporters/testing/xml/__init__.py
@@ -258,7 +258,7 @@ class XMLExporter(Exporter):
             filename = '{}.xml'.format(slugify(child_report.name))
             filename = unique_name(filename, files)
             files.add(filename)
-            file_path = os.path.join(self.cfg.xml_dir, filename)
+            file_path = os.path.join(xml_dir, filename)
 
             # If a report has XML string attribute it was mostly
             # generated via parsing a JUnit compatible XML file

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -113,9 +113,9 @@ class TestRunnerConfig(RunnableConfig):
             ConfigOption(
                 'exporters', default=None): Use(get_exporters),
             ConfigOption(
-                'stdout_style', default=defaults.STDOUT_STYLE,): Style,
+                'stdout_style', default=defaults.STDOUT_STYLE): Style,
             ConfigOption(
-                'report_dir', default=defaults.REPORT_DIR,): str,
+                'report_dir', default=defaults.REPORT_DIR): Or(str, None),
             ConfigOption('xml_dir', default=None,): Or(str, None),
             ConfigOption('pdf_path', default=None,): Or(str, None),
             ConfigOption('json_path', default=None,): Or(str, None),


### PR DESCRIPTION
* Each exporter has a config option (e.g. `json_path`, `http_url`) and
  this option is not repulsive because the exporter can get its value
  from parent(`TestRunner` instance) during runtime. Since it has no
  default value, if not explicitly specified in exporter constructor and
  the parent does not has that attribute, then the option is missing
  in exporter config. Before exporting we have a check to make sure
  the option cannot be `None`, otherwise raise exception, actually it
  will not work, Config.__getattr__() can directly raise exception,
  what we need to do is to make that error message clear.