### PR TITLE
Use partial updates of interactive report

### DIFF
--- a/testplan/common/report/base.py
+++ b/testplan/common/report/base.py
@@ -201,6 +201,14 @@ class Report(object):
         """
         return [(depth, entry) for entry in self]
 
+    @property
+    def hash(self):
+        """Return a hash of all entries in this report."""
+        return hash((
+            self.uid,
+            tuple(id(entry) for entry in self.entries))
+        )
+
 
 class ReportGroup(Report):
     """
@@ -402,3 +410,4 @@ class ReportGroup(Report):
         return list(itertools.chain.from_iterable((rep.logs)
                                                   for rep in self.flatten()
                                                   if isinstance(rep, Report)))
+

--- a/testplan/common/report/schemas.py
+++ b/testplan/common/report/schemas.py
@@ -39,6 +39,7 @@ class ReportSchema(schemas.TreeNodeSchema):
 
     uid = fields.String()
     logs = fields.Nested(ReportLogSchema, many=True)
+    hash = fields.Integer(dump_only=True)
 
     @post_load
     def make_report(self, data):

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -276,6 +276,25 @@ class BaseReportGroup(ReportGroup):
 
         return self.filter(_filter_func)
 
+    @property
+    def hash(self):
+        """
+        Generate a hash of this report object, including its entries. This
+        hash is used to detect when changes are made under particular nodes
+        in the report tree. Since all report entries are mutable, this hash
+        should NOT be used to index the report entry in a set or dict - we
+        have avoided using the magic __hash__ method for this reason. Always
+        use the UID for indexing purposes.
+
+        :return: a hash of all entries in this report group.
+        :rtype: ``int``
+        """
+        return hash((
+            self.uid,
+            self.status,
+            tuple(entry.hash for entry in self.entries))
+        )
+
 
 class TestReport(BaseReportGroup):
     """
@@ -660,4 +679,23 @@ class TestCaseReport(Report):
         """
         from .schemas import TestCaseReportSchema
         return TestCaseReportSchema(strict=True).load(data).data
+
+    @property
+    def hash(self):
+        """
+        Generate a hash of this report object, including its entries. This
+        hash is used to detect when changes are made under particular nodes
+        in the report tree. Since all report entries are mutable, this hash
+        should NOT be used to index the report entry in a set or dict - we
+        have avoided using the magic __hash__ method for this reason. Always
+        use the UID for indexing purposes.
+
+        :return: a hash of all entries in this report group.
+        :rtype: ``int``
+        """
+        return hash((
+            self.uid,
+            self.status,
+            tuple(id(entry) for entry in self.entries))
+        )
 

--- a/testplan/report/testing/schemas.py
+++ b/testplan/report/testing/schemas.py
@@ -184,6 +184,7 @@ class ShallowTestReportSchema(Schema):
     attachments = fields.Dict()
     entry_uids = fields.List(fields.Str(), dump_only=True)
     parent_uids = fields.List(fields.Str())
+    hash = fields.Integer(dump_only=True)
 
     @post_load
     def make_test_report(self, data):
@@ -215,6 +216,7 @@ class ShallowTestGroupReportSchema(Schema):
     tags = TagField()
     entry_uids = fields.List(fields.Str(), dump_only=True)
     parent_uids = fields.List(fields.Str())
+    hash = fields.Integer(dump_only=True)
 
     @post_load
     def make_testgroup_report(self, data):

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
@@ -48,13 +48,14 @@ exports[`InteractiveReport Loads report skeleton when mounted 1`] = `
                     },
                     "description": null,
                     "entries": Array [],
+                    "hash": 12345,
                     "logs": Array [],
-                    "name": "testcaseUID",
+                    "name": "testcaseName",
                     "name_type_index": Set {
-                      "testcaseUID|testcase",
-                      "SuiteUID|testplan",
-                      "MultiTestUID|testplan",
-                      "TestplanUID|testplan",
+                      "testcaseName|testcase",
+                      "SuiteName|testplan",
+                      "MultitestName|testplan",
+                      "TestplanName|testplan",
                     },
                     "parent_uids": Array [
                       "TestplanUID",
@@ -75,16 +76,17 @@ exports[`InteractiveReport Loads report skeleton when mounted 1`] = `
                   "testcaseUID",
                 ],
                 "fix_spec_path": null,
