### PR TITLE
Add xfail feature for dealing with tests that cannot succeed

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -1266,3 +1266,25 @@ If the testcase times out it will raise a :py:class:`TimeoutException <testplan.
 
 Also keep in mind that testplan will take a little bit of effort to monitor execution time of testcases with ``timeout`` attribute, so it is better to allocate a little more seconds than you have estimated how long a testcase would need.
 
+Xfail
+-----
+
+You can mark testsuite/testcase that you expect to fail to testplan can deal with them accordingly and present as pass in the test report, while keeping the testsuites/testcase `green`.
+
+A Xfail means that you expect a test to fail for some reason. A common example is a test for a feature not yet implemented, or a bug not yet fixed. When a test passes despite being expected to fail(marked with `xfail`), it's an `Xpass` and will be reported as failed in the test report
+
+The ``xfail`` decorator mandates a reason that explains why the test is marked as Xfail:
+
+.. code-block:: python
+
+    @xfail(reason='api changes')
+    def fail_testcase(self, env, result):
+        ...
+
+`Xpass` fails the testsuite/testcase, unless the ``strict`` parameter is passed as ``False``. A common example is a test is unstable:
+
+.. code-block:: python
+
+    @xfail(reason='unstable test', strict=False)
+    def unstable_testcase(self, env, result):
+        ...

--- a/testplan/common/utils/logger.py
+++ b/testplan/common/utils/logger.py
@@ -15,7 +15,7 @@ import sys
 import logging
 
 from testplan.common.utils.strings import Color
-
+from testplan.report.testing import Status
 
 # Define our log-level constants. We add some extra levels between INFO and
 # WARNING.
@@ -80,15 +80,26 @@ class TestplanLogger(logging.Logger):
         """Log 'msg % args' with severity 'DRIVER_INFO'"""
         self._custom_log(DRIVER_INFO, msg, *args, **kwargs)
 
-    def log_test_status(self, name, passed, indent=0, level=TEST_INFO):
+    def log_test_status(self, name, status, indent=0, level=TEST_INFO):
         """Shortcut to log a pass/fail status for a test."""
-        pass_label = Color.green('Pass') if passed else Color.red('Fail')
+        if status in Status.PASSED_STATUSES:
+            pass_label = Color.green(status)
+        elif status in Status.FAILED_STATUSES:
+            pass_label = Color.red(status)
+        else:
+            pass_label = Color.yellow(status)
+
         indent_str = indent * ' '
         msg = self._TEST_STATUS_FORMAT
         self._custom_log(
             level,
             msg,
-            {'name': name, 'pass_label': pass_label, 'indent': indent_str})
+            {
+                'name': name,
+                'pass_label': pass_label.title(),
+                'indent': indent_str
+            }
+        )
 
     def _custom_log(self, level, msg, *args, **kwargs):
         """Log 'msg % args' with severity 'level'."""

--- a/testplan/report/testing/schemas.py
+++ b/testplan/report/testing/schemas.py
@@ -82,6 +82,8 @@ class TestCaseReportSchema(ReportSchema):
     tags = TagField()
     category = fields.String(dump_only=True)
 
+    status_reason = fields.String(allow_none=True)
+
     @post_load
     def make_report(self, data):
         """
@@ -111,6 +113,8 @@ class TestGroupReportSchema(TestCaseReportSchema):
     category = fields.String()
     part = fields.List(fields.Integer, allow_none=True)
     fix_spec_path = fields.String(allow_none=True)
+
+    status_reason = fields.String(allow_none=True)
 
     entries = custom_fields.GenericNested(
         schema_context={

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -638,7 +638,7 @@ class TestRunner(Runnable):
             self._result.test_report.status_override = Status.FAILED
         else:
             self.logger.log_test_status(self.cfg.name,
-                                        self._result.test_report.passed)
+                                        self._result.test_report.status)
 
     def _invoke_exporters(self):
         # Add this logic into a ReportExporter(Runnable)

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -302,7 +302,7 @@ class Test(Runnable):
                             for line in details.split(os.linesep))
                         TESTPLAN_LOGGER.test_info(details)
                 else:
-                    self.logger.log_test_status(name, passed, indent=indent)
+                    self.logger.log_test_status(name, obj.status, indent=indent)
 
         for depth, obj in items:
             if top_down:

--- a/testplan/testing/multitest/__init__.py
+++ b/testplan/testing/multitest/__init__.py
@@ -1,4 +1,4 @@
 """Multitest main test execution framework."""
 
 from .base import MultiTest
-from .suite import testcase, testsuite
+from .suite import testcase, testsuite, xfail

--- a/testplan/testing/multitest/parametrization.py
+++ b/testplan/testing/multitest/parametrization.py
@@ -204,6 +204,9 @@ def _generate_func(
         func_name=function.__name__,
         kwargs=kwargs)
 
+    if hasattr(function, '__xfail__'):
+        _generated.__xfail__ = function.__xfail__
+
     # Tags generated via `tag_func` will be assigned as native tags
     _generated.__tags__ = tagging.validate_tag_value(tag_func(kwargs)) \
         if tag_func else {}

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -686,3 +686,32 @@ def post_testcase(*functions):
         return klass
 
     return post_testcase_inner
+
+
+def xfail(reason, strict=True):
+    """
+    Mark a testcase/testsuit as XFail(known to fail) when not possible to fix
+    immediately. This decorator mandates a reason that explains why the test is
+    marked as passed. XFail testcases will be highlighted as amber on testplan
+    report.
+    By default, should the test pass while we expect it to fail, the report
+    will mark it as failed.
+    For unstable tests, set ``strict`` to ``False``. Note that doing so
+    decreases the value of the test.
+
+    :param reason: Explains why the test is marked as passed.
+    :type reason: ``str``
+    :param strict: Should the test pass while we expect it to fail, the report
+    will mark it as failed if strict is True,  default is True.
+    :type strict: ``bool``
+    :return:
+    """
+
+    def _xfail_test(test):
+        test.__xfail__ = {
+            'reason': reason,
+            'strict': strict
+        }
+        return test
+
+    return _xfail_test

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -177,6 +177,7 @@ EXPECTED_INITIAL_GET = [
                 "timer": {},
                 "type": "TestCaseReport",
                 "uid": "test_passes",
+                "status_reason": None,
             },
             {
                 "category": "testcase",
@@ -196,6 +197,7 @@ EXPECTED_INITIAL_GET = [
                 "timer": {},
                 "type": "TestCaseReport",
                 "uid": "test_fails",
+                "status_reason": None,
             },
             {
                 "category": "testcase",
@@ -215,6 +217,7 @@ EXPECTED_INITIAL_GET = [
                 "timer": {},
                 "type": "TestCaseReport",
                 "uid": "test_logs",
+                "status_reason": None,
             },
         ],
     ),
@@ -238,6 +241,7 @@ EXPECTED_INITIAL_GET = [
             "timer": {},
             "type": "TestCaseReport",
             "uid": "test_passes",
+            "status_reason": None,
         },
     ),
 ]

--- a/tests/functional/testplan/testing/multitest/test_xfail.py
+++ b/tests/functional/testplan/testing/multitest/test_xfail.py
@@ -1,0 +1,69 @@
+
+from testplan.testing.multitest import MultiTest, testsuite, testcase, xfail
+
+from testplan import Testplan
+from testplan.runners.pools import ThreadPool
+from testplan.runners.pools.tasks import Task
+from testplan.report.testing import Status
+from testplan.common.utils.testing import log_propagation_disabled
+from testplan.common.utils.logger import TESTPLAN_LOGGER
+
+
+@testsuite
+class StrictXfailedSuite(object):
+    """A test suite with parameterized testcases."""
+
+    @testcase(
+        parameters=tuple(range(10))
+    )
+    @xfail('Should be fail')
+    def test_fail(self, env, result, val):
+        result.true(val > 100, description='Check if value is true')
+
+    @testcase(
+        parameters=tuple(range(10))
+    )
+    @xfail('Should be pass')
+    def test_pass(self, env, result, val):
+        result.true(val < 100, description='Check if value is true')
+
+
+@testsuite
+class NoStrictXfailedSuite(object):
+    """A test suite with parameterized testcases."""
+
+    @testcase(
+        parameters=tuple(range(10))
+    )
+    @xfail('Should be fail', strict=False)
+    def test_fail(self, env, result, val):
+        result.true(val > 100, description='Check if value is true')
+
+    @testcase(
+        parameters=tuple(range(10))
+    )
+    @xfail('Should be pass', strict=False)
+    def test_pass(self, env, result, val):
+        result.true(val < 100, description='Check if value is true')
+
+
+def test_xfail():
+    plan = Testplan(name='plan', parse_cmdline=False)
+    plan.add(
+        MultiTest(
+            name='xfail_test',
+            suites=[StrictXfailedSuite(), NoStrictXfailedSuite()]
+        )
+    )
+    result = plan.run()
+
+    assert result.report.passed is False
+
+    strict_xfail_suite_report = result.report.entries[0].entries[0]
+    assert strict_xfail_suite_report.passed is False
+    assert strict_xfail_suite_report.entries[0].passed is True
+    assert strict_xfail_suite_report.entries[1].passed is False
+
+    no_strict_xfail_suite_report = result.report.entries[0].entries[1]
+    assert no_strict_xfail_suite_report.entries[0].passed is True
+    assert no_strict_xfail_suite_report.entries[1].passed is True

--- a/tests/unit/testplan/report/test_testing.py
+++ b/tests/unit/testplan/report/test_testing.py
@@ -27,15 +27,13 @@ def test_report_status_precedent():
     `precedent` should return the value with the
     highest precedence (the lowest index).
     """
-    rule = ['alpha', 'beta', 'gamma']
 
-    assert 'alpha' == Status.precedent(['alpha', 'beta'], rule=rule)
-    assert 'alpha' == Status.precedent(['alpha', 'gamma'], rule=rule)
-    assert 'beta' == Status.precedent(['beta', 'gamma'], rule=rule)
-    assert 'gamma' == Status.precedent(['gamma'], rule=rule)
-
-    with pytest.raises(ValueError):
-        Status.precedent(['foo', 'alpha', 'beta'], rule=rule)
+    assert Status.PASSED == Status.precedent([Status.PASSED, Status.XPASS])
+    assert Status.FAILED == Status.precedent([Status.PASSED, Status.FAILED])
+    assert Status.READY == Status.precedent([Status.READY, Status.PASSED])
+    assert Status.FAILED == Status.precedent([Status.FAILED])
+    assert Status.PASSED == Status.precedent([Status.PASSED, Status.XFAIL])
+    assert Status.FAILED == Status.precedent([Status.FAILED, Status.XFAIL])
 
 
 @disable_log_propagation(report.log.LOGGER)


### PR DESCRIPTION
* Add `@xfail` decorator to mark failed testcase/testsuite
* `@xfail` decorator will add `__xfail__` attribute into testcase/testsuite
* `@xfail` test will be marked xfail(if fail) xpass(if pass)
* Add xfail testcase
* Add `xfail` document