### PR TITLE
Refactor interactive backend and add UTs

### DIFF
--- a/testplan/common/entity/__init__.py
+++ b/testplan/common/entity/__init__.py
@@ -13,7 +13,5 @@ from .base import (Entity,
                    RunnableConfig,
                    RunnableResult,
                    RunnableIRunner,
-                   RunnableIHandler,
-                   RunnableIHandlerConfig,
                    FailedAction,
                    DEFAULT_RUNNABLE_ABORT_SIGNALS)

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -8,19 +8,19 @@ from lxml import objectify
 from schema import Or, Use, And
 
 from testplan.common.config import ConfigOption, validate_func
+
 from testplan.testing import filtering, ordering, tagging
+
 from testplan.common.entity import (
-    Resource, Runnable, RunnableResult, RunnableConfig, RunnableIRunner,
-)
+    Resource, Runnable, RunnableResult, RunnableConfig, RunnableIRunner)
 from testplan.common.utils.process import subprocess_popen
 from testplan.common.utils.timing import parse_duration, format_duration
 from testplan.common.utils.process import enforce_timeout, kill_process
 from testplan.common.utils.strings import slugify
+
 from testplan.report import (
-    test_styles, TestGroupReport, TestCaseReport, Status,
-)
+    test_styles, TestGroupReport, TestCaseReport, Status)
 from testplan.common.utils.logger import TESTPLAN_LOGGER
-from testplan import defaults
 
 
 TEST_INST_INDENT = 2
@@ -90,10 +90,8 @@ class TestConfig(RunnableConfig):
             ConfigOption('before_stop', default=None): start_stop_signature,
             ConfigOption('after_stop', default=None): start_stop_signature,
             ConfigOption('test_filter'): filtering.BaseFilter,
-            ConfigOption('test_sorter',
-                         default=ordering.NoopSorter()): ordering.BaseSorter,
-            ConfigOption('stdout_style',
-                         default=defaults.STDOUT_STYLE): test_styles.Style,
+            ConfigOption('test_sorter'): ordering.BaseSorter,
+            ConfigOption('stdout_style'): test_styles.Style,
             ConfigOption(
                 'tags',
                 default=None

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -8,19 +8,19 @@ from lxml import objectify
 from schema import Or, Use, And
 
 from testplan.common.config import ConfigOption, validate_func
-
 from testplan.testing import filtering, ordering, tagging
-
 from testplan.common.entity import (
-    Resource, Runnable, RunnableResult, RunnableConfig, RunnableIRunner)
+    Resource, Runnable, RunnableResult, RunnableConfig, RunnableIRunner,
+)
 from testplan.common.utils.process import subprocess_popen
 from testplan.common.utils.timing import parse_duration, format_duration
 from testplan.common.utils.process import enforce_timeout, kill_process
 from testplan.common.utils.strings import slugify
-
 from testplan.report import (
-    test_styles, TestGroupReport, TestCaseReport, Status)
+    test_styles, TestGroupReport, TestCaseReport, Status,
+)
 from testplan.common.utils.logger import TESTPLAN_LOGGER
+from testplan import defaults
 
 
 TEST_INST_INDENT = 2
@@ -90,8 +90,10 @@ class TestConfig(RunnableConfig):
             ConfigOption('before_stop', default=None): start_stop_signature,
             ConfigOption('after_stop', default=None): start_stop_signature,
             ConfigOption('test_filter'): filtering.BaseFilter,