-                "name": "SuiteUID",
+                "hash": 12345,
+                "name": "SuiteName",
                 "name_type_index": Set {
-                  "SuiteUID|testplan",
-                  "MultiTestUID|testplan",
-                  "TestplanUID|testplan",
-                  "testcaseUID|testcase",
+                  "SuiteName|testplan",
+                  "MultitestName|testplan",
+                  "TestplanName|testplan",
+                  "testcaseName|testcase",
                 },
                 "parent_uids": Array [
                   "TestplanUID",
-                  "MultiTestUID",
+                  "MultitestUID",
                 ],
                 "part": null,
                 "status": "ready",
@@ -99,12 +101,13 @@ exports[`InteractiveReport Loads report skeleton when mounted 1`] = `
               "SuiteUID",
             ],
             "fix_spec_path": null,
-            "name": "MultiTestUID",
+            "hash": 12345,
+            "name": "MultitestName",
             "name_type_index": Set {
-              "MultiTestUID|testplan",
-              "TestplanUID|testplan",
-              "SuiteUID|testplan",
-              "testcaseUID|testcase",
+              "MultitestName|testplan",
+              "TestplanName|testplan",
+              "SuiteName|testplan",
+              "testcaseName|testcase",
             },
             "parent_uids": Array [
               "TestplanUID",
@@ -121,16 +124,283 @@ exports[`InteractiveReport Loads report skeleton when mounted 1`] = `
         "entry_uids": Array [
           "MultiTestUID",
         ],
+        "hash": 12345,
         "meta": Object {},
-        "name": "TestplanUID",
+        "name": "TestplanName",
         "name_type_index": Set {
-          "TestplanUID|testplan",
-          "MultiTestUID|testplan",
-          "SuiteUID|testplan",
-          "testcaseUID|testcase",
+          "TestplanName|testplan",
+          "MultitestName|testplan",
+          "SuiteName|testplan",
+          "testcaseName|testcase",
         },
         "parent_uids": Array [],
         "status": "ready",
