### PR TITLE
Simplify auto-select for batch and interactive reports

### DIFF
--- a/testplan/web_ui/testing/src/Common/utils.js
+++ b/testplan/web_ui/testing/src/Common/utils.js
@@ -40,6 +40,17 @@ function getNavEntryDisplayData(entry) {
 }
 
 /**
+ * Convert a report entry into a nav entry type.
+ *
+ * @param {object} reportEntry - entry from report object.
+ * @returns {object}
+ */
+const ReportToNavEntry = (reportEntry) => ({
+  uid: reportEntry.uid,
+  type: getNavEntryType(reportEntry),
+});
+
+/**
  * Returns true of any element of an iterable is true. If not, returns false.
  *
  * @param iterable
@@ -82,7 +93,7 @@ function uniqueId() {
   return 'id-' + Math.random().toString(36).substr(2, 16);
 }
 
-/** 
+/**
  * Generate a hash code by string
  * @param {string} str - string that generate hash code
  * @returns {number}
@@ -112,6 +123,7 @@ function domToString(dom) {
 export {
   getNavEntryType,
   getNavEntryDisplayData,
+  ReportToNavEntry,
   any,
   sorted,
   uniqueId,

--- a/testplan/web_ui/testing/src/Nav/InteractiveNav.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNav.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import NavBreadcrumbs from "./NavBreadcrumbs";
 import InteractiveNavList from "./InteractiveNavList";
-import {ParseNavSelection, HandleNavClick} from "./navUtils";
+import {ParseNavSelection} from "./navUtils";
 
 /**
  * Interactive Nav component.
@@ -21,66 +21,30 @@ import {ParseNavSelection, HandleNavClick} from "./navUtils";
  * to change. In particular, there may initially be some code duplication
  * with the main Nav component, which will need to be eliminated.
  */
