### PR TITLE
Remove Pillow from dependencies

### DIFF
--- a/examples/Attachments/test_plan.py
+++ b/examples/Attachments/test_plan.py
@@ -6,7 +6,18 @@ import tempfile
 
 import testplan
 from testplan.testing import multitest
-from PIL import Image, ImageDraw
+
+try:
+    from PIL import Image, ImageDraw
+except ImportError:
+    sys.exit("""\
+This example requires the Pillow library, which is not automatically
+installed as a part of testplan.
+
+To install it run: `pip install Pillow`
+
+For more information about Pillow see: https://pillow.readthedocs.io/en/stable/
+""")
 
 
 @multitest.testsuite

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -18,7 +18,6 @@ pyzmq
 terminaltables
 pyparsing
 cycler
-Pillow<6.0.0
 functools32; python_version <= '2.7'
 requests>=2.4.3
 flask

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ REQUIRED = [
     'terminaltables',
     'pyparsing',
     'cycler',
-    'Pillow<6.0.0',
     'matplotlib',
     'numpy',
     'scipy',


### PR DESCRIPTION
Pillow is not used anywhere in the testplan package, so it should not be listed as a dependency in setup.py. For the one example that uses it, note that Pillow needs to be installed manually.