+        "status_override": null,
+        "tags_index": Object {},
+        "timer": Object {},
+        "uid": "TestplanUID",
+      }
+    }
+    selected={
+      Array [
+        Object {
+          "type": "testplan",
+          "uid": "TestplanUID",
+        },
+      ]
+    }
+  />
+  <Message
+    left={18}
+    message="Please select a testcase."
+  />
+</div>
+`;
+
+exports[`InteractiveReport Parially refreshes the report on update. 1`] = `
+<div
+  className=""
+>
+  <Toolbar
+    handleNavFilter={[Function]}
+    status="ready"
+    updateEmptyDisplayFunc={[Function]}
+    updateFilterFunc={[Function]}
+    updateTagsDisplayFunc={[Function]}
+  />
+  <InteractiveNav
+    displayEmpty={true}
+    displayTags={false}
+    filter={null}
+    handleNavClick={[Function]}
+    handlePlayClick={[Function]}
+    report={
+      Object {
+        "attachments": Object {},
+        "category": "testplan",
+        "entries": Array [
+          Object {
+            "category": "multitest",
+            "description": null,
+            "entries": Array [
+              Object {
+                "category": "suite",
+                "description": null,
+                "entries": Array [
+                  Object {
+                    "description": null,
+                    "entries": Array [],
+                    "hash": 12345,
+                    "logs": Array [],
+                    "name": "testcaseName",
+                    "parent_uids": Array [
+                      "TestplanUID",
+                      "MultiTestUID",
+                      "SuiteUID",
+                    ],
+                    "status": "ready",
+                    "status_override": null,
+                    "suite_related": false,
+                    "tags": Object {},
+                    "timer": Object {},
+                    "type": "TestCaseReport",
+                    "uid": "testcaseUID",
+                  },
+                ],
+                "fix_spec_path": null,
+                "hash": 12345,
+                "name": "SuiteName",
+                "parent_uids": Array [
+                  "TestplanUID",
+                  "MultiTestUID",
+                ],
+                "part": null,
+                "status": "ready",
+                "status_override": null,
+                "tags": Object {},
+                "timer": Object {},
+                "type": "TestGroupReport",
+                "uid": "SuiteUID",
+              },
+            ],
+            "fix_spec_path": null,
+            "hash": 12345,
+            "name": "MultiTestName",
+            "parent_uids": Array [
+              "TestplanUID",
+            ],
+            "part": null,
+            "status": "ready",
+            "status_override": null,
+            "tags": Object {},
+            "timer": Object {},
+            "type": "TestGroupReport",
+            "uid": "MultiTestUID",
+          },
+        ],
+        "hash": 12345,
+        "meta": Object {},
+        "name": "TestplanName",
+        "parent_uids": Array [],
+        "status": "ready",
+        "status_override": null,
+        "tags_index": Object {},
+        "timer": Object {},
+        "type": "TestGroupReport",
+        "uid": "TestplanUID",
+      }
+    }
+    selected={
+      Array [
+        Object {
+          "type": "testplan",
+          "uid": "TestplanUID",
+        },
+      ]
+    }
+  />
+  <Message
+    left={18}
+    message="Please select a testcase."
+  />
+</div>
+`;
+
+exports[`InteractiveReport Updates testcase state 1`] = `
+<div
+  className=""
+>
+  <Toolbar
+    handleNavFilter={[Function]}
+    status="running"
+    updateEmptyDisplayFunc={[Function]}
+    updateFilterFunc={[Function]}
+    updateTagsDisplayFunc={[Function]}
+  />
+  <InteractiveNav
+    displayEmpty={true}
+    displayTags={false}
+    filter={null}
+    handleNavClick={[Function]}
+    handlePlayClick={[Function]}
+    report={
+      Object {
+        "attachments": Object {},
+        "case_count": Object {
+          "failed": 0,
+          "passed": 0,
+        },
+        "entries": Array [
+          Object {
+            "case_count": Object {
+              "failed": 0,
+              "passed": 0,
+            },
+            "category": "multitest",
+            "description": null,
+            "entries": Array [
+              Object {
+                "case_count": Object {
+                  "failed": 0,
+                  "passed": 0,
+                },
+                "category": "suite",
+                "description": null,
+                "entries": Array [
+                  Object {
+                    "case_count": Object {
+                      "failed": 0,
+                      "passed": 0,
+                    },
+                    "description": null,
+                    "entries": Array [],
+                    "hash": 44444,
+                    "logs": Array [],
+                    "name": "testcaseName",
+                    "name_type_index": Set {
+                      "testcaseName|testcase",
+                      "SuiteName|testplan",
+                      "MultitestName|testplan",
+                      "TestplanName|testplan",
+                    },
+                    "parent_uids": Array [
+                      "TestplanUID",
+                      "MultitestUID",
+                      "SuiteUID",
+                    ],
+                    "status": "running",
+                    "status_override": null,
+                    "suite_related": false,
+                    "tags": Object {},
+                    "tags_index": Object {},
+                    "timer": Object {},
+                    "type": "TestCaseReport",
+                    "uid": "TestcaseUID",
+                  },
+                ],
+                "entry_uids": Array [
+                  "test_basic_assertions",
+                ],
+                "fix_spec_path": null,
+                "hash": 33333,
+                "name": "SuiteName",
+                "name_type_index": Set {
+                  "SuiteName|testplan",
+                  "MultitestName|testplan",
+                  "TestplanName|testplan",
+                  "testcaseName|testcase",
+                },
+                "parent_uids": Array [
+                  "TestplanUID",
+                  "MultitestUID",
+                ],
+                "part": null,
+                "status": "running",
+                "status_override": null,
+                "tags": Object {},
+                "tags_index": Object {},
+                "timer": Object {},
+                "uid": "SuiteUID",
+              },
+            ],
+            "entry_uids": Array [
+              "SuiteUID",
+            ],
+            "fix_spec_path": null,
+            "hash": 22222,
+            "name": "MultitestName",
+            "name_type_index": Set {
+              "MultitestName|testplan",
+              "TestplanName|testplan",
+              "SuiteName|testplan",
+              "testcaseName|testcase",
+            },
+            "parent_uids": Array [
+              "TestplanUID",
+            ],
+            "part": null,
+            "status": "running",
+            "status_override": null,
+            "tags": Object {},
+            "tags_index": Object {},
+            "timer": Object {},
+            "uid": "MultitestUID",
+          },
+        ],
+        "entry_uids": Array [
+          "MultitestUID",
+        ],
+        "hash": 11111,
+        "meta": Object {},
+        "name": "TestplanName",
+        "name_type_index": Set {
+          "TestplanName|testplan",
+          "MultitestName|testplan",
+          "SuiteName|testplan",
+          "testcaseName|testcase",
+        },
+        "parent_uids": Array [],
+        "status": "running",
         "status_override": null,
         "tags_index": Object {},
         "timer": Object {},
@@ -186,6 +456,7 @@ exports[`InteractiveReport handles individual test suites being run 1`] = `
                   Object {
                     "description": null,
                     "entries": Array [],
+                    "hash": 12345,
                     "logs": Array [],
                     "name": "testcaseName",
                     "parent_uids": Array [
@@ -203,6 +474,7 @@ exports[`InteractiveReport handles individual test suites being run 1`] = `
                   },
                 ],
                 "fix_spec_path": null,