-            ConfigOption('test_sorter'): ordering.BaseSorter,
-            ConfigOption('stdout_style'): test_styles.Style,
+            ConfigOption('test_sorter',
+                         default=ordering.NoopSorter()): ordering.BaseSorter,
+            ConfigOption('stdout_style',
+                         default=defaults.STDOUT_STYLE): test_styles.Style,
             ConfigOption(
                 'tags',
                 default=None

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -62,8 +62,11 @@ class MultitestIRunner(TestIRunner):
         """
         Generator for dry_run execution.
         """
-        yield (self._runnable.dry_run,
-               RunnableIRunner.EMPTY_TUPLE, dict(status=Status.INCOMPLETE))
+        yield (
+            self._runnable.dry_run,
+            tuple(),
+            {"status": Status.INCOMPLETE},
+        )
 
     @TestIRunner.set_run_status
     def run(self, suite='*', case='*'):
@@ -73,9 +76,11 @@ class MultitestIRunner(TestIRunner):
         pattern = Pattern('*:{}:{}'.format(suite, case))
         for entry in self._runnable.get_test_context(test_filter=pattern):
             for case in entry[1]:
-                yield (self._runnable.run_tests,
-                       RunnableIRunner.EMPTY_TUPLE,
-                       dict(patch_report=True, ctx=[(entry[0], [case])]))
+                yield (
+                    self._runnable.run_tests,
+                    tuple(),
+                    {"ctx": [(entry[0], [case])]},
+                )
 
 
 class MultiTestConfig(TestConfig):

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -57,7 +57,7 @@ def plan():
     )
     plan.run()
     timing.wait(
-        lambda: plan.interactive.http_handler_info[0] is not None,
+        lambda: plan.interactive.http_handler_info is not None,
         300,
         raise_on_timeout=True,
     )

--- a/tests/unit/testplan/runnable/interactive/test_irunner.py
+++ b/tests/unit/testplan/runnable/interactive/test_irunner.py
@@ -2,11 +2,14 @@
 import mock
 import pytest
 
-from testplan.runnable.interactive import base
+from testplan import defaults
 from testplan import report
-from testplan.common import entity
 from testplan import runners
+from testplan.common import entity
+from testplan.testing import filtering
 from testplan.testing import multitest
+from testplan.testing import ordering
+from testplan.runnable.interactive import base
 
 
 @multitest.testsuite
@@ -47,7 +50,13 @@ def irunner():
     local_runner = runners.LocalRunner()
     test_uids = ["test_1", "test_2", "test_3"]
     test_objs = [
-        multitest.MultiTest(name=uid, suites=[Suite()])
+        multitest.MultiTest(
+            name=uid,
+            suites=[Suite()],
+            test_filter=filtering.Filter(),
+            test_sorter=ordering.NoopSorter(),
+            stdout_style=defaults.STDOUT_STYLE,
+        )
         for uid in test_uids
     ]
 

