### PR TITLE
Rename "C++" examples to "CPP"

### DIFF
--- a/doc/en/download/CPP.rst
+++ b/doc/en/download/CPP.rst
@@ -1,4 +1,4 @@
-C++
+CPP
 ***
 
 Google Test

--- a/doc/en/download/index.rst
+++ b/doc/en/download/index.rst
@@ -17,4 +17,4 @@ Downloadable examples
     Execution Pools
     Database
     Data Science
-    C++
+    CPP


### PR DESCRIPTION
To avoid encoding issue with the sphinx docs.