### PR TITLE
Refactor PropagateIndices function to take single report entry

### DIFF
--- a/testplan/web_ui/testing/src/Report/BatchReport.js
+++ b/testplan/web_ui/testing/src/Report/BatchReport.js
@@ -5,7 +5,7 @@ import axios from 'axios';
 import Toolbar from '../Toolbar/Toolbar';
 import Nav from '../Nav/Nav';
 import {
-  propagateIndices,
+  PropagateIndices,
   UpdateSelectedState,
   GetReportState,
   GetCenterPane,
@@ -56,25 +56,27 @@ class BatchReport extends React.Component {
     // we will display a fake report for development purposes.
     const uid = this.props.match.params.uid;
     if (uid === "_dev") {
-      const [r] = propagateIndices([fakeReportAssertions]);
+      const processedReport = PropagateIndices(fakeReportAssertions);
       setTimeout(
         () => this.setState({
-          report: r,
-          selected: this.autoSelect(r),
+          report: processedReport,
+          selected: this.autoSelect(processedReport),
           loading: false,
         }),
         1500);
     } else {
       axios.get(`/api/v1/reports/${uid}`)
-        .then(response => propagateIndices([response.data]))
-        .then(reportEntries => this.setState({
-          report: reportEntries[0],
-          selected: this.autoSelect(reportEntries[0]),
-          loading: false
-        }))
+        .then(response => {
+          const processedReport = PropagateIndices(fakeReportAssertions);
+          this.setState({
+            report: processedReport,
+            selected: this.autoSelect(processedReport),
+            loading: false,
+          });
+        })
         .catch(error => this.setState({
-          error,
-          loading: false
+          error: error,
+          loading: false,
         }));
     }
   }

--- a/testplan/web_ui/testing/src/Report/__tests__/reportUtils.test.js
+++ b/testplan/web_ui/testing/src/Report/__tests__/reportUtils.test.js
@@ -1,14 +1,13 @@
 import React from 'react';
 
 import {TESTPLAN_REPORT} from "../../Common/sampleReports";
-import {propagateIndices} from "../reportUtils";
+import {PropagateIndices} from "../reportUtils";
 
 describe('Report/reportUtils', () => {
 
-  describe('propagateIndices', () => {
+  describe('PropagateIndices', () => {
 
     let report;
-    let testplan;
     let multitest;
     let suiteA;
     let suiteB;
@@ -16,14 +15,13 @@ describe('Report/reportUtils', () => {
     let testplanEntries = {};
 
     beforeEach(() => {
-      report = propagateIndices([TESTPLAN_REPORT]);
-      testplan = report[0];
-      multitest = testplan.entries[0];
+      report = PropagateIndices(TESTPLAN_REPORT);
+      multitest = report.entries[0];
       suiteA = multitest.entries[0];
       suiteB = multitest.entries[1];
       testcase = suiteA.entries[0];
       testplanEntries = {
-        testplan: testplan,
+        testplan: report,
         multitest: multitest,
         suite: suiteA,
         testcase: testcase,
@@ -32,7 +30,6 @@ describe('Report/reportUtils', () => {
 
     afterEach(() => {
       report = undefined;
-      testplan = undefined;
       multitest = undefined;
       suiteA = undefined;
       suiteB = undefined;

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -123,7 +123,7 @@ const propagateIndicesRecur = (entries, parentIndices) => {
     indices.case_count.failed += caseCount.failed;
   }
   return indices;
-}
+};
 
 /**
  * Propagate indices through report to be utilised by filter box. A single entry

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -55,7 +55,7 @@ function _mergeTags(tagsA, tagsB) {
  * Array.
  * @private
  */
-function propagateIndices(entries, parentIndices) {
+const propagateIndicesRecur = (entries, parentIndices) => {
   if (parentIndices === undefined) {
     parentIndices = {
       tags_index: {},
@@ -90,7 +90,7 @@ function propagateIndices(entries, parentIndices) {
 
     if (entryType !== 'testcase') {
       // Propagate indices to children.
-      let descendantsIndices = propagateIndices(
+      let descendantsIndices = propagateIndicesRecur(
         entry.entries,
         {tags_index: tags, name_type_index: nameTypeIndex}
       );
@@ -137,7 +137,7 @@ function propagateIndices(entries, parentIndices) {
  * @returns {Array} - The Testplan report with indices, in an Array.
  */
 const PropagateIndices = (report) => {
-  propagateIndices([report], undefined);
+  propagateIndicesRecur([report], undefined);
   return report;
 };
 

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -55,7 +55,7 @@ function _mergeTags(tagsA, tagsB) {
  * Array.
  * @private
  */
-function _propagateIndices(entries, parentIndices) {
+function propagateIndices(entries, parentIndices) {
   if (parentIndices === undefined) {
     parentIndices = {
       tags_index: {},
@@ -90,7 +90,7 @@ function _propagateIndices(entries, parentIndices) {
 
     if (entryType !== 'testcase') {
       // Propagate indices to children.
-      let descendantsIndices = _propagateIndices(
+      let descendantsIndices = propagateIndices(
         entry.entries,
         {tags_index: tags, name_type_index: nameTypeIndex}
       );
@@ -136,10 +136,10 @@ function _propagateIndices(entries, parentIndices) {
  * @param {Array} entries - A single Testplan report in an Array.
  * @returns {Array} - The Testplan report with indices, in an Array.
  */
-function propagateIndices(entries) {
-  _propagateIndices(entries, undefined);
-  return entries;
-}
+const PropagateIndices = (report) => {
+  propagateIndices([report], undefined);
+  return report;
+};
 
 /**
  * Return the updated state after a new entry is selected from the Nav
@@ -233,7 +233,7 @@ const getReportFetchMessage = (state) => {
 };
 
 export {
-  propagateIndices,
+  PropagateIndices,
   UpdateSelectedState,
   GetReportState,
   GetCenterPane,

--- a/tests/unit/testplan/web_ui/testing/test_jest.py
+++ b/tests/unit/testplan/web_ui/testing/test_jest.py
@@ -1,4 +1,4 @@
-from testplan import Testplan
+"""Run tests for the UI code."""
 import subprocess
 import os
 
@@ -31,6 +31,15 @@ def tp_ui_installed():
 @pytest.mark.skipif(not (npm_installed() and tp_ui_installed()),
                     reason='requires npm & testplan UI to have been installed.')
 def test_testplan_ui():
+    """Run the Jest unit tests for the UI."""
     env = os.environ.copy()
     env['CI'] = 'true'
     subprocess.check_call('npm test', shell=True, cwd=TESTPLAN_UI_DIR, env=env)
+
+
+@pytest.mark.skipif(not npm_installed(),
+                    reason='requires npm to have been installed.')
+def test_eslint():
+    """Run eslint over the UI source code."""
+    subprocess.check_call(["npm", "run", "lint"], cwd=TESTPLAN_UI_DIR)
+


### PR DESCRIPTION
- Change the PropagateIndices function to take and return a single report entry instead of an array of one entry.
- Add testcase to run eslint over UI source code.