--- a/tests/unit/testplan/runnable/interactive/test_irunner.py
+++ b/tests/unit/testplan/runnable/interactive/test_irunner.py
@@ -1,0 +1,185 @@
+"""Test the interactive test runner."""
+import mock
+import pytest
+
+from testplan.runnable.interactive import base
+from testplan import report
+from testplan.common import entity
+from testplan import runners
+from testplan.testing import multitest
+
+
+@multitest.testsuite
+class Suite(object):
+    """Test suite."""
+
+    @multitest.testcase
+    def case(self, env, result):
+        """Testcase."""
+        del env  # unused
+        result.true(True)
+
+
+def test_startup():
+    """Test initializing and running the interactive runner."""
+    target = mock.MagicMock()
+    mock_server = mock.MagicMock()
+
+    with mock.patch("cheroot.wsgi.Server", return_value=mock_server):
+        irunner = base.TestRunnerIHandler(target)
+
+        irunner.setup()
+        mock_server.prepare.assert_called_once()
+        mock_server.bind_addr = ("hostname", 1234)
+        assert irunner.http_handler_info == mock_server.bind_addr
+
+        irunner.run()
+        mock_server.serve.assert_called_once()
+
+        irunner.teardown()
+
+
+@pytest.fixture
+def irunner():
+    """Set up an irunner instance for testing."""
+    target = mock.MagicMock()
+
+    local_runner = runners.LocalRunner()
+    test_uids = ["test_1", "test_2", "test_3"]
+    test_objs = [
+        multitest.MultiTest(name=uid, suites=[Suite()])
+        for uid in test_uids
+    ]
+
+    for test in test_objs:
+        local_runner.add(test, test.uid())
+
+    target.resources = entity.Environment()
+    target.resources.add(local_runner)
+
+    with mock.patch("cheroot.wsgi.Server"):
+        irunner = base.TestRunnerIHandler(target)
+        irunner.setup()
+
+        yield irunner
+
+        irunner.teardown()
+
+
+@pytest.mark.parametrize("sync", [True, False])
+def test_run_all_tests(irunner, sync):
+    """Test running all tests."""
+    _check_initial_report(irunner.report)
+
+    results = irunner.run_all_tests(await_results=sync)
+    assert len(results) == 3
+    for res in results:
+        # If tests were run synchronously, we should have the report objects.
+        # Otherwise, we will have async result objects which we can await.
+        if sync:
+            test_report = res
+        else:
+            test_report = res.get()
+        assert isinstance(test_report, report.TestGroupReport)
+        assert test_report.passed
+
+    # The test report should have been updated as a side effect.
+    assert irunner.report.passed
+    for test_report in irunner.report:
+        assert test_report.passed
+
+
+@pytest.mark.parametrize("sync", [True, False])
+def test_run_test(irunner, sync):
+    """Test running a single test."""
+    results = irunner.run_test("test_1", await_results=sync)
+    assert len(results) == 1
+
+    # If tests were run synchronously, we should have the report objects.
+    # Otherwise, we will have async result objects which we can await.
+    if sync:
+        test_report = results[0]
+    else:
+        test_report = results[0].get()
+
+    assert isinstance(test_report, report.TestGroupReport)
+    assert test_report.passed
+
+    # The test report should have been updated as a side effect.
+    assert irunner.report.status == report.Status.READY
+    for test_report in irunner.report:
+        if test_report.uid == "test_1":
+            assert test_report.passed
+        else:
+            assert test_report.status == report.Status.READY
+
+
+@pytest.mark.parametrize("sync", [True, False])
+def test_run_suite(irunner, sync):
+    """Test running a single test suite."""
+    results = irunner.run_test_suite("test_1", "Suite", await_results=sync)
+    assert len(results) == 1
+
+    # If tests were run synchronously, we should have the report objects.
+    # Otherwise, we will have async result objects which we can await.
+    if sync:
+        test_report = results[0]
+    else:
+        test_report = results[0].get()
+
+    assert isinstance(test_report, report.TestGroupReport)
+    assert test_report.passed
+
+    # The test report should have been updated as a side effect.
+    assert irunner.report.status == report.Status.READY
+    for test_report in irunner.report:
+        if test_report.uid == "test_1":
+            assert test_report.passed
+        else:
+            assert test_report.status == report.Status.READY
+
+
+@pytest.mark.parametrize("sync", [True, False])
+def test_run_testcase(irunner, sync):
+    """Test running a single testcase."""
+    results = irunner.run_test_case(
+        "test_1", "Suite", "case", await_results=sync,
+    )
+    assert len(results) == 1
+
+    # If tests were run synchronously, we should have the report objects.
+    # Otherwise, we will have async result objects which we can await.
+    if sync:
+        test_report = results[0]
+    else:
+        test_report = results[0].get()
+
+    assert isinstance(test_report, report.TestGroupReport)
+    assert test_report.passed
+
+    # The test report should have been updated as a side effect.
+    assert irunner.report.status == report.Status.READY
+    for test_report in irunner.report:
+        if test_report.uid == "test_1":
+            assert test_report.passed
+        else:
+            assert test_report.status == report.Status.READY
+
+
+def _check_initial_report(initial_report):
+    """
+    Check that the initial report tree is generated correctly.
+
+    First, check that there are three top-level Test reports.
+    """
+    assert initial_report.status == report.Status.READY
+    assert len(initial_report.entries) == 3
+    for test_report in initial_report:
+        # Each Test contains one suite.
+        assert test_report.status == report.Status.READY
+        assert len(test_report.entries) == 1
+        for suite_report in test_report:
+            # Each suite contains one testcase.
+            assert suite_report.status == report.Status.READY
+            assert len(suite_report.entries) == 1
+


### PR DESCRIPTION
Change how backend runs tests and updates the test report: now the
interactive handler fully owns the report tree and handles emrging in
partial test results returned from runners. This avoids ending up with
dangling report entries owned by test runners.

Remove `RunnableIHandler` base class and move task running logic into single TestRunnerIHandler class for simplicity.

Add unit tests for the interactive backend runner, to cover running
tests at various levels. These UTs will be extended to cover environment
start/stop and other features in future.

There is still some work to do in tidying up the TestRunnerIHandler class - I think there are a few methods that can be removed or simplified in future.