### PR TITLE
Skip FIX example on Windows and add warning to Fix Server

### DIFF
--- a/examples/Transports/FIX/test_plan.py
+++ b/examples/Transports/FIX/test_plan.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 """
 This example demonstrates FIX communication via FixServer and FixClient drivers.
+
+NOTE: The FixServer driver implementation requires select.poll(), which is not
+available on all platforms. Typically it is available on POSIX systems but
+not on Windows. This example will not run correctly on platforms where
+select.poll() is not available.
 """
 
 import sys

--- a/testplan/testing/multitest/driver/fix/server.py
+++ b/testplan/testing/multitest/driver/fix/server.py
@@ -1,6 +1,8 @@
 """FixServer driver classes."""
 
 import os
+import select
+import platform
 
 from six.moves import queue
 from schema import Use
@@ -46,6 +48,10 @@ class FixServer(Driver):
     :py:class:`testplan.common.utils.sockets.fix.server.Server` class, which
     provides equivalent functionality and may be used outside of MultiTest.
 
+    NOTE: FixServer requires select.poll(), which is not implemented on all
+    operating systems - typically it is available on POSIX systems but not
+    on Windows.
+
     :param name: Name of FixServer.
     :type name: ``str``
     :param msgclass: Type used to send and receive FIX messages.
@@ -76,6 +82,13 @@ class FixServer(Driver):
         **options
     ):
         options.update(self.filter_locals(locals()))
+
+        if not hasattr(select, 'poll'):
+            raise RuntimeError(
+                'select.poll() is required for FixServer but is not available '
+                'on the current platform ({})'.format(platform.system())
+            )
+
         super(FixServer, self).__init__(**options)
         self._host = None
         self._port = None

--- a/tests/functional/examples/test_examples.py
+++ b/tests/functional/examples/test_examples.py
@@ -27,7 +27,6 @@ KNOWN_EXCEPTIONS = [
     r"ImportError: No module named _tkinter.*", # Missing module Tkinter. Will skip Data Science example.
     r"RuntimeError: Download pyfixmsg library .*", # Missing module pyfixmsg. Will skip FIX example.
     r"No spec file set\. You should download .*", # Missing FIX spec file. Will skip FIX example.
-    r"AttributeError: 'module' object has no attribute 'poll'",
     r"RuntimeError: You need to compile test binary first.", # Need to compile cpp binary first. Will skip GTest example.
     r"FATAL ERROR: Network error: Connection refused", # We don't fail a pool test for connection incapability.
     r"lost connection"
@@ -48,6 +47,7 @@ SKIP = [
 SKIP_ON_WINDOWS = [
     os.path.join('Cpp', 'GTest', 'test_plan.py'),
     os.path.join('Cpp', 'HobbesTest', 'test_plan.py'),
+    os.path.join('Transports', 'FIX', 'test_plan.py'),
 ]
 
 # Contents to look for under root dir.


### PR DESCRIPTION
Explicitly mark Fix example as skipped on Windows. Previously it would detect the "module object has no attribute poll" error message but this message has changed wording slightly on Python 3.7. Instead of relying on the exact wording of error messages and having fragile tests, just mark the FIX example as skipped on Windows for simplicity.