### PR TITLE
Optimize update of interactive report

### DIFF
--- a/testplan/web_ui/testing/src/Nav/InteractiveNav.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNav.js
@@ -34,7 +34,22 @@ class InteractiveNav extends React.Component {
   handlePlayClick(e, navEntry) {
     e.stopPropagation();
     console.log("Running " + navEntry.name);
-    this.props.runEntry(navEntry);
+    const currSelected = this.state.selected[this.state.selected.length - 1];
+    if (currSelected === undefined) {
+      throw new Error("Expected a report element to be selected");
+    }
+
+    const clickedReportEntry = this.findClickedReportEntry(
+      currSelected,
+      navEntry,
+    );
+
+    const fullSelected = this.state.selected.concat([clickedReportEntry]);
+    this.props.runEntry(fullSelected);
+  }
+
+  findClickedReportEntry(currSelected, navEntry) {
+    return currSelected.entries.find((el) => el.uid === navEntry.uid);
   }
 
   render() {

--- a/testplan/web_ui/testing/src/Nav/InteractiveNav.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNav.js
@@ -35,8 +35,12 @@ class InteractiveNav extends React.Component {
     e.stopPropagation();
     console.log("Running " + navEntry.name);
     const currSelected = this.state.selected[this.state.selected.length - 1];
-    if (currSelected === undefined) {
-      throw new Error("Expected a report element to be selected");
+    if (!currSelected) {
+      alert(
+        "Error: Expected a report element to be selected. Selected = " +
+        this.state.selected
+      );
+      return;
     }
 
     const clickedReportEntry = this.findClickedReportEntry(

--- a/testplan/web_ui/testing/src/Report/__tests__/InteractiveReport.test.js
+++ b/testplan/web_ui/testing/src/Report/__tests__/InteractiveReport.test.js
@@ -12,10 +12,14 @@ describe('InteractiveReport', () => {
 
   it("updates testcase status to passed", () => {
     const interactiveReport = shallow(<InteractiveReport />);
-    const testcaseEntry = (
-      interactiveReport.state("report").entries[0].entries[0].entries[0]
-    );
-    interactiveReport.instance().setEntryStatus(testcaseEntry, "passed");
+    const reportState = interactiveReport.state("report");
+    const selectedEntries = [
+      reportState,
+      reportState.entries[0],
+      reportState.entries[0].entries[0],
+      reportState.entries[0].entries[0].entries[0],
+    ];
+    interactiveReport.instance().setEntryStatus(selectedEntries, "passed");
     interactiveReport.update();
 
     const newTestcaseEntry = (


### PR DESCRIPTION
Instead of checking every entry in the report exhaustively,
only check down branches that match the current selection
hierarchy (Testplan -> MultiTest -> testsuite -> testcase).
This will optimize the efficiency of updating the report for
reports that contain many entries.