+                "hash": 12345,
                 "name": "SuiteName",
                 "parent_uids": Array [
                   "TestplanUID",
@@ -218,6 +490,7 @@ exports[`InteractiveReport handles individual test suites being run 1`] = `
               },
             ],
             "fix_spec_path": null,
+            "hash": 12345,
             "name": "MultiTestName",
             "parent_uids": Array [
               "TestplanUID",
@@ -231,6 +504,7 @@ exports[`InteractiveReport handles individual test suites being run 1`] = `
             "uid": "MultiTestUID",
           },
         ],
+        "hash": 12345,
         "meta": Object {},
         "name": "TestplanName",
         "parent_uids": Array [],
@@ -295,6 +569,7 @@ exports[`InteractiveReport handles individual testcases being run 1`] = `
                     },
                     "description": null,
                     "entry_uids": Array [],
+                    "hash": 12345,
                     "logs": Array [],
                     "name": "testcaseName",
                     "name_type_index": Set {
@@ -316,6 +591,7 @@ exports[`InteractiveReport handles individual testcases being run 1`] = `
                   },
                 ],
                 "fix_spec_path": null,
+                "hash": 12345,
                 "name": "SuiteName",
                 "parent_uids": Array [
                   "TestplanUID",
@@ -331,6 +607,7 @@ exports[`InteractiveReport handles individual testcases being run 1`] = `
               },
             ],
             "fix_spec_path": null,
+            "hash": 12345,
             "name": "MultiTestName",
             "parent_uids": Array [
               "TestplanUID",
@@ -344,6 +621,7 @@ exports[`InteractiveReport handles individual testcases being run 1`] = `
             "uid": "MultiTestUID",
           },
         ],
+        "hash": 12345,
         "meta": Object {},
         "name": "TestplanName",
         "parent_uids": Array [],
@@ -404,6 +682,7 @@ exports[`InteractiveReport handles navigation entries being clicked 1`] = `
                   Object {
                     "description": null,
                     "entries": Array [],
+                    "hash": 12345,
                     "logs": Array [],
                     "name": "testcaseName",
                     "parent_uids": Array [
@@ -421,6 +700,7 @@ exports[`InteractiveReport handles navigation entries being clicked 1`] = `
                   },
                 ],
                 "fix_spec_path": null,
+                "hash": 12345,
                 "name": "SuiteName",
                 "parent_uids": Array [
                   "TestplanUID",
@@ -436,6 +716,7 @@ exports[`InteractiveReport handles navigation entries being clicked 1`] = `
               },
             ],
             "fix_spec_path": null,
+            "hash": 12345,
             "name": "MultiTestName",
             "parent_uids": Array [
               "TestplanUID",
@@ -449,6 +730,7 @@ exports[`InteractiveReport handles navigation entries being clicked 1`] = `
             "uid": "MultiTestUID",
           },
         ],
+        "hash": 12345,
         "meta": Object {},
         "name": "TestplanName",
         "parent_uids": Array [],
