### PR TITLE
Add default value for '--http' option of argument parser

### DIFF
--- a/testplan/base.py
+++ b/testplan/base.py
@@ -113,10 +113,12 @@ class Testplan(entity.RunnableManager):
     :type report_dir: ``str``
     :param xml_dir: XML output directory.
     :type xml_dir: ``str``
-    :param pdf_path: PDF output path <PATH>/\*.pdf.
-    :type pdf_path: ``str``
     :param json_path: JSON output path <PATH>/\*.json.
     :type json_path: ``str``
+    :param http_url: HTTP url to post JSON report.
+    :type http_url: ``str``
+    :param pdf_path: PDF output path <PATH>/\*.pdf.
+    :type pdf_path: ``str``
     :param pdf_style: PDF creation styling options.
     :type pdf_style:
         :py:class:`Style <testplan.report.testing.styles.Style>`
@@ -150,7 +152,7 @@ class Testplan(entity.RunnableManager):
     :type timeout: ``NoneType`` or ``int`` or ``float`` greater than 0.
     :param interactive_handler: Handler for interactive mode execution.
     :type interactive_handler: Subclass of :py:class:
-        `TestRunnerIHandler <testplan.runnable.interactive.TestRunnerIHandler>`  # pylint: disable=line-too-long
+        `TestRunnerIHandler <testplan.runnable.interactive.TestRunnerIHandler>`
     :param extra_deps: Extra module dependencies for interactive reload.
     :type extra_deps: ``list`` of ``module``
     """
@@ -178,8 +180,9 @@ class Testplan(entity.RunnableManager):
                  stdout_style=defaults.STDOUT_STYLE,
                  report_dir=defaults.REPORT_DIR,
                  xml_dir=None,
-                 pdf_path=None,
                  json_path=None,
+                 http_url=None,
+                 pdf_path=None,
                  pdf_style=defaults.PDF_STYLE,
                  report_tags=None,
                  report_tags_all=None,
@@ -227,8 +230,9 @@ class Testplan(entity.RunnableManager):
             stdout_style=stdout_style,
             report_dir=report_dir,
             xml_dir=xml_dir,
-            pdf_path=pdf_path,
             json_path=json_path,
+            http_url=http_url,
+            pdf_path=pdf_path,
             pdf_style=pdf_style,
             report_tags=report_tags,
             report_tags_all=report_tags_all,
@@ -325,8 +329,9 @@ class Testplan(entity.RunnableManager):
                      stdout_style=defaults.STDOUT_STYLE,
                      report_dir=defaults.REPORT_DIR,
                      xml_dir=None,
-                     pdf_path=None,
                      json_path=None,
+                     http_url=None,
+                     pdf_path=None,
                      pdf_style=defaults.PDF_STYLE,
                      report_tags=None,
                      report_tags_all=None,
@@ -377,8 +382,9 @@ class Testplan(entity.RunnableManager):
                     stdout_style=stdout_style,
                     report_dir=report_dir,
                     xml_dir=xml_dir,
-                    pdf_path=pdf_path,
                     json_path=json_path,
+                    http_url=http_url,
+                    pdf_path=pdf_path,
                     pdf_style=pdf_style,
                     report_tags=report_tags,
                     report_tags_all=report_tags_all,

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -181,7 +181,8 @@ Test filter, runs tests that match ALL of the given tags.
 
         report_group.add_argument(
             '--http', dest='http_url',
-            default=None, metavar='URL',
+            default=self._default_options["http_url"],
+            metavar='URL',
             help='Web URL for posting report.'
         )
 

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -41,8 +41,8 @@ def get_default_exporters(config):
         result.append(test_exporters.JSONExporter())
     if config.xml_dir:
         result.append(test_exporters.XMLExporter())
-    if config.http_url is not None:
-        result.append(test_exporters.HTTPExporter(url=config.http_url))
+    if config.http_url:
+        result.append(test_exporters.HTTPExporter())
     if config.ui_port is not None:
         result.append(test_exporters.WebServerExporter(ui_port=config.ui_port))
     return result
@@ -654,8 +654,8 @@ class TestRunner(Runnable):
                 self._result.exporter_results.append(exp_result)
             else:
                 raise NotImplementedError(
-                    'Exporter logic not'
-                    ' implemented for: {}'.format(type(exporter)))
+                    'Exporter logic not implemented for: {}'.format(
+                        type(exporter)))
 
     def _post_exporters(self):
         report_opened = False

--- a/tests/functional/exporters/testing/test_http.py
+++ b/tests/functional/exporters/testing/test_http.py
@@ -81,7 +81,7 @@ def test_http_exporter(http_server):
 
     plan = Testplan(
         name='plan', parse_cmdline=False,
-        exporters=HTTPExporter(url=http_url))
+        exporters=HTTPExporter(http_url=http_url))
     multitest_1 = multitest.MultiTest(name='Primary', suites=[Alpha()])
     multitest_2 = multitest.MultiTest(name='Secondary', suites=[Beta()])
     plan.add(multitest_1)


### PR DESCRIPTION
* The config option 'url' changed to 'http_url' so that the exporter
  can find this value from parent (TestRunner) even not defined.
* Add 'http_url' argument in `test_plan` decorator.
* There was a change to use programmatically defined values as default
  value of command line argument parser, also apply it to 'http_url'.