### PR TITLE
Fix a regular expression for URL in HTTP Exporter

### DIFF
--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -24,6 +24,7 @@ requests>=2.4.3
 flask
 flask_restplus
 cheroot
+validators
 
 # Documentation
 # ---------------

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ REQUIRED = [
     'flask',
     'flask_restplus',
     'cheroot',
+    'validators',
     'ipaddress',
 ]
 

--- a/testplan/common/utils/validation.py
+++ b/testplan/common/utils/validation.py
@@ -2,6 +2,7 @@
 This module contains helper validation functions
 to be used with configuration schemas.
 """
+import validators
 
 
 def is_subclass(parent_kls):
@@ -24,3 +25,8 @@ def has_method(method_name):
     def _validator(kls):
         return hasattr(kls, method_name) and callable(getattr(kls, method_name))
     return _validator
+
+
+def is_valid_url(url):
+    """Validator that checks if a url is valid"""
+    return True if validators.url(url) is True else False

--- a/testplan/exporters/testing/http/__init__.py
+++ b/testplan/exporters/testing/http/__init__.py
@@ -9,6 +9,7 @@ import requests
 from schema import Or, Regex
 
 from testplan.common.config import ConfigOption
+from testplan.common.utils.validation import is_valid_url
 from testplan.common.exporters import ExporterConfig
 from testplan.report.testing.schemas import TestReportSchema
 
@@ -24,8 +25,7 @@ class HTTPExporterConfig(ExporterConfig):
     @classmethod
     def get_options(cls):
         return {
-            ConfigOption('url'):
-                Regex(r'^http[s]?://[\w\d_-]+(:\d{2,5})?.+$', flags=re.I)
+            ConfigOption('url'): is_valid_url
         }
 
 


### PR DESCRIPTION
* The original regex has a ".+" at the end, that is not correct, it
  makes some obviously invalid url validated (e.g. http://xyz.c#o@m).
* Use `validators.url` method to check url string.