### PR TITLE
Keep the attributes of test suite defined by user in report

### DIFF
--- a/testplan/base.py
+++ b/testplan/base.py
@@ -263,6 +263,11 @@ class Testplan(entity.RunnableManager):
                                 default_options=self._default_options)
 
     @property
+    def runnable(self):
+        """Runnable instance."""
+        return self._runnable
+
+    @property
     def args(self):
         """Parsed arguments."""
         return self._parsed_args

--- a/testplan/common/utils/validation.py
+++ b/testplan/common/utils/validation.py
@@ -29,4 +29,8 @@ def has_method(method_name):
 
 def is_valid_url(url):
     """Validator that checks if a url is valid"""
-    return True if validators.url(url) is True else False
+    return bool(validators.url(url))
+
+
+def is_valid_email(email):
+    return bool(validators.email(email))

--- a/testplan/exporters/testing/pdf/__init__.py
+++ b/testplan/exporters/testing/pdf/__init__.py
@@ -24,9 +24,6 @@ except Exception as exc:
     warnings.warn('reportlab must be supported: {}'.format(exc))
 
 
-from testplan import defaults
-from testplan.common.utils.logger import TESTPLAN_LOGGER
-
 from testplan.common.utils.strings import slugify
 from testplan.common.report import Report
 

--- a/testplan/exporters/testing/xml/__init__.py
+++ b/testplan/exporters/testing/xml/__init__.py
@@ -8,8 +8,6 @@ import shutil
 from lxml import etree
 from lxml.builder import E  # pylint: disable=no-name-in-module
 
-from testplan import defaults
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.common.utils.path import unique_name
 from testplan.common.utils.strings import slugify
 

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -491,6 +491,7 @@ class TestGroupReport(BaseReportGroup):
                  category=ReportCategories.TESTGROUP,
                  tags=None,
                  part=None,
+                 extra_attributes=None,
                  fix_spec_path=None,
                  env_status=None,
                  **kwargs):
@@ -508,6 +509,8 @@ class TestGroupReport(BaseReportGroup):
         # can be hold back for merging (if necessary)
         self.part = part  # i.e. (m, n), while 0 <= m < n and n > 1
         self.part_report_lookup = {}
+
+        self.extra_attributes = extra_attributes
 
         self.fix_spec_path = fix_spec_path
 

--- a/testplan/report/testing/schemas.py
+++ b/testplan/report/testing/schemas.py
@@ -233,6 +233,7 @@ class TestGroupReportSchema(TestCaseReportSchema):
     source_class = TestGroupReport
     category = fields.String()
     part = fields.List(fields.Integer, allow_none=True)
+    extra_attributes = fields.Dict(allow_none=True)
     fix_spec_path = fields.String(allow_none=True)
     env_status = fields.String(allow_none=True)
 

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -415,6 +415,7 @@ class MultiTest(Test):
                         category=ReportCategories.TESTSUITE,
                         uid=get_testsuite_name(next_suite),
                         tags=next_suite.__tags__,
+                        extra_attributes=next_suite.__extra_attributes__
                     )
                     if hasattr(next_suite, '__xfail__'):
                         testsuite_report.status_reason = \

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -256,6 +256,15 @@ def _testsuite(klass):
         klass.__tags__ = {}  # used for UI
         klass.__tags_index__ = {}  # used for actual filtering
 
+    # Attributes defined in test suite will be saved in test report,
+    # they should be normal objects which can be serialized with json
+    klass.__extra_attributes__ = {
+        attrib: getattr(klass, attrib) for attrib in dir(klass) if not (
+            attrib.startswith('__') or callable(getattr(klass, attrib))
+            or attrib in klass.__testcases__ or getattr(
+                getattr(klass, attrib), '__parametrization_template__', False))
+    }
+
     klass.get_testcases = get_testcase_methods
 
     for func in __GENERATED_TESTCASES__:


### PR DESCRIPTION
* user can define some useful attributes in test suite and they will be
  saved in report in a dictionary named 'extra_attributes'.
* Add a common util for verifying email address.