### PR TITLE
Fix "None" runpath issue on Process Pool

### DIFF
--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -262,8 +262,7 @@ class Pool(Executor):
         self._conn = self.CONN_MANAGER()
         self._conn.parent = self
         self._pool_lock = threading.Lock()
-        self._metadata = {}
-        self._metadata['runpath'] = self.runpath
+        self._metadata = None  # Set when Pool is started.
         self._exit_loop = False
         self._start_monitor_thread = True
 
@@ -645,6 +644,10 @@ class Pool(Executor):
         """Starting the pool and workers."""
         # TODO do we need a lock here?
         self.make_runpath_dirs()
+        if self.runpath is None:
+            raise RuntimeError("runpath was not set correctly")
+        self._metadata = {'runpath': self.runpath}
+
         self._conn.start()
 
         for worker in self._workers:

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -141,7 +141,10 @@ class ChildLoop(object):
 
         pool_metadata = response.sender_metadata
 
-        self.runpath = self.runpath or str(pool_metadata['runpath'])
+        if self.runpath is None:
+            if pool_metadata.get('runpath') is None:
+                raise RuntimeError("runpath was not set in pool metadata")
+            self.runpath = pool_metadata['runpath']
         self._setup_logfiles()
 
     def worker_loop(self):


### PR DESCRIPTION
Fixes https://github.com/Morgan-Stanley/testplan/issues/274 where the runpath used for Process Pool workers is the string
"None", resulting in a None/ directory being created in the local working
dir. self.runpath is not set until self.make_runpath_dirs() is called from
within self.starting().