### PR TITLE
Serve static interactive files

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -22,6 +22,7 @@ from testplan.common.utils.thread import execute_as_thread
 from testplan.common.utils.timing import wait
 from testplan.common.utils.path import makeemptydirs, makedirs, default_runpath
 from testplan.common.utils import logger
+from testplan.common.utils import networking
 
 
 class Environment(object):
@@ -700,13 +701,25 @@ class RunnableIHandler(Entity):
         wait(lambda: self._http_handler.port is not None,
              self.cfg.http_handler_startup_timeout,
              raise_on_timeout=True )
+        self._display_connection_info()
+
+    def _display_connection_info(self):
+        """
+        Log information for how to connect to the interactive runner.
+        Currently only the API is implemented so we log how to access the
+        API schema. In future we will log how to access the UI page.
+        """
+        host, port = self._http_handler.host, self._http_handler.port
+
         self.logger.warning(
             'Interactive web viewer is not yet implemented. Interactive mode '
-            'currently only allows control of a Testplan via its HTTP API.')
+            'currently only allows control of a Testplan via its HTTP API.'
+        )
+
         self.logger.test_info(
-            'Interactive Testplan API listening on: %s:%d',
-            self._http_handler.host,
-            self._http_handler.port)
+            'Interactive Testplan API is running. View the API schema:\n%s',
+            networking.format_access_urls(host, port, "/api/v1/interactive/"),
+        )
 
     def __call__(self, *args, **kwargs):
         self.status.change(RunnableStatus.RUNNING)

--- a/testplan/common/utils/networking.py
+++ b/testplan/common/utils/networking.py
@@ -8,10 +8,65 @@ from __future__ import (
     absolute_import,
 )
 import socket
+import ipaddress
 
 
 def port_to_int(port):
+    """Convert a port string to an integer."""
     try:
         return int(port)
     except ValueError:
         return socket.getservbyname(port)
+
+
+def format_access_urls(host, port, url_path):
+    """
+    Format a string to log to give HTTP access to a URL endpoint listening
+    on a particular host/port. Handles special 0.0.0.0 IP and formats IPV6
+    addresses. The returned string is indented by 4 spaces.
+
+    :param host: hostname or IP address
+    :type host: ``str``
+    :param port: port number
+    :type port: ``int``
+    :param url_path: path to format after host:port part of URL (expected to
+        contain leading "/" e.g "/index.html")
+    :type url_path: ``str``
+    :return: a formatted string containing the connection URL(s)
+    :rtype: ``str``
+    """
+    # Handle 0.0.0.0 as a special case: this means that the URL can be accessed
+    # both via localhost or on any IP address this host owns.
+    if host == "0.0.0.0":
+        local_url = "http://localhost:{port}{path}".format(
+            port=port, path=url_path
+        )
+
+        try:
+            local_ip = socket.gethostbyname(socket.getfqdn())
+            network_url = "http://{host}:{port}{path}".format(
+                host=local_ip, port=port, path=url_path
+            )
+
+            return (
+                "    Local: {local}\n"
+                "    On Your Network: {network}".format(
+                    local=local_url, network=network_url
+                )
+            )
+        except socket.gaierror:
+            return "    {}".format(local_url)
+    else:
+        # Check for an IPv6 address. Web browsers require IPv6 addresses
+        # to be enclosed in [].
+        try:
+            if ipaddress.ip_address(host).version == 6:
+                host = "[{}]".format(host)
+        except ValueError:
+            # Expected if the host is a host name instead of an IP address.
+            pass
+
+        url = "http://{host}:{port}{path}".format(
+            host=host, port=port, path=url_path
+        )
+        return "    {}".format(url)

--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -32,11 +32,12 @@ def generate_interactive_api(http_handler, ihandler):
     build_directory = os.path.join(
         os.path.dirname(testplan.__file__), "web_ui", "testing", "build"
     )
+    static_dir = os.path.join(build_directory, "static")
 
     api_prefix = "/api/v1/interactive"
     api_blueprint = flask.Blueprint("api", "testplan")
     api = flask_restplus.Api(api_blueprint)
-    app = flask.Flask("testplan")
+    app = flask.Flask("testplan", static_folder=static_dir)
     app.register_blueprint(api_blueprint, url_prefix=api_prefix)
 
     @app.route("/interactive/")

--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -11,8 +11,8 @@ from builtins import str
 from future import standard_library
 
 standard_library.install_aliases()
-import uuid
 from multiprocessing import dummy
+import os
 
 import flask
 import flask_restplus
@@ -20,6 +20,7 @@ from cheroot import wsgi
 import werkzeug.exceptions
 import marshmallow.exceptions
 
+import testplan
 from testplan.common.config import ConfigOption
 from testplan.common.entity import Entity, EntityConfig, RunnableIHandler
 from testplan import defaults
@@ -28,10 +29,35 @@ from testplan import report
 
 def generate_interactive_api(http_handler, ihandler):
     """Generates the interactive API using Flask."""
-    app = flask.Flask(__name__)
-    api = flask_restplus.Api(app)
+    build_directory = os.path.join(
+        os.path.dirname(testplan.__file__), "web_ui", "testing", "build"
+    )
 
