### PR TITLE
Some improvement or fixes

### DIFF
--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -594,9 +594,13 @@ class MultiTest(Test):
 
                 time_restriction = getattr(testcase, 'timeout', None)
                 if time_restriction:
-                    timeout_deco(
+                    # pylint: disable=unbalanced-tuple-unpacking
+                    executed, execution_result = timeout_deco(
                         time_restriction, 'Testcase timeout after {} seconds'
                     )(testcase)(self.resources, case_result)
+                    if not executed:
+                        testcase_report.logger.error(execution_result)
+                        testcase_report.status_override = Status.ERROR
                 else:
                     testcase(self.resources, case_result)
 

--- a/testplan/testing/multitest/parametrization.py
+++ b/testplan/testing/multitest/parametrization.py
@@ -175,6 +175,10 @@ def _ensure_unique_names(functions):
     """
     name_counts = collections.Counter([f.__name__ for f in functions])
     dupe_names = {k for k, v in name_counts.items() if v > 1}
+
+    if len(dupe_names) == 0:
+        return
+
     dupe_counter = collections.defaultdict(int)
 
     for func in functions:
@@ -184,6 +188,15 @@ def _ensure_unique_names(functions):
             func.__name__ = '{}__{}'.format(name, count)
             dupe_counter[name] += 1
 
+    # Can still have name conflict if user defined name_func does not work well
+    name_counts = collections.Counter([f.__name__ for f in functions])
+    dupe_names = {k for k, v in name_counts.items() if v > 1}
+
+    if len(dupe_names) > 0:
+        msg = (
+            '"name_func" produces duplicated function names and cannot be '
+            'automatically fixed by adding a suffix number, please check it.')
+        raise ParametrizationError(msg)
 
 def _generate_func(
      function, name_func, tag_func, docstring_func, tag_dict, kwargs):


### PR DESCRIPTION
* Fix an issue that when testcase has a timeout, the exception info
  cannot be caught, and our code itself raises an `IndexError`.
* Enhancement for `HttpExporter` that if the report has some objects
  that cannot be serialized by json, then we provide a customized
  json encoder to deal with it to avoid exception.
* Customized name_func for parametrized testcase cannot ensure no
  deplicated testcase names exist: after we simply renaming the invalid
  names there might still conflict be found, we need to check again.