### PR TITLE
Interactive UI can run tests and display results

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -588,7 +588,7 @@ class RunnableIHandlerConfig(Config):
                 ConfigOption('http_handler', default=None): object,
                 ConfigOption('http_handler_startup_timeout', default=10): int,
                 ConfigOption('http_port', default=0): int,
-                ConfigOption('max_operations', default=5):
+                ConfigOption('max_operations', default=1000):
                     And(Use(int), lambda n: n > 0)}
 
 

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -596,7 +596,18 @@ class TestCaseReport(Report):
 
     @status.setter
     def status(self, new_status):
+        """
+        Update the status of a testcase. This status is only used for a
+        testcase containing no entries, otherwise the status of the entries
+        is used with precedence rules.
+
+        As a special case, when setting the status of a testcase to "running",
+        any entries from a previous run are discarded, so the status is
+        guaranteed to be read as "running".
+        """
         self._status = new_status
+        if new_status == "running":
+            self.entries = []
 
     def _assertions_status(self):
         for entry in self:

--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -57,6 +57,15 @@ def generate_interactive_api(ihandler):
         """
         return flask.send_from_directory(build_directory, filename)
 
+    @app.after_request
+    def add_cache_control_headers(response):
+        """
+        Disable browser caching for all HTTP requests, so that the most
+        up-to-date data is always returned.
+        """
+        response.headers["Cache-Control"] = "no-cache"
+        return response
+
     @api.route("/report")
     class Report(flask_restplus.Resource):
         """

--- a/testplan/web_ui/testing/src/Nav/InteractiveNav.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNav.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import NavBreadcrumbs from "./NavBreadcrumbs";
 import InteractiveNavList from "./InteractiveNavList";
-import {ParseNavSelection} from "./navUtils";
+import {ParseNavSelection, GetSelectedUid} from "./navUtils";
 
 /**
  * Interactive Nav component.
@@ -40,6 +40,7 @@ const InteractiveNav = (props) => {
         filter={null}
         displayEmpty={true}
         displayTags={false}
+        selectedUid={GetSelectedUid(props.selected)}
         handlePlayClick={props.handlePlayClick}
       />
     </>

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
@@ -13,16 +13,20 @@ import {getNavEntryType} from "../Common/utils";
  * an interactive report.
  */
 const InteractiveNavList = (props) => {
-  const navButtons = CreateNavButtons(props, (entry) => (
-    <InteractiveNavEntry
-      name={entry.name}
-      status={entry.status}
-      type={getNavEntryType(entry)}
-      caseCountPassed={entry.case_count.passed}
-      caseCountFailed={entry.case_count.failed}
-      handlePlayClick={(e) => props.handlePlayClick(e, entry)}
-    />
-  ));
+  const navButtons = CreateNavButtons(
+    props,
+    (entry) => (
+      <InteractiveNavEntry
+        name={entry.name}
+        status={entry.status}
+        type={getNavEntryType(entry)}
+        caseCountPassed={entry.case_count.passed}
+        caseCountFailed={entry.case_count.failed}
+        handlePlayClick={(e) => props.handlePlayClick(e, entry)}
+      />
+    ),
+    props.selectedUid,
+  );
 
   return (
     <Column>

--- a/testplan/web_ui/testing/src/Nav/Nav.js
+++ b/testplan/web_ui/testing/src/Nav/Nav.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import NavBreadcrumbs from "./NavBreadcrumbs";
 import NavList from "./NavList";
-import {ParseNavSelection} from "./navUtils";
+import {ParseNavSelection, GetSelectedUid} from "./navUtils";
 
 /**
  * Nav component:
@@ -18,11 +18,6 @@ const Nav = (props) => {
     props.selected,
   );
 
-  let selectedUid = undefined;
-  if (props.selected && props.selected.length>0) {
-    selectedUid = props.selected[props.selected.length-1].uid;
-  }
-
   return (
     <>
       <NavBreadcrumbs
@@ -36,7 +31,7 @@ const Nav = (props) => {
         filter={props.filter}
         displayEmpty={props.displayEmpty}
         displayTags={props.displayTags}
-        selectedUid={selectedUid}
+        selectedUid={GetSelectedUid(props.selected)}
       />
     </>
   );

--- a/testplan/web_ui/testing/src/Nav/NavList.js
+++ b/testplan/web_ui/testing/src/Nav/NavList.js
@@ -13,15 +13,19 @@ import {getNavEntryType} from "../Common/utils";
  * Render a vertical list of all the currently selected entries children.
  */
 const NavList = (props) => {
-  const navButtons = CreateNavButtons(props, (entry) => (
-    <NavEntry
-      name={entry.name}
-      status={entry.status}
-      type={getNavEntryType(entry)}
-      caseCountPassed={entry.case_count.passed}
-      caseCountFailed={entry.case_count.failed}
-    />
-  ), props.selectedUid);
+  const navButtons = CreateNavButtons(
+    props,
+    (entry) => (
+      <NavEntry
+        name={entry.name}
+        status={entry.status}
+        type={getNavEntryType(entry)}
+        caseCountPassed={entry.case_count.passed}
+        caseCountFailed={entry.case_count.failed}
+      />
+    ),
+    props.selectedUid
+  );
 
   return (
     <Column>

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNav.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNav.test.js.snap
@@ -42,6 +42,7 @@ exports[`InteractiveNav shallow renders and matches snapshot 1`] = `
     filter={null}
     handleNavClick={[MockFunction]}
     handlePlayClick={[MockFunction]}
+    selectedUid="aaa"
   />
 </Fragment>
 `;

--- a/testplan/web_ui/testing/src/Nav/navUtils.js
+++ b/testplan/web_ui/testing/src/Nav/navUtils.js
@@ -140,9 +140,9 @@ function ParseNavSelection(report, selected) {
  * @returns {Array|ListGroupItem}
  */
 const CreateNavButtons = (
-  props, 
-  createEntryComponent, 
-  selectedUid=null
+  props,
+  createEntryComponent,
+  selectedUid
   ) => {
   const depth = props.breadcrumbLength;
 
@@ -244,7 +244,20 @@ const styles = StyleSheet.create({
   },
 });
 
+/**
+ * Return the UID of the currently selected entry, or null if there is no
+ * entry selected.
+ */
+const GetSelectedUid = (selected) => {
+  if (selected && selected.length > 0) {
+    return selected[selected.length - 1].uid;
+  } else {
+    return null;
+  }
+};
+
 export {
   ParseNavSelection,
   CreateNavButtons,
+  GetSelectedUid,
 };

--- a/testplan/web_ui/testing/src/Report/InteractiveReport.js
+++ b/testplan/web_ui/testing/src/Report/InteractiveReport.js
@@ -5,16 +5,28 @@
  */
 import React from 'react';
 import {StyleSheet, css} from 'aphrodite';
+import axios from 'axios';
 
+import {COLUMN_WIDTH} from "../Common/defaults";
+import {getNavEntryType} from "../Common/utils";
 import Toolbar from '../Toolbar/Toolbar.js';
 import InteractiveNav from '../Nav/InteractiveNav.js';
 import {FakeInteractiveReport} from '../Common/sampleReports.js';
 import {
+  PropagateIndices,
   UpdateSelectedState,
   GetReportState,
   GetCenterPane,
 } from './reportUtils.js';
 import {ReportToNavEntry} from "../Common/utils";
+
+// Interval to poll for report updates over. We may want to reduce this to make
+// the UI update more quickly.
+//
+// NOTE: currently we poll for updates using HTTP for simplicity but in future
+// it might be better to use websockets or SSEs to allow the backend to notify
+// us when updates are available.
+const POLL_MS = 1000;
 
 /**
  * Interactive report viewer. As opposed to a batch report, an interactive
@@ -27,6 +39,7 @@ class InteractiveReport extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      navWidth: COLUMN_WIDTH,
       report: null,
       selected: [],
       assertions: null,
@@ -38,6 +51,7 @@ class InteractiveReport extends React.Component {
     this.setEntryStatusRecur = this.setEntryStatusRecur.bind(this);
     this.handleNavClick = this.handleNavClick.bind(this);
     this.handlePlayClick = this.handlePlayClick.bind(this);
+    this.getReport = this.getReport.bind(this);
   }
 
   /**
@@ -49,20 +63,92 @@ class InteractiveReport extends React.Component {
   }
 
   /**
-   * Fetch the Testplan interactive report.
+   * Fetch the Testplan interactive report and start polling for updates.
    *
-   * Currently we don't make a real API call and instead just display a fake
-   * report.
+   * If running in dev mode we just display a fake report.
    */
   getReport() {
-    setTimeout(
-      () => this.setState({
-        report: FakeInteractiveReport,
-        selected: this.autoSelect(FakeInteractiveReport),
-        loading: false,
-      }),
-      1500,
-    );
+    if (this.props.dev) {
+      setTimeout(
+        () => this.setState({
+          report: FakeInteractiveReport,
+          selected: this.autoSelect(FakeInteractiveReport),
+          loading: false,
+        }),
+        1500,
+      );
+    } else {
+      axios.get('/api/v1/interactive/report')
+      .then(response => {
+        this.getTests().then(tests => {
+          const rawReport = {...response.data, entries: tests};
+          const processedReport = PropagateIndices(rawReport);
+          this.setState(
+            (state, props) => ({
+              report: processedReport,
+              selected: state.selected.length > 0 ?
+                state.selected : this.autoSelect(processedReport),
+              loading: false,
+            })
+          );
+        });
+      })
+      .catch(error => {
+        console.log(error);
+        this.setState({error: error, loading: false});
+      });
+
+      // We poll for updates to the report every second. Currently we
+      // completely refresh the whole report, which is clearly
+      // inefficient for largish reports. In future we should add
+      // a mechanism to tell when we can partially update the report,
+      // e.g. by adding update timestamps to report entries or by
+      // subscribing to notifications from the backend when specific
+      // entries are updated.
+      setTimeout(this.getReport, POLL_MS);
+    }
+  }
+
+  /**
+   * Get the top-level Tests, including their suites and testcases, from the
+   * backend.
+   */
+  getTests() {
+    return axios.get(
+      "/api/v1/interactive/report/tests"
+    ).then(response => {
+      return Promise.all(response.data.map(
+        test => this.getSuites(test)
+          .then(suites => ({...test, entries: suites}))
+      ));
+    });
+  }
+
+
+  /**
+   * Get the suites owned by a particular test from the backend.
+   */
+  getSuites(test) {
+    return axios.get(
+      `/api/v1/interactive/report/tests/${test.uid}/suites`
+    ).then(response => {
+      return Promise.all(
+        response.data.map((suite) => this.getTestCases(test, suite)
+          .then(testcases => ({...suite, entries: testcases}))
+      ));
+    });
+  }
+
+  /**
+   * Get the testcases owned by a particular test suite from the backend.
+   */
+  getTestCases(test, suite) {
+    return axios.get(
+        `/api/v1/interactive/report/tests/${test.uid}/suites/${suite.uid}/` +
+        `testcases`
+    ).then(response => {
+      return response.data;
+    });
   }
 
   /**
@@ -73,15 +159,145 @@ class InteractiveReport extends React.Component {
   }
 
   /**
-   * Trigger the run of either a single testcase or a group of testcases
-   * (suite, MultiTest or Testplan) represented by an entry in the report.
+   * Find a report entry in our current report state given the selected
+   * navigation entries.
    */
-  runEntry(selectedEntries) {
-    this.setEntryStatus(selectedEntries, "running");
-    // Normally would make request to the backend here to run the test. For now,
-    // we'll mock out the backend interaction and just wait a set time before
-    // marking the test as finished.
-    setTimeout(() => this.setEntryStatus(selectedEntries, "passed"), 3000);
+  findReportEntry(selectedEntries, currEntry) {
+    const [headSelectedEntry, ...tailSelectedEntries] = selectedEntries;
+    const match = (currEntry.uid === headSelectedEntry.uid);
+
+    // Check if the UID matches.
+    if (match) {
+      // Two cases to distinguish between:
+      //
+      // - There are more selected entries to search down for: we recurse down.
+      // - There are no more selected entries: we have found the matching
+      //   report entry, so return it.
+      if (tailSelectedEntries.length === 0) {
+        return currEntry;
+      } else {
+        return currEntry.entries.reduce(
+          (accumulator, entry) => {
+            if (accumulator) {
+              return accumulator;
+            } else {
+              return this.findReportEntry(tailSelectedEntries, entry);
+            }
+          },
+          null,
+        );
+      }
+    } else {
+      // Return null to indicate no match.
+      return null;
+    }
+  }
+
+  /**
+   * Request to update an entry in the report via PUT.
+   */
+  putUpdatedReportEntry(updatedReportEntry, selectedEntries) {
+    const apiUrl = this.getApiUrl(updatedReportEntry, selectedEntries);
+    return axios.put(apiUrl, updatedReportEntry);
+  }
+
+  /**
+   * Get the API URL for requesting to update the state of a report entry.
+   */
+  getApiUrl(updatedReportEntry, selectedEntries) {
+    const api_prefix = "/api/v1/interactive";
+
+    switch (selectedEntries.length) {
+      case 1:
+        return api_prefix + "/report";
+
+      case 2: {
+        const test_uid = selectedEntries[1].uid;
+        return api_prefix + `/report/tests/${test_uid}`;
+      }
+
+      case 3: {
+        const test_uid = selectedEntries[1].uid;
+        const suite_uid = selectedEntries[2].uid;
+        return api_prefix + `/report/tests/${test_uid}/suites/${suite_uid}`;
+      }
+
+      case 4: {
+        const test_uid = selectedEntries[1].uid;
+        const suite_uid = selectedEntries[2].uid;
+        const testcase_uid = selectedEntries[3].uid;
+        return api_prefix + (
+          `/report/tests/${test_uid}`
+          + `/suites/${suite_uid}`
+          + `/testcases/${testcase_uid}`
+        );
+      }
+
+      default:
+        throw new Error(
+          "Unexpected number of selected entries: " + selectedEntries
+        );
+    }
+  }
+
+  /**
+   * Update an entry in the report.
+   */
+  setReportEntry(updatedReportEntry, selectedEntries) {
+    this.setState((state, props) => ({
+      report: this.updateReportEntryRecur(
+        updatedReportEntry, selectedEntries, state.report
+      ),
+      assertions: this.selectedAssertions(state),
+    }));
+  }
+
+  /**
+   * Return the set of assertions if a testcase is currently selected,
+   * otherwise null.
+   */
+  selectedAssertions(state) {
+    const selectedEntry = this.findReportEntry(state.selected, state.report);
+    if (getNavEntryType(selectedEntry) === "testcase") {
+      return selectedEntry.entries;
+    }
+
+    return null;
+  }
+
+  /**
+   * Update a single entry in the report tree recursively. This function
+   * returns a new report object, it does not mutate the current report.
+   */
+  updateReportEntryRecur(updatedReportEntry, selectedEntries, currEntry) {
+    const [headSelectedEntry, ...tailSelectedEntries] = selectedEntries;
+    const match = (currEntry.uid === headSelectedEntry.uid);
+
+    // Check if the UID matches.
+    if (match) {
+      // Two cases to distinguish between:
+      //
+      // - There are more selected entries to search down for: we recurse down.
+      // - There are no more selected entries: we have found the matching
+      //   report entry, so return it.
+      if (tailSelectedEntries.length === 0) {
+        return updatedReportEntry;
+      } else {
+        return {
+          ...currEntry,
+          entries: currEntry.entries.map(
+            entry => this.updateReportEntryRecur(
+              updatedReportEntry,
+              tailSelectedEntries,
+              entry,
+            )
+          ),
+        };
+      }
+    } else {
+      // Return entry unchanged.
+      return currEntry;
+    }
   }
 
   /**
@@ -162,19 +378,58 @@ class InteractiveReport extends React.Component {
   }
 
   /* Handle the play button being clicked on a Nav entry. */
-  handlePlayClick(e, navEntry) {
+  handlePlayClick(e, entry) {
     e.stopPropagation();
+
+    // To be able to update the correct entry in the report tree efficiently,
+    // we need to know the hierarchy of parent entries. Currently we do this
+    // by inspecting the array of selected entry UIDs. In future it would
+    // be better if the UIDs of parent entries could be stored on each
+    // report entry so that we don't need to do it this way.
     const currSelected = this.state.selected[this.state.selected.length - 1];
-    if (!currSelected) {
-      alert(
-        "Error: Expected a report element to be selected. Selected = " +
-        this.state.selected
+    if (currSelected.type === "testcase") {
+      // When testcases are selected, there is an additional complication:
+      // the testcase that is being run may not be the same testcase that is
+      // currently selected. In that case we swap out the UIDs in the selected
+      // array before passing it down (this does not affect the actual
+      // selected entries in this component's state).
+      if (currSelected.uid === entry.uid) {
+        this.runEntry(this.state.selected);
+      } else {
+        const runEntryHierarchy = this.state.selected.slice(0, -1).concat(
+          [ReportToNavEntry(entry)]
+        );
+        this.runEntry(runEntryHierarchy);
+      }
+    } else {
+      const runEntryHierarchy = this.state.selected.concat(
+        [ReportToNavEntry(entry)]
       );
-      return;
+      this.runEntry(runEntryHierarchy);
+    }
+  }
+
+  /**
+   * Trigger the run of either a single testcase or a group of testcases
+   * (suite, MultiTest or Testplan) represented by an entry in the report.
+   */
+  runEntry(selectedEntries) {
+    const reportEntry = this.findReportEntry(
+      selectedEntries, this.state.report
+    );
+    if (!reportEntry) {
+      console.log(selectedEntries);
+      throw new Error("Could not find entry to run");
     }
 
-    const fullSelected = this.state.selected.concat([navEntry]);
-    this.runEntry(fullSelected);
+    const updatedReportEntry = {...reportEntry, status: "running"};
+
+    // TODO handle request error by resyncing report state.
+    this.putUpdatedReportEntry(updatedReportEntry, selectedEntries)
+      .then(response => this.setReportEntry(
+        PropagateIndices(response.data), selectedEntries
+      ))
+      .catch(error => this.setState({error: error}));
   }
 
   render() {

--- a/testplan/web_ui/testing/src/Report/__tests__/InteractiveReport.test.js
+++ b/testplan/web_ui/testing/src/Report/__tests__/InteractiveReport.test.js
@@ -29,19 +29,19 @@ describe('InteractiveReport', () => {
       request.respondWith({
         status: 200,
         response: {
-					"uid": "Assertions Example",
-					"timer": {},
-					"status": "ready",
-					"meta": {},
-					"entry_uids": [
-						"Assertions Test"
-					],
-					"status_override": null,
-					"attachments": {},
-					"tags_index": {},
-					"name": "Assertions Example"
-				},
-			}).then(() => {
+          "uid": "Assertions Example",
+          "timer": {},
+          "status": "ready",
+          "meta": {},
+          "entry_uids": [
+            "Assertions Test"
+          ],
+          "status_override": null,
+          "attachments": {},
+          "tags_index": {},
+          "name": "Assertions Example"
+        },
+      }).then(() => {
         moxios.wait(() => {
           const request = moxios.requests.mostRecent();
           expect(request.url).toBe("/api/v1/interactive/report/tests");
@@ -73,22 +73,22 @@ describe('InteractiveReport', () => {
               request.respondWith({
                 status: 200,
                 response: [{
-									"uid": "SampleSuite",
-									"timer": {},
-									"description": null,
-									"tags": {},
-									"status": "ready",
-									"part": null,
-									"status_override": null,
-									"category": "suite",
-									"entry_uids": [
-										"test_basic_assertions",
-									],
-									"name": "SampleSuite",
-									"fix_spec_path": null
-								}]
-							}).then(() => {
-								moxios.wait(() => {
+                  "uid": "SampleSuite",
+                  "timer": {},
+                  "description": null,
+                  "tags": {},
+                  "status": "ready",
+                  "part": null,
+                  "status_override": null,
+                  "category": "suite",
+                  "entry_uids": [
+                    "test_basic_assertions",
+                  ],
+                  "name": "SampleSuite",
+                  "fix_spec_path": null
+                }]
+              }).then(() => {
+                moxios.wait(() => {
                   const request = moxios.requests.mostRecent();
                   expect(request.url).toBe(
                     "/api/v1/interactive/report/tests/Assertions Test"
@@ -97,22 +97,22 @@ describe('InteractiveReport', () => {
                   request.respondWith({
                     status: 200,
                     response: [{
-											"uid": "test_basic_assertions",
-											"timer": {},
-											"description": null,
-											"tags": {},
-											"type": "TestCaseReport",
-											"status": "ready",
-											"logs": [],
-											"suite_related": false,
-											"entries": [],
-											"status_override": null,
-											"name": "test_basic_assertions"
-										}]
-									}).then(() => {
-										expect(interactiveReport).toMatchSnapshot();
-										done();
-			            });
+                      "uid": "test_basic_assertions",
+                      "timer": {},
+                      "description": null,
+                      "tags": {},
+                      "type": "TestCaseReport",
+                      "status": "ready",
+                      "logs": [],
+                      "suite_related": false,
+                      "entries": [],
+                      "status_override": null,
+                      "name": "test_basic_assertions"
+                    }]
+                  }).then(() => {
+                    expect(interactiveReport).toMatchSnapshot();
+                    done();
+                  });
                 });
               });
             });

--- a/testplan/web_ui/testing/src/Report/__tests__/InteractiveReport.test.js
+++ b/testplan/web_ui/testing/src/Report/__tests__/InteractiveReport.test.js
@@ -1,37 +1,124 @@
 /* Tests the InteractiveReport component. */
 import React from 'react';
 import {shallow} from 'enzyme';
+import {StyleSheetTestUtils} from "aphrodite";
+import moxios from 'moxios';
 
 import InteractiveReport from '../InteractiveReport.js';
 import {FakeInteractiveReport} from '../../Common/sampleReports.js';
 import {ReportToNavEntry} from '../../Common/utils.js';
 
 describe('InteractiveReport', () => {
-  it("shallow renders and matches snapshot", () => {
-    const interactiveReport = shallow(<InteractiveReport />);
-    expect(interactiveReport).toMatchSnapshot();
+  beforeEach(() => {
+    // Stop Aphrodite from injecting styles, this crashes the tests.
+    StyleSheetTestUtils.suppressStyleInjection();
+    moxios.install();
   });
 
-  it("updates testcase status to passed", () => {
+  afterEach(() => {
+    // Resume style injection once test is finished.
+    StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
+    moxios.uninstall();
+  });
+
+  it("Loads report skeleton when mounted", done => {
     const interactiveReport = shallow(<InteractiveReport />);
-    interactiveReport.setState({report: FakeInteractiveReport});
-
-    const selectedReportEntries = [
-      FakeInteractiveReport,
-      FakeInteractiveReport.entries[0],
-      FakeInteractiveReport.entries[0].entries[0],
-      FakeInteractiveReport.entries[0].entries[0].entries[0],
-    ];
-
-    const selectedNavEntries = selectedReportEntries.map(ReportToNavEntry);
-    interactiveReport.instance().setEntryStatus(selectedNavEntries, "passed");
-    interactiveReport.update();
-
-    const newTestcaseEntry = (
-      interactiveReport.state("report").entries[0].entries[0].entries[0]
-    );
-    expect(newTestcaseEntry.status).toBe("passed");
-    expect(interactiveReport).toMatchSnapshot();
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      expect(request.url).toBe("/api/v1/interactive/report");
+      request.respondWith({
+        status: 200,
+        response: {
+					"uid": "Assertions Example",
+					"timer": {},
+					"status": "ready",
+					"meta": {},
+					"entry_uids": [
+						"Assertions Test"
+					],
+					"status_override": null,
+					"attachments": {},
+					"tags_index": {},
+					"name": "Assertions Example"
+				},
+			}).then(() => {
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent();
+          expect(request.url).toBe("/api/v1/interactive/report/tests");
+          request.respondWith({
+            status: 200,
+            response: [
+              {
+                "uid": "Assertions Test",
+                "timer": {},
+                "description": null,
+                "tags": {},
+                "status": "ready",
+                "part": null,
+                "status_override": null,
+                "category": "multitest",
+                "entry_uids": [
+                  "SampleSuite"
+                ],
+                "name": "Assertions Test",
+                "fix_spec_path": null
+              }
+            ]
+          }).then(() => {
+            moxios.wait(() => {
+              const request = moxios.requests.mostRecent();
+              expect(request.url).toBe(
+                "/api/v1/interactive/report/tests/Assertions Test/suites"
+              );
+              request.respondWith({
+                status: 200,
+                response: [{
+									"uid": "SampleSuite",
+									"timer": {},
+									"description": null,
+									"tags": {},
+									"status": "ready",
+									"part": null,
+									"status_override": null,
+									"category": "suite",
+									"entry_uids": [
+										"test_basic_assertions",
+									],
+									"name": "SampleSuite",
+									"fix_spec_path": null
+								}]
+							}).then(() => {
+								moxios.wait(() => {
+                  const request = moxios.requests.mostRecent();
+                  expect(request.url).toBe(
+                    "/api/v1/interactive/report/tests/Assertions Test"
+                    + "/suites/SampleSuite/testcases"
+                  );
+                  request.respondWith({
+                    status: 200,
+                    response: [{
+											"uid": "test_basic_assertions",
+											"timer": {},
+											"description": null,
+											"tags": {},
+											"type": "TestCaseReport",
+											"status": "ready",
+											"logs": [],
+											"suite_related": false,
+											"entries": [],
+											"status_override": null,
+											"name": "test_basic_assertions"
+										}]
+									}).then(() => {
+										expect(interactiveReport).toMatchSnapshot();
+										done();
+			            });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
   });
 });
-

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
@@ -1,32 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`InteractiveReport shallow renders and matches snapshot 1`] = `
-<div
-  className=""
->
-  <Toolbar
-    handleNavFilter={[Function]}
-    status={null}
-    updateEmptyDisplayFunc={[Function]}
-    updateFilterFunc={[Function]}
-    updateTagsDisplayFunc={[Function]}
-  />
-  <InteractiveNav
-    displayEmpty={true}
-    displayTags={false}
-    filter={null}
-    handleNavClick={[Function]}
-    handlePlayClick={[Function]}
-    report={null}
-    selected={Array []}
-  />
-  <Message
-    message="Fetching Testplan report..."
-  />
-</div>
-`;
-
-exports[`InteractiveReport updates testcase status to passed 1`] = `
+exports[`InteractiveReport Loads report skeleton when mounted 1`] = `
 <div
   className=""
 >
@@ -45,6 +19,7 @@ exports[`InteractiveReport updates testcase status to passed 1`] = `
     handlePlayClick={[Function]}
     report={
       Object {
+        "attachments": Object {},
         "case_count": Object {
           "failed": 0,
           "passed": 0,
@@ -74,57 +49,92 @@ exports[`InteractiveReport updates testcase status to passed 1`] = `
                     "description": null,
                     "entries": Array [],
                     "logs": Array [],
-                    "name": "test_interactive",
-                    "name_type_index": Set {},
-                    "status": "passed",
+                    "name": "test_basic_assertions",
+                    "name_type_index": Set {
+                      "test_basic_assertions|testcase",
+                      "SampleSuite|testplan",
+                      "Assertions Test|testplan",
+                      "Assertions Example|testplan",
+                    },
+                    "status": "ready",
                     "status_override": null,
                     "suite_related": false,
                     "tags": Object {},
                     "tags_index": Object {},
                     "timer": Object {},
                     "type": "TestCaseReport",
-                    "uid": "ddd",
+                    "uid": "test_basic_assertions",
                   },
                 ],
-                "logs": Array [],
-                "name": "Interactive Suite",
-                "name_type_index": Set {},
+                "entry_uids": Array [
+                  "test_basic_assertions",
+                ],
+                "fix_spec_path": null,
+                "name": "SampleSuite",
+                "name_type_index": Set {
+                  "SampleSuite|testplan",
+                  "Assertions Test|testplan",
+                  "Assertions Example|testplan",
+                  "test_basic_assertions|testcase",
+                },
                 "part": null,
                 "status": "ready",
                 "status_override": null,
                 "tags": Object {},
                 "tags_index": Object {},
                 "timer": Object {},
-                "type": "TestGroupReport",
-                "uid": "ccc",
+                "uid": "SampleSuite",
               },
             ],
-            "logs": Array [],
-            "name": "Interactive MTest",
-            "name_type_index": Set {},
+            "entry_uids": Array [
+              "SampleSuite",
+            ],
+            "fix_spec_path": null,
+            "name": "Assertions Test",
+            "name_type_index": Set {
+              "Assertions Test|testplan",
+              "Assertions Example|testplan",
+              "SampleSuite|testplan",
+              "test_basic_assertions|testcase",
+            },
             "part": null,
             "status": "ready",
             "status_override": null,
             "tags": Object {},
             "tags_index": Object {},
             "timer": Object {},
-            "type": "TestGroupReport",
-            "uid": "bbb",
+            "uid": "Assertions Test",
           },
         ],
+        "entry_uids": Array [
+          "Assertions Test",
+        ],
         "meta": Object {},
-        "name": "Fake Interactive Report",
-        "name_type_index": Set {},
+        "name": "Assertions Example",
+        "name_type_index": Set {
+          "Assertions Example|testplan",
+          "Assertions Test|testplan",
+          "SampleSuite|testplan",
+          "test_basic_assertions|testcase",
+        },
         "status": "ready",
         "status_override": null,
         "tags_index": Object {},
-        "timer": null,
-        "uid": "aaa",
+        "timer": Object {},
+        "uid": "Assertions Example",
       }
     }
-    selected={Array []}
+    selected={
+      Array [
+        Object {
+          "type": "testplan",
+          "uid": "Assertions Example",
+        },
+      ]
+    }
   />
   <Message
+    left={18}
     message="Please select a testcase."
   />
 </div>

--- a/testplan/web_ui/testing/src/index.js
+++ b/testplan/web_ui/testing/src/index.js
@@ -16,7 +16,12 @@ const AppRouter = () => (
   <Router>
     <Switch>
       <Route path="/testplan/:uid" component={BatchReport} />
-      <Route path="/interactive" component={InteractiveReport} />
+      <Route path="/interactive/_dev">
+        <InteractiveReport dev={true} />
+      </Route>
+      <Route path="/interactive">
+        <InteractiveReport dev={false} />
+      </Route>
       <Route component={EmptyReport} />
     </Switch>
   </Router>


### PR DESCRIPTION
Basic demo-able quality, some further improvements are needed to handle moderate sized reports and to tidy up the code quality.

With this change, the interactive UI can load the report from the backend API and display the test hierarchy. Testcases may be run by clicking the play button and the results will be displayed after the tests have finished running.

Specific further work to be made in future PRs:

- Optimize polling update to only refresh parts of the report that need changing (i.e. testcases that have finished running). Currently the whole report is refreshed - this is only a _temporary_ simplification! Will require some change to the backend.
- Store entry parent UIDs to allow fast lookup and update of report entries without having to refer to the array of selected UIDs
- Type annotations
- Evaluate alternatives to HTTP polling (websockets, SSEs)