### PR TITLE
Add a property `exporters` for `TestRunner`

### DIFF
--- a/testplan/exporters/testing/http/__init__.py
+++ b/testplan/exporters/testing/http/__init__.py
@@ -41,17 +41,15 @@ class HTTPExporter(Exporter):
     """
     CONFIG = HTTPExporterConfig
 
-    def _upload_report(self, url, source):
+    def _upload_report(self, url, data):
         """
-        Upload Json report, then return the response from server with an
+        Upload Json data, then return the response from server with an
         error message (if any).
         """
         response = None
         errmsg = ''
 
-        if len(source):
-            test_plan_schema = TestReportSchema(strict=True)
-            data = test_plan_schema.dump(source).data
+        if data and data['entries']:
             headers = {
                 'Content-Type': 'application/json',
                 'Accept': 'application/json, text/javascript, */*; q=0.01'
@@ -64,18 +62,19 @@ class HTTPExporter(Exporter):
                 errmsg = 'Failed to export to {}: {}'.format(url, exp)
         else:
             errmsg = (
-                'Skipping exporting test report via http for empty report:'
-                ' {}'.format(source.name))
+                'Skipping exporting test report via http '
+                'for empty report: %s', data.name)
 
         return response, errmsg
 
     def export(self, source):
 
         url = self.cfg.url
-        _, errmsg = self._upload_report(url, source)
+        test_plan_schema = TestReportSchema(strict=True)
+        data = test_plan_schema.dump(source).data
+        _, errmsg = self._upload_report(url, data)
 
         if errmsg:
             self.logger.exporter_info(errmsg)
         else:
-            self.logger.exporter_info(
-                'Test report posted to {}'.format(url))
+            self.logger.exporter_info('Test report posted to %s', url)

--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -63,8 +63,7 @@ class JSONExporter(Exporter):
             save_attachments(report=source, directory=attachments_dir)
 
             self.logger.exporter_info(
-                'JSON generated at {}'.format(json_path))
+                'JSON generated at %s', os.path.abspath(json_path))
         else:
             self.logger.exporter_info(
-                'Skipping JSON creation'
-                ' for empty report: {}'.format(source.name))
+                'Skipping JSON creation for empty report: %s', source.name)

--- a/testplan/exporters/testing/pdf/__init__.py
+++ b/testplan/exporters/testing/pdf/__init__.py
@@ -198,14 +198,13 @@ class PDFExporter(Exporter):
 
         if len(source):
             create_pdf(source, self.cfg)
-            TESTPLAN_LOGGER.exporter_info(
-                'PDF generated at {}'.format(pdf_path))
+            self.logger.exporter_info(
+                'PDF generated at %s', os.path.abspath(pdf_path))
             self.url = 'file:{}'.format(
                 pathname2url(os.path.abspath(pdf_path)))
         else:
-            TESTPLAN_LOGGER.exporter_info(
-                'Skipping PDF creation'
-                ' for empty report: {}'.format(source.name))
+            self.logger.exporter_info(
+                'Skipping PDF creation for empty report: %s', source.name)
 
 
 class TagFilteredPDFExporter(TagFilteredExporter):

--- a/testplan/exporters/testing/webserver/base.py
+++ b/testplan/exporters/testing/webserver/base.py
@@ -53,8 +53,8 @@ class WebServerExporter(Exporter):
         """Serve the web UI locally for our test report."""
         if not len(source):
             self.logger.exporter_info(
-                'Skipping starting web server'
-                ' for empty report: {}'.format(source.name))
+                'Skipping starting web server for '
+                'empty report: %s', source.name)
             return
 
         if not self._ui_installed:
@@ -77,8 +77,7 @@ class WebServerExporter(Exporter):
         attachments_dir = os.path.join(data_path, defaults.ATTACHMENTS)
         save_attachments(report=source, directory=attachments_dir)
 
-        self.logger.exporter_info(
-            'JSON generated at {}'.format(defaults.JSON_PATH))
+        self.logger.exporter_info('JSON generated at %s', defaults.JSON_PATH)
 
         # Start the web server.
         self._web_server_thread = web_app.WebServer(

--- a/testplan/exporters/testing/xml/__init__.py
+++ b/testplan/exporters/testing/xml/__init__.py
@@ -279,6 +279,7 @@ class XMLExporter(Exporter):
                     encoding='UTF-8'
                 )
 
-        TESTPLAN_LOGGER.exporter_info(
-            '%s XML files created at: %s', len(source), xml_dir)
+        self.logger.exporter_info(
+            '%s XML files created at %s', len(source), os.path.abspath(xml_dir)
+        )
 


### PR DESCRIPTION
* A `TestRunner` instance generates exporters only once, and it only
  depends on the constructor arguments. Add a private member to store
  these exporters and it can be accessed from outside as a property.
  Then the exporters know each other through their parent.
* After exporting, the log info should contain the full path of saved
  report rather than a single file name relative to the current path.
* All exporters use self.logger instead of `TESTPLAN_LOGGER`, and use %
  notation in `exporter_info`.