### PR TITLE
Log async errors and fix report initialisation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ REQUIRED = [
     'cheroot',
     'validators',
     'ipaddress',
+    "futures; python_version <= '2.7'",
 ]
 
 setup(name='Testplan',

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -15,8 +15,8 @@ import re
 import six
 import numbers
 import threading
-import multiprocessing.dummy
 import itertools
+from concurrent import futures
 
 from testplan.common import entity
 from testplan.common import config
@@ -131,7 +131,7 @@ class TestRunnerIHandler(entity.Entity):
             "Starting {} for {}".format(self.__class__.__name__, self.target)
         )
         self._http_handler = self._setup_http_handler()
-        self._pool = multiprocessing.dummy.Pool(1)
+        self._pool = futures.ThreadPoolExecutor(max_workers=1)
 
     def run(self):
         """
@@ -143,7 +143,8 @@ class TestRunnerIHandler(entity.Entity):
 
         self.status.change(entity.RunnableStatus.RUNNING)
         self._display_connection_info()
-        self._http_handler.run()
+        with self._pool:
+            self._http_handler.run()
         self.status.change(entity.RunnableStatus.FINISHED)
 
     def teardown(self):
@@ -151,7 +152,6 @@ class TestRunnerIHandler(entity.Entity):
         if self._pool is None or self._http_handler is None:
             raise RuntimeError("setup() not run")
 
-        self._pool.close()
         self._pool = None
         self._http_handler = None
 
@@ -196,9 +196,7 @@ class TestRunnerIHandler(entity.Entity):
 
         return [
             self.run_test(
-                test_uid,
-                runner_uid=runner_uid,
-                await_results=await_results,
+                test_uid, runner_uid=runner_uid, await_results=await_results
             )
             for test_uid, real_runner_uid in all_tests
         ]
@@ -223,8 +221,8 @@ class TestRunnerIHandler(entity.Entity):
         if await_results:
             return self._run_all_test_operations(test_run_generator)
         else:
-            return self._pool.apply_async(
-                self._run_all_test_operations, (test_run_generator,)
+            return self._run_async(
+                self._run_all_test_operations, test_run_generator
             )
 
     @auto_start_stop_environment
@@ -250,8 +248,8 @@ class TestRunnerIHandler(entity.Entity):
         if await_results:
             return self._run_all_test_operations(test_run_generator)
         else:
-            return self._pool.apply_async(
-                self._run_all_test_operations, (test_run_generator,)
+            return self._run_async(
+                self._run_all_test_operations, test_run_generator
             )
 
     @auto_start_stop_environment
@@ -281,8 +279,8 @@ class TestRunnerIHandler(entity.Entity):
         if await_results:
             return self._run_all_test_operations(test_run_generator)
         else:
-            return self._pool.apply_async(
-                self._run_all_test_operations, (test_run_generator,)
+            return self._run_async(
+                self._run_all_test_operations, test_run_generator
             )
 
     def test(self, test_uid, runner_uid=None):
@@ -327,9 +325,10 @@ class TestRunnerIHandler(entity.Entity):
                 test_uid, test_irunner.start_resources()
             )
         else:
-            return self._pool.apply_async(
+            return self._run_async(
                 self._start_environment,
-                (test_uid, test_irunner.start_resources()),
+                test_uid,
+                test_irunner.start_resources(),
             )
 
     def stop_test_resources(
@@ -355,9 +354,8 @@ class TestRunnerIHandler(entity.Entity):
                 test_uid, test_irunner.stop_resources()
             )
         else:
-            return self._pool.apply_async(
-                self._stop_environment,
-                (test_uid, test_irunner.stop_resources()),
+            return self._run_async(
+                self._stop_environment, test_uid, test_irunner.stop_resources()
             )
 
     def get_environment(self, env_uid):
@@ -727,23 +725,8 @@ class TestRunnerIHandler(entity.Entity):
 
         for test_uid, runner_uid in self.all_tests():
             test = self.test(test_uid, runner_uid=runner_uid)
-
-            for suite in test.suites:
-                suite_name = suite.__class__.__name__
-                suite_report = testplan.report.TestGroupReport(
-                    name=suite_name, uid=suite_name, category='testsuite'
-                )
-
-                for testcase in suite.get_testcases():
-                    testcase_name = testcase.__name__
-                    testcase_report = testplan.report.TestCaseReport(
-                        name=testcase_name, uid=testcase_name
-                    )
-                    suite_report.append(testcase_report)
-
-                test.result.report.append(suite_report)
-
-            report.append(test.result.report)
+            test_report = test.dry_run().report
+            report.append(test_report)
 
         return report
 
@@ -804,3 +787,20 @@ class TestRunnerIHandler(entity.Entity):
                 "Setting env status of %s to %s", test_uid, new_status
             )
             self.report[test_uid].env_status = new_status
+
+    def _run_async(self, func, *args, **kwargs):
+        """
+        Schedule a function to run asynchronously in our task pool. We add a
+        callback to ensure that all async exceptions are logged, for debugging
+        purposes.
+        """
+        future = self._pool.submit(func, *args, **kwargs)
+        future.add_done_callback(self._log_async_exceptions)
+        return future
+
+    def _log_async_exceptions(self, future):
+        """Log any exceptions that occur while running async."""
+        try:
+            future.result()
+        except Exception:
+            self.logger.exception("Exception caught in async function")

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -313,13 +313,7 @@ class MultiTest(Test):
         ctx = [(self.test_context[idx][0], self.test_context[idx][1][:])
                for idx in range(len(self.test_context))]
 
-        self.result.report = TestGroupReport(
-            name=self.cfg.name,
-            description=self.cfg.description,
-            category=self.__class__.__name__.lower(),
-            uid=self.uid(),
-            tags=self.cfg.tags,
-        )
+        self.result.report = self._new_test_report()
 
         while len(ctx) > 0:
             testsuite, testcases = ctx.pop(0)

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -128,7 +128,7 @@ EXPECTED_INITIAL_GET = [
         [
             {
                 "category": "testsuite",
-                "description": None,
+                "description": "Example test suite.",
                 "entry_uids": ["test_passes", "test_fails", "test_logs"],
                 "env_status": None,
                 "fix_spec_path": None,
@@ -147,7 +147,7 @@ EXPECTED_INITIAL_GET = [
         "/report/tests/ExampleMTest/suites/ExampleSuite",
         {
             "category": "testsuite",
-            "description": None,
+            "description": "Example test suite.",
             "entry_uids": ["test_passes", "test_fails", "test_logs"],
             "env_status": None,
             "fix_spec_path": None,
@@ -166,7 +166,7 @@ EXPECTED_INITIAL_GET = [
         [
             {
                 "category": "testcase",
-                "description": None,
+                "description": "Testcase that passes.",
                 "entries": [],
                 "logs": [],
                 "name": "test_passes",
@@ -186,7 +186,7 @@ EXPECTED_INITIAL_GET = [
             },
             {
                 "category": "testcase",
-                "description": None,
+                "description": "Testcase that fails.",
                 "entries": [],
                 "logs": [],
                 "name": "test_fails",
@@ -206,7 +206,7 @@ EXPECTED_INITIAL_GET = [
             },
             {
                 "category": "testcase",
-                "description": None,
+                "description": "Testcase that makes a log.",
                 "entries": [],
                 "logs": [],
                 "name": "test_logs",
@@ -230,7 +230,7 @@ EXPECTED_INITIAL_GET = [
         "/report/tests/ExampleMTest/suites/ExampleSuite/testcases/test_passes",
         {
             "category": "testcase",
-            "description": None,
+            "description": "Testcase that passes.",
             "entries": [],
             "logs": [],
             "name": "test_passes",

--- a/tests/unit/testplan/runnable/interactive/test_irunner.py
+++ b/tests/unit/testplan/runnable/interactive/test_irunner.py
@@ -90,7 +90,7 @@ def test_run_all_tests(irunner, sync):
         if sync:
             test_reports = res
         else:
-            test_reports = res.get()
+            test_reports = res.result()
         assert len(test_reports) == 1
         test_report = test_reports[0]
 
@@ -113,7 +113,7 @@ def test_run_test(irunner, sync):
     if sync:
         results = ret
     else:
-        results = ret.get()
+        results = ret.result()
 
     assert len(results) == 1
     test_report = results[0]
@@ -140,7 +140,7 @@ def test_run_suite(irunner, sync):
     if sync:
         results = ret
     else:
-        results = ret.get()
+        results = ret.result()
 
     assert len(results) == 1
     test_report = results[0]
@@ -160,16 +160,14 @@ def test_run_suite(irunner, sync):
 @pytest.mark.parametrize("sync", [True, False])
 def test_run_testcase(irunner, sync):
     """Test running a single testcase."""
-    ret = irunner.run_test_case(
-        "test_1", "Suite", "case", await_results=sync
-    )
+    ret = irunner.run_test_case("test_1", "Suite", "case", await_results=sync)
 
     # If tests were run synchronously, we should have the report objects.
     # Otherwise, we will have async result objects which we can await.
     if sync:
         results = ret
     else:
-        results = ret.get()
+        results = ret.result()
 
     assert len(results) == 1
     test_report = results[0]
@@ -198,7 +196,7 @@ def test_environment_control(irunner, sync):
     # If the environment was started asynchronously, wait for all of the
     # operations to copmlete before continuing.
     if not sync:
-        start_results.get()
+        start_results.result()
 
     assert test.resources.all_status(entity.ResourceStatus.STARTED)
     assert (
@@ -211,7 +209,7 @@ def test_environment_control(irunner, sync):
 
     # Again, await the async operation results if testing async.
     if not sync:
-        stop_results.get()
+        stop_results.result()
 
     assert test.resources.all_status(entity.ResourceStatus.STOPPED)
     assert (


### PR DESCRIPTION
Use the concurrent.futures package instead of multiprocessing and add a
callback to log exceptions that occur asynchronously. Add python2
backport as a dependency.

Fix and simplify report initialisation to use the dry_run method of
tests. This ensures that the report skeleton for parametrized testcases
is generated correctly and reduces code duplication. As a side effect,
descriptions for testsuites and testcases are now correctly included in
the interactive UI.

Further fixes for running parametrized testcases in interactive mode are
required and will be made soon...