-    @api.route("/api/v1/interactive/report")
+    api_prefix = "/api/v1/interactive"
+    api_blueprint = flask.Blueprint("api", "testplan")
+    api = flask_restplus.Api(api_blueprint)
+    app = flask.Flask("testplan")
+    app.register_blueprint(api_blueprint, url_prefix=api_prefix)
+
+    @app.route("/interactive/")
+    def interactive():
+        """
+        Main entry point for the interactive mode UI page. Serves the static
+        index.html from the UI app's build directory. We serve the app at
+        /interactive and not just at /index.html or at / because the same app
+        is used for batch and interactive report, and the way it
+        distinguishes between the two modes is by the URL.
+        """
+        return flask.send_from_directory(build_directory, "index.html")
+
+    @app.route("/<path:filename>")
+    def serve_static(filename):
+        """
+        Serve all static files (HTML, JS, CSS, images etc.) at the root path.
+        """
+        return flask.send_from_directory(build_directory, filename)
+
+    @api.route("/report")
     class Report(flask_restplus.Resource):
         """
         Interactive report endpoint. There is a single root report object
@@ -65,7 +91,7 @@ def generate_interactive_api(http_handler, ihandler):
                 ihandler.report = new_report
                 return ihandler.report.shallow_serialize()
 
-    @api.route("/api/v1/interactive/report/tests")
+    @api.route("/report/tests")
     class AllTests(flask_restplus.Resource):
         """
         Tests endpoint. Represents all Test objects in the report. Read-only.
@@ -76,7 +102,7 @@ def generate_interactive_api(http_handler, ihandler):
             with ihandler.report_mutex:
                 return [test.uid for test in ihandler.report]
 
-    @api.route("/api/v1/interactive/report/tests/<string:test_uid>")
+    @api.route("/report/tests/<string:test_uid>")
     class SingleTest(flask_restplus.Resource):
         """
         Test endpoint. Represents a single Test object in the testplan with
@@ -120,7 +146,7 @@ def generate_interactive_api(http_handler, ihandler):
                 ihandler.report[test_uid] = new_test
                 return ihandler.report[test_uid].shallow_serialize()
 
-    @api.route("/api/v1/interactive/report/tests/<string:test_uid>/suites")
+    @api.route("/report/tests/<string:test_uid>/suites")
     class AllSuites(flask_restplus.Resource):
         """
         Suites endpoint. Represents all test suites within a Test object.
@@ -133,10 +159,7 @@ def generate_interactive_api(http_handler, ihandler):
             except KeyError:
                 raise werkzeug.exceptions.NotFound
 
-    @api.route(
-        "/api/v1/interactive/report/tests/<string:test_uid>/suites/"
-        "<string:suite_uid>"
-    )
+    @api.route("/report/tests/<string:test_uid>/suites/<string:suite_uid>")
     class SingleSuite(flask_restplus.Resource):
         """
         Suite endpoint. Represents a single test suite within a Test object
@@ -183,8 +206,7 @@ def generate_interactive_api(http_handler, ihandler):
                 return ihandler.report[test_uid][suite_uid].shallow_serialize()
 
     @api.route(
-        "/api/v1/interactive/report/tests/<string:test_uid>/suites/"
-        "<string:suite_uid>/testcases"
+        "/report/tests/<string:test_uid>/suites/<string:suite_uid>/testcases"
     )
     class AllTestcases(flask_restplus.Resource):
         """
@@ -204,8 +226,8 @@ def generate_interactive_api(http_handler, ihandler):
                     raise werkzeug.exceptions.NotFound
 
     @api.route(
-        "/api/v1/interactive/report/tests/<string:test_uid>/suites/"
-        "<string:suite_uid>/testcases/<string:testcase_uid>"
+        "/report/tests/<string:test_uid>/suites/<string:suite_uid>/testcases"
+        "/<string:testcase_uid>"
     )
     class SingleTestcase(flask_restplus.Resource):
         """
@@ -328,12 +350,21 @@ class TestRunnerHTTPHandler(Entity):
 
     @property
     def host(self):
+        """
+        :return: the hostname the server is listening on, or None if the server
+            is not running.
+        """
         if self._server is None or not self._server.ready:
             return None
         return self._server.bind_addr[0]
 
     @property
     def port(self):
+        """
+        :return: the port the server is listening on, or None if the server is
+            not running. Note that when ephemeral ports (port 0) is requested,
+            this property will return the actual port that is given.
+        """
         if self._server is None or not self._server.ready:
             return None
         return self._server.bind_addr[1]
@@ -343,6 +374,7 @@ class TestRunnerHTTPHandler(Entity):
         Runs the threader HTTP handler for interactive mode.
         """
         app, _ = generate_interactive_api(self, self.cfg.ihandler)
+
         self._server = wsgi.Server((self.cfg.host, self.cfg.port), app)
 
         # Cannot use context manager on Python 2 to use try/finally to ensure


### PR DESCRIPTION
Serve the testplan web app alongside the interactive API when running
interactive mode. Log how to access the API schema. Since the UI
is still a work in progress, don't yet log details on how to access it.