-class InteractiveNav extends React.Component {
-
-  constructor(props) {
-    super(props);
-    this.state = {selected: [props.report]};
-    this.handleNavClick = HandleNavClick.bind(this);
-    this.handlePlayClick = this.handlePlayClick.bind(this);
-  }
-
-  /* Handle the play button being clicked on a Nav entry. */
-  handlePlayClick(e, navEntry) {
-    e.stopPropagation();
-    console.log("Running " + navEntry.name);
-    const currSelected = this.state.selected[this.state.selected.length - 1];
-    if (!currSelected) {
-      alert(
-        "Error: Expected a report element to be selected. Selected = " +
-        this.state.selected
-      );
-      return;
-    }
-
-    const clickedReportEntry = this.findClickedReportEntry(
-      currSelected,
-      navEntry,
-    );
-
-    const fullSelected = this.state.selected.concat([clickedReportEntry]);
-    this.props.runEntry(fullSelected);
-  }
-
-  findClickedReportEntry(currSelected, navEntry) {
-    return currSelected.entries.find((el) => el.uid === navEntry.uid);
-  }
-
-  render() {
-    const selection = ParseNavSelection(
-      this.props.report,
-      this.state.selected,
-    );
-    return (
-      <>
-        <NavBreadcrumbs
-          entries={selection.navBreadcrumbs}
-          handleNavClick={this.handleNavClick}
-        />
-        <InteractiveNavList
-          entries={selection.navList}
-          breadcrumbLength={selection.navBreadcrumbs.length}
-          handleNavClick={this.handleNavClick}
-          autoSelect={() => undefined}
-          filter={null}
-          displayEmpty={true}
-          displayTags={false}
-          handlePlayClick={this.handlePlayClick}
-        />
-      </>
-    );
-  }
-}
+const InteractiveNav = (props) => {
+  const selection = ParseNavSelection(
+    props.report,
+    props.selected,
+  );
+  return (
+    <>
+      <NavBreadcrumbs
+        entries={selection.navBreadcrumbs}
+        handleNavClick={props.handleNavClick}
+      />
+      <InteractiveNavList
+        entries={selection.navList}
+        breadcrumbLength={selection.navBreadcrumbs.length}
+        handleNavClick={props.handleNavClick}
+        autoSelect={() => undefined}
+        filter={null}
+        displayEmpty={true}
+        displayTags={false}
+        handlePlayClick={props.handlePlayClick}
+      />
+    </>
+  );
+};
 
 InteractiveNav.propTypes = {
   /** Testplan report */

--- a/testplan/web_ui/testing/src/Nav/Nav.js
+++ b/testplan/web_ui/testing/src/Nav/Nav.js
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 
 import NavBreadcrumbs from "./NavBreadcrumbs";
 import NavList from "./NavList";
-import {ParseNavSelection, HandleNavClick} from "./navUtils";
-import {getNavEntryType} from "../Common/utils";
+import {ParseNavSelection} from "./navUtils";
 
 /**
  * Nav component:
@@ -13,78 +12,35 @@ import {getNavEntryType} from "../Common/utils";
  *   * handle clicking through menus, tracking what has been selected.
  *   * auto select entries if the list is empty or has 1 entry.
  */
-class Nav extends React.Component {
-  constructor(props) {
-    super(props);
-    this.handleNavClick = HandleNavClick.bind(this);
-    this.autoSelect = this.autoSelect.bind(this);
-    this.state = {
-      selected: []
-    };
-  }
+const Nav = (props) => {
+  const selection = ParseNavSelection(
+    props.report,
+    props.selected,
+  );
 
-  /**
-   * Auto select Nav entries depending on whether the passed entries Array is
-   * empty (go up a level) or has 1 entry (go down a level).
-   *
-   * @param {Array} entries - Nav entries (should be NavList entries).
-   * @param breadcrumbsLength - Number of the NavBreadcrumbs entries.
-   * @public
-   */
-  autoSelect(entries, breadcrumbsLength) {
-    const selected = this.getAutoSelectEntry(entries, breadcrumbsLength);
-    if (selected !== null) {
-      this.setState({selected: selected});
-    }
-  }
-
-  getAutoSelectEntry(entries, breadcrumbsLength) {
-    const lastSelectedType = (
-      this.state.selected.length > 0
-      ? this.state.selected[this.state.selected.length - 1].type
-      : null
-    );
-
-    if (entries.length === 0 && this.state.selected.length > 1) {
-      return this.state.selected.slice(0, breadcrumbsLength);
-    } else if (entries.length === 1 && lastSelectedType !== 'testcase') {
-      return this.state.selected.concat([{
-        uid: entries[0].uid,
-        type: getNavEntryType(entries[0])
-      }]);
-    } else {
-      return null;
-    }
-  }
-
-  render() {
-    const selection = ParseNavSelection(
-      this.props.report,
-      this.state.selected,
-    );
-    return (
-      <>
-        <NavBreadcrumbs
-          entries={selection.navBreadcrumbs}
-          handleNavClick={this.handleNavClick}
-        />
-        <NavList
-          entries={selection.navList}
-          breadcrumbLength={selection.navBreadcrumbs.length}
-          handleNavClick={this.handleNavClick}
-          autoSelect={this.autoSelect}
-          filter={this.props.filter}
-          displayEmpty={this.props.displayEmpty}
-          displayTags={this.props.displayTags}
-        />
-      </>
-    );
-  }
-}
+  return (
+    <>
+      <NavBreadcrumbs
+        entries={selection.navBreadcrumbs}
+        handleNavClick={props.handleNavClick}
+      />
+      <NavList
+        entries={selection.navList}
+        breadcrumbLength={selection.navBreadcrumbs.length}
+        handleNavClick={props.handleNavClick}
+        filter={props.filter}
+        displayEmpty={props.displayEmpty}
+        displayTags={props.displayTags}
+      />
+    </>
+  );
+};
 
 Nav.propTypes = {
   /** Testplan report */
   report: PropTypes.object,
+  /** Selected navigation entries. */
+  selected: PropTypes.arrayOf(PropTypes.object),
   /** Function to handle saving the assertions found by the Nav */
   saveAssertions: PropTypes.func,
   /** Entity filter */
@@ -93,6 +49,8 @@ Nav.propTypes = {
   displayTags: PropTypes.bool,
   /** Flag to display empty testcase on navbar */
   displayEmpty: PropTypes.bool,
+  /** Callback when a navigation entry is clicked. */
+  handleNavClick: PropTypes.func,
 };
 
 export default Nav;

--- a/testplan/web_ui/testing/src/Nav/NavList.js
+++ b/testplan/web_ui/testing/src/Nav/NavList.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {ListGroup} from 'reactstrap';
 
@@ -11,33 +11,23 @@ import {getNavEntryType} from "../Common/utils";
 /**
  * Render a vertical list of all the currently selected entries children.
  */
-class NavList extends Component {
-  componentDidMount() {
-    this.props.autoSelect(this.props.entries, this.props.breadcrumbLength);
-  }
+const NavList = (props) => {
+  const navButtons = CreateNavButtons(props, (entry) => (
+    <NavEntry
+      name={entry.name}
+      status={entry.status}
+      type={getNavEntryType(entry)}
+      caseCountPassed={entry.case_count.passed}
+      caseCountFailed={entry.case_count.failed}
+    />
+  ));
 
-  componentDidUpdate() {
-    this.props.autoSelect(this.props.entries, this.props.breadcrumbLength);
-  }
-
-  render() {
-    const navButtons = CreateNavButtons(this.props, (entry) => (
-      <NavEntry
-        name={entry.name}
-        status={entry.status}
-        type={getNavEntryType(entry)}
-        caseCountPassed={entry.case_count.passed}
-        caseCountFailed={entry.case_count.failed}
-      />
-    ));
-
-    return (
-      <Column>
-        <ListGroup>{navButtons}</ListGroup>
-      </Column>
-    );
-  }
-}
+  return (
+    <Column>
+      <ListGroup>{navButtons}</ListGroup>
+    </Column>
+  );
+};
 
 NavList.propTypes = {
   /** Nav list entries to be displayed */
@@ -54,8 +44,6 @@ NavList.propTypes = {
   breadcrumbLength: PropTypes.number,
   /** Function to handle Nav entries being clicked (selected) */
   handleNavClick: PropTypes.func,
-  /** Function to automatically select Nav entries */
-  autoSelect: PropTypes.func,
   /** Entity filter */
   filter: PropTypes.string,
   /** Flag to display tags on navbar */

--- a/testplan/web_ui/testing/src/Nav/__tests__/InteractiveNav.test.js
+++ b/testplan/web_ui/testing/src/Nav/__tests__/InteractiveNav.test.js
@@ -21,11 +21,12 @@ describe('InteractiveNav', () => {
     const renderedNav = shallow(
       <InteractiveNav
         report={FakeInteractiveReport}
-        saveAssertions={() => undefined}
+        selected={[{uid: FakeInteractiveReport.uid, type: "testplan"}]}
         filter={null}
         displayEmpty={true}
         displayTags={false}
-        runEntry={() => undefined}
+        handleNavClick={jest.fn()}
+        handlePlayClick={jest.fn()}
       />
     );
     expect(renderedNav).toMatchSnapshot();

--- a/testplan/web_ui/testing/src/Nav/__tests__/Nav.test.js
+++ b/testplan/web_ui/testing/src/Nav/__tests__/Nav.test.js
@@ -5,57 +5,27 @@ import {StyleSheetTestUtils} from "aphrodite";
 import Nav from '../Nav';
 import {TESTPLAN_REPORT} from '../../Common/sampleReports';
 
-function defaultProps() {
-  return {
-    report: TESTPLAN_REPORT,
-    saveAssertions: jest.fn(),
-  };
-}
+const defaultProps = {
+  report: TESTPLAN_REPORT,
+  selected: [{uid: TESTPLAN_REPORT.uid, type: "testplan"}],
+};
 
 describe('Nav', () => {
-  let props;
-  let mountedNav;
-  const renderNav = () => {
-    if (!mountedNav) {
-      mountedNav = shallow(
-        <Nav {...props} />
-      );
-    }
-    return mountedNav;
-  };
 
   beforeEach(() => {
     // Stop Aphrodite from injecting styles, this crashes the tests.
     StyleSheetTestUtils.suppressStyleInjection();
-    props = defaultProps();
-    mountedNav = undefined;
   });
 
   afterEach(() => {
     // Resume style injection once test is finished.
     StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
-    props.saveAssertions.mockClear();
   });
 
-  it('shallow renders without crashing', () => {
-    renderNav();
+  it('shallow renders and matches snapshot', () => {
+    const rendered = shallow(<Nav {...defaultProps} />);
+    expect(rendered).toMatchSnapshot();
   });
-
-  it('shallow renders the correct HTML structure', () => {
-    const nav = renderNav();
-    expect(nav).toMatchSnapshot();
-  });
-
-  // Unsure how to test handleNavClick. Already checked it is called
-  // in correct place in child components. Should we call it and check
-  // state is changed correctly? Not sure we should be testing state
-  // change, as this is an input/internal implementation detail not an
-  // output of the react component.
-
-  // Unsure how to test autoSelect. Already checked it is called
-  // in correct place in child components. Should we call it and check
-  // state is changed correctly? Not sure we should be testing state
-  // change, as this is an input/internal implementation detail not an
-  // output of the react component.
 
 });
+

--- a/testplan/web_ui/testing/src/Nav/__tests__/NavList.test.js
+++ b/testplan/web_ui/testing/src/Nav/__tests__/NavList.test.js
@@ -23,7 +23,6 @@ function defaultProps() {
     entries: [entry],
     breadcrumbLength: 1,
     handleNavClick: jest.fn(),
-    autoSelect: jest.fn(),
   };
 }
 
@@ -39,26 +38,13 @@ describe('NavList', () => {
     // Resume style injection once test is finished.
     StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
     props.handleNavClick.mockClear();
-    props.autoSelect.mockClear();
   });
 
-  it('shallow renders the correct HTML structure', () => {
+  it('shallow renders and matches snapshot', () => {
     const nav_list = shallow(
       <NavList {...props} />
     );
     expect(nav_list).toMatchSnapshot();
-  });
-
-  it('calls autoSelect when mounting and updating', () => {
-    const auto_select = props.autoSelect;
-    const nav_list = shallow(
-      <NavList {...props} />
-    );
-    expect(auto_select.mock.calls.length).toEqual(1);
-
-    nav_list.setProps({'name': 'test2'});
-    nav_list.update();
-    expect(auto_select.mock.calls.length).toEqual(2);
   });
 
   it('calls handleNavClick when nav entry has been clicked', () => {

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNav.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNav.test.js.snap
@@ -16,7 +16,7 @@ exports[`InteractiveNav shallow renders and matches snapshot 1`] = `
         },
       ]
     }
-    handleNavClick={[Function]}
+    handleNavClick={[MockFunction]}
   />
   <InteractiveNavList
     autoSelect={[Function]}
@@ -40,8 +40,8 @@ exports[`InteractiveNav shallow renders and matches snapshot 1`] = `
       ]
     }
     filter={null}
-    handleNavClick={[Function]}
-    handlePlayClick={[Function]}
+    handleNavClick={[MockFunction]}
+    handlePlayClick={[MockFunction]}
   />
 </Fragment>
 `;

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/Nav.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/Nav.test.js.snap
@@ -1,14 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Nav shallow renders the correct HTML structure 1`] = `
+exports[`Nav shallow renders and matches snapshot 1`] = `
 <Fragment>
   <NavBreadcrumbs
-    entries={Array []}
-    handleNavClick={[Function]}
-  />
-  <NavList
-    autoSelect={[Function]}
-    breadcrumbLength={0}
     entries={
       Array [
         Object {
@@ -18,7 +12,33 @@ exports[`Nav shallow renders the correct HTML structure 1`] = `
         },
       ]
     }
-    handleNavClick={[Function]}
+  />
+  <NavList
+    breadcrumbLength={1}
+    entries={
+      Array [
+        Object {
+          "category": "multitest",
+          "name": "Primary",
+          "status": "failed",
+          "tags": Object {
+            "simple": Array [
+              "server",
+            ],
+          },
+          "type": "TestGroupReport",
+          "uid": "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+        },
+        Object {
+          "category": "multitest",
+          "name": "Secondary",
+          "status": "passed",
+          "tags": Object {},
+          "type": "TestGroupReport",
+          "uid": "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+        },
+      ]
+    }
   />
 </Fragment>
 `;

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavList.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavList.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NavList shallow renders the correct HTML structure 1`] = `
+exports[`NavList shallow renders and matches snapshot 1`] = `
 <Column>
   <ListGroup
     tag="ul"

--- a/testplan/web_ui/testing/src/Nav/navUtils.js
+++ b/testplan/web_ui/testing/src/Nav/navUtils.js
@@ -134,28 +134,6 @@ function ParseNavSelection(report, selected) {
 }
 
 /**
- * Handle Nav entries being clicked. Add/remove entries from selected Array
- * in state.
- *
- * NOTE: this function is intended to be mixed into a component which
- * binds "this". Currently this method is shared by the Nav and InteractiveNav
- * components.
- *
- * @param {Object} e - click event.
- * @param {Object} entry - Nav entry metadata.
- * @param {number} depth - depth of Nav entry in Testplan report.
- * @public
- */
-function HandleNavClick (e, entry, depth) {
-  e.stopPropagation();
-  const entryType = getNavEntryType(entry);
-  const selected = this.state.selected.slice(0, depth);
-  selected.push({uid: entry.uid, type: entryType});
-  this.setState({selected: selected});
-  this.props.saveAssertions(entry);
-}
-
-/**
  * Create the list entry buttons or a single button stating nothing can be
  * displayed.
  *
@@ -260,6 +238,5 @@ const styles = StyleSheet.create({
 
 export {
   ParseNavSelection,
-  HandleNavClick,
   CreateNavButtons,
 };

--- a/testplan/web_ui/testing/src/Report/__tests__/InteractiveReport.test.js
+++ b/testplan/web_ui/testing/src/Report/__tests__/InteractiveReport.test.js
@@ -2,7 +2,9 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import InteractiveReport from '../InteractiveReport';
+import InteractiveReport from '../InteractiveReport.js';
+import {FakeInteractiveReport} from '../../Common/sampleReports.js';
+import {ReportToNavEntry} from '../../Common/utils.js';
 
 describe('InteractiveReport', () => {
   it("shallow renders and matches snapshot", () => {
@@ -12,14 +14,17 @@ describe('InteractiveReport', () => {
 
   it("updates testcase status to passed", () => {
     const interactiveReport = shallow(<InteractiveReport />);
-    const reportState = interactiveReport.state("report");
-    const selectedEntries = [
-      reportState,
-      reportState.entries[0],
-      reportState.entries[0].entries[0],
-      reportState.entries[0].entries[0].entries[0],
+    interactiveReport.setState({report: FakeInteractiveReport});
+
+    const selectedReportEntries = [
+      FakeInteractiveReport,
+      FakeInteractiveReport.entries[0],
+      FakeInteractiveReport.entries[0].entries[0],
+      FakeInteractiveReport.entries[0].entries[0].entries[0],
     ];
-    interactiveReport.instance().setEntryStatus(selectedEntries, "passed");
+
+    const selectedNavEntries = selectedReportEntries.map(ReportToNavEntry);
+    interactiveReport.instance().setEntryStatus(selectedNavEntries, "passed");
     interactiveReport.update();
 
     const newTestcaseEntry = (

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
@@ -15,6 +15,7 @@ exports[`BatchReport shallow renders the correct HTML structure when report load
     displayEmpty={true}
     displayTags={false}
     filter={null}
+    handleNavClick={[Function]}
     report={
       Object {
         "entries": Array [
@@ -268,7 +269,7 @@ exports[`BatchReport shallow renders the correct HTML structure when report load
         "uid": "520a92e4-325e-4077-93e6-55d7091a3f83",
       }
     }
-    saveAssertions={[Function]}
+    selected={Array []}
   />
   <Message
     left={18}

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
@@ -15,87 +15,13 @@ exports[`InteractiveReport shallow renders and matches snapshot 1`] = `
     displayEmpty={true}
     displayTags={false}
     filter={null}
-    report={
-      Object {
-        "case_count": Object {
-          "failed": 0,
-          "passed": 0,
-        },
-        "entries": Array [
-          Object {
-            "case_count": Object {
-              "failed": 0,
-              "passed": 0,
-            },
-            "category": "multitest",
-            "description": null,
-            "entries": Array [
-              Object {
-                "case_count": Object {
-                  "failed": 0,
-                  "passed": 0,
-                },
-                "category": "suite",
-                "description": null,
-                "entries": Array [
-                  Object {
-                    "case_count": Object {
-                      "failed": 0,
-                      "passed": 0,
-                    },
-                    "description": null,
-                    "entries": Array [],
-                    "logs": Array [],
-                    "name": "test_interactive",
-                    "name_type_index": Set {},
-                    "status": "ready",
-                    "status_override": null,
-                    "suite_related": false,
-                    "tags": Object {},
-                    "tags_index": Object {},
-                    "timer": Object {},
-                    "type": "TestCaseReport",
-                    "uid": "ddd",
-                  },
-                ],
-                "logs": Array [],
-                "name": "Interactive Suite",
-                "name_type_index": Set {},
-                "part": null,
-                "status": "ready",
-                "status_override": null,
-                "tags": Object {},
-                "tags_index": Object {},
-                "timer": Object {},
-                "type": "TestGroupReport",
-                "uid": "ccc",
-              },
-            ],
-            "logs": Array [],
-            "name": "Interactive MTest",
-            "name_type_index": Set {},
-            "part": null,
-            "status": "ready",
-            "status_override": null,
-            "tags": Object {},
-            "tags_index": Object {},
-            "timer": Object {},
-            "type": "TestGroupReport",
-            "uid": "bbb",
-          },
-        ],
-        "meta": Object {},
-        "name": "Fake Interactive Report",
-        "name_type_index": Set {},
-        "status": "ready",
-        "status_override": null,
-        "tags_index": Object {},
-        "timer": null,
-        "uid": "aaa",
-      }
-    }
-    runEntry={[Function]}
-    saveAssertions={[Function]}
+    handleNavClick={[Function]}
+    handlePlayClick={[Function]}
+    report={null}
+    selected={Array []}
+  />
+  <Message
+    message="Fetching Testplan report..."
   />
 </div>
 `;
@@ -106,7 +32,7 @@ exports[`InteractiveReport updates testcase status to passed 1`] = `
 >
   <Toolbar
     handleNavFilter={[Function]}
-    status={null}
+    status="ready"
     updateEmptyDisplayFunc={[Function]}
     updateFilterFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
@@ -115,6 +41,8 @@ exports[`InteractiveReport updates testcase status to passed 1`] = `
     displayEmpty={true}
     displayTags={false}
     filter={null}
+    handleNavClick={[Function]}
+    handlePlayClick={[Function]}
     report={
       Object {
         "case_count": Object {
@@ -194,8 +122,10 @@ exports[`InteractiveReport updates testcase status to passed 1`] = `
         "uid": "aaa",
       }
     }
-    runEntry={[Function]}
-    saveAssertions={[Function]}
+    selected={Array []}
+  />
+  <Message
+    message="Please select a testcase."
   />
 </div>
 `;

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -1,7 +1,11 @@
 /**
  * Report utility functions.
  */
+import React from "react";
+
 import {getNavEntryType} from "../Common/utils";
+import AssertionPane from '../AssertionPane/AssertionPane';
+import Message from '../Common/Message';
 
 /**
  * Merge two tag objects into a single tag object.
@@ -137,6 +141,101 @@ function propagateIndices(entries) {
   return entries;
 }
 
+/**
+ * Return the updated state after a new entry is selected from the Nav
+ * component.
+ *
+ * @param {Object} entry - Nav entry metadata.
+ * @param {number} depth - depth of Nav entry in Testplan report.
+ * @public
+ */
+const UpdateSelectedState = (state, entry, depth) => {
+  const entryType = getNavEntryType(entry);
+  const selected = state.selected.slice(0, depth);
+  selected.push({uid: entry.uid, type: entryType});
+  if (entryType === 'testcase') {
+    return {
+      selected: selected,
+      assertions: entry.entries,
+      testcaseUid: entry.uid,
+    };
+  } else {
+    return {
+      selected: selected,
+      assertions: null,
+      testcaseUid: null,
+    };
+  }
+};
+
+/**
+ * Get the current report data, status and fetch message as required.
+ */
+const GetReportState = (state) => {
+  // Handle the Testplan report if it has been fetched.
+  if (!state.report) {
+    // The Testplan report hasn't been fetched yet.
+    return {
+      reportStatus: null,
+      reportFetchMessage: getReportFetchMessage(state),
+    };
+  } else {
+    // The Testplan report has been fetched.
+    return {
+      reportStatus: state.report.status,
+      reportFetchMessage: null,
+    };
+  }
+};
+
+/**
+ * Get the component to display in the centre pane.
+ */
+const GetCenterPane = (state, props, reportFetchMessage, reportUid) => {
+  if (state.assertions !== null) {
+    return (
+      <AssertionPane
+        assertions={state.assertions}
+        left={state.navWidth + 1.5}
+        testcaseUid={state.testcaseUid}
+        filter={state.filter}
+        reportUid={reportUid}
+      />
+    );
+  } else if (reportFetchMessage !== null) {
+    return (
+      <Message
+        message={reportFetchMessage}
+        left={state.navWidth}
+      />
+    );
+  } else {
+    return (
+      <Message
+        message='Please select a testcase.'
+        left={state.navWidth}
+      />
+    );
+  }
+};
+
+/**
+ * Get a message relating to the progress of fetching the testplan report.
+ */
+const getReportFetchMessage = (state) => {
+  if (state.loading) {
+    return 'Fetching Testplan report...';
+  } else if (state.error !== null){
+    return `Error fetching Testplan report. (${state.error.message})`;
+  } else {
+    return 'Waiting to fetch Testplan report...';
+  }
+};
+
 export {
   propagateIndices,
+  UpdateSelectedState,
+  GetReportState,
+  GetCenterPane,
 };
+


### PR DESCRIPTION
Simplify auto-select logic for both batch and interactive reports.
Entries are automatically selected when the report is first loaded only,
not on every re-render.

Lift the selection state up into the report
components to make the navigation components fully-controlled and
stateless.

Add report loading and assertion rendering into interactive report. Add tests.

Some other minor refactor/tidy up.