@@ -513,6 +795,7 @@ exports[`InteractiveReport handles tests being run 1`] = `
                   Object {
                     "description": null,
                     "entries": Array [],
+                    "hash": 12345,
                     "logs": Array [],
                     "name": "testcaseName",
                     "parent_uids": Array [
@@ -530,6 +813,7 @@ exports[`InteractiveReport handles tests being run 1`] = `
                   },
                 ],
                 "fix_spec_path": null,
+                "hash": 12345,
                 "name": "SuiteName",
                 "parent_uids": Array [
                   "TestplanUID",
@@ -545,6 +829,7 @@ exports[`InteractiveReport handles tests being run 1`] = `
               },
             ],
             "fix_spec_path": null,
+            "hash": 12345,
             "name": "MultiTestName",
             "parent_uids": Array [
               "TestplanUID",
@@ -558,6 +843,7 @@ exports[`InteractiveReport handles tests being run 1`] = `
             "uid": "MultiTestUID",
           },
         ],
+        "hash": 12345,
         "meta": Object {},
         "name": "TestplanName",
         "parent_uids": Array [],

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -18,6 +18,8 @@ from testplan import report
 from testplan.testing import multitest
 from testplan.common.utils import timing
 
+from tests.unit.testplan.runnable.interactive import test_api
+
 
 @multitest.testsuite
 class ExampleSuite(object):
@@ -259,7 +261,7 @@ def test_initial_get(plan):
             )
         )
         assert rsp.status_code == 200
-        _compare_json(rsp.json(), expected_json)
+        test_api.compare_json(rsp.json(), expected_json)
 
 
 def test_run_all_tests(plan):
@@ -282,7 +284,7 @@ def test_run_all_tests(plan):
     assert rsp.status_code == 200
 
     updated_json = rsp.json()
-    _compare_json(updated_json, report_json)
+    test_api.compare_json(updated_json, report_json)
     assert updated_json["hash"] != last_hash
 
     timing.wait(
@@ -313,7 +315,7 @@ def test_run_mtest(plan):
     rsp = requests.put(mtest_url, json=mtest_json)
     assert rsp.status_code == 200
     updated_json = rsp.json()
-    _compare_json(updated_json, mtest_json)
+    test_api.compare_json(updated_json, mtest_json)
     assert updated_json["hash"] != mtest_json["hash"]
 
     timing.wait(
@@ -345,7 +347,7 @@ def test_run_suite(plan):
     rsp = requests.put(suite_url, json=suite_json)
     assert rsp.status_code == 200
     updated_json = rsp.json()
-    _compare_json(updated_json, suite_json)
+    test_api.compare_json(updated_json, suite_json)
     assert updated_json["hash"] != suite_json["hash"]
 
     timing.wait(
@@ -381,7 +383,7 @@ def test_run_testcase(plan):
         rsp = requests.put(testcase_url, json=testcase_json)
         assert rsp.status_code == 200
         updated_json = rsp.json()
-        _compare_json(updated_json, testcase_json)
+        test_api.compare_json(updated_json, testcase_json)
         assert updated_json["hash"] != testcase_json["hash"]
 
         timing.wait(
@@ -395,20 +397,6 @@ def test_run_testcase(plan):
             timeout=300,
             raise_on_timeout=True,
         )
-
-
-def _compare_json(actual, expected):
-    if isinstance(actual, list):
-        assert isinstance(expected, list)
-        for actual_item, expected_item in zip(actual, expected):
-            _compare_json(actual_item, expected_item)
-    else:
-        assert isinstance(actual, dict)
-        assert isinstance(expected, dict)
-
-        for key in expected:
-            if key != "hash":
-                assert actual[key] == expected[key]
 
 
 def _check_test_status(test_url, expected_status, last_hash):


### PR DESCRIPTION
Enhance the backend to provide a hash of each node in the report tree.
This hash value is used to determine if there have been changes to that
particular node or in the sub-tree below it.

Compare the hash value in the frontend with previous values when
performing updates, and only drill down into parts of the report tree
where the hash value has changed. This greatly reduces the number of
HTTP requests made when polling for report updates.