### PR TITLE
Fix Empty header returned issue on result.log

### DIFF
--- a/testplan/testing/multitest/entries/stdout/base.py
+++ b/testplan/testing/multitest/entries/stdout/base.py
@@ -37,7 +37,7 @@ class StdOutRegistry(Registry):
         details = logger.get_details(entry) or ''
         output_style = stdout_style.get_style(passing=bool(entry))
 
-        if not header:
+        if header is None:
             raise ValueError(
                 'Empty header returned by'
                 ' {logger} for {entry}'.format(


### PR DESCRIPTION
If call `result.log('')` in testcase,  testplan will raise "ValueError: Empty header returned by <testplan.testing.multitest.entries.stdout.base.LogRenderer". This is because that `StdOutRegistry` doesn't checks header is None.