### PR TITLE
Fix running of all parametrized testcases in UI

### DIFF
--- a/testplan/testing/filtering.py
+++ b/testplan/testing/filtering.py
@@ -249,7 +249,7 @@ class Pattern(Filter):
         <Multitest name>:*:<testcase name>
         *:<suite name>:*
     """
- 
+
     MAX_LEVEL = 3
     DELIMITER = ':'
     ALL_MATCH = '*'
@@ -282,8 +282,21 @@ class Pattern(Filter):
             get_testsuite_name(suite), self.suite_pattern)
 
     def filter_case(self, case):
-        return fnmatch.fnmatch(
+        name_match = fnmatch.fnmatch(
             case.__name__, self.case_pattern)
+
+        # Check if the testcase is parametrized - if so, we also consider
+        # the filter to match if the parametrization template is matched.
+        parametrization_template = getattr(
+            case, "_parametrization_template", None
+        )
+        if parametrization_template:
+            param_match = fnmatch.fnmatch(
+                parametrization_template, self.case_pattern
+            )
+            return name_match or param_match
+
+        return name_match
 
     @classmethod
     def any(cls, *patterns):

--- a/tests/unit/testplan/testing/test_filtering.py
+++ b/tests/unit/testplan/testing/test_filtering.py
@@ -1,6 +1,7 @@
 import pytest
 
 from testplan.testing.multitest import MultiTest, testsuite, testcase
+from testplan.testing.multitest import parametrization
 
 from testplan.testing import filtering
 
@@ -57,6 +58,14 @@ class Gamma(object):
 
     @testcase(tags={'color': ('blue', 'red')})
     def test_four(self, env, result):
+        pass
+
+
+@testsuite
+class Delta(object):
+
+    @testcase(parameters=[1, 2, 3])
+    def parametrized(self, env, result, val):
         pass
 
 
@@ -252,6 +261,22 @@ class TestPattern(object):
     def test_filter_case(self, pattern, testcase_obj, expected):
         filter_obj = filtering.Pattern(pattern=pattern)
         assert bool(filter_obj.filter_case(testcase_obj)) == expected
+
+    def test_filter_parametrized_cases(self):
+        """
+        Test filtering parametrized testcases.
+
+        Parametrized testcases should match filter patterns for either the
+        base parametrization template or the generated testcase name.
+        """
+        suite = Delta()
+        testcases = suite.get_testcases()
+        assert len(testcases) == 3  # Expect 3 testcases to be generated.
+
+        testcase = testcases[0]
+        for pattern in ['*:Delta:parametrized', '*:Delta:parametrized__val_1']:
+            filter_obj = filtering.Pattern(pattern=pattern)
+            assert filter_obj.filter_case(testcase)
 
     def test_filter_initialization_error(self):
         """


### PR DESCRIPTION
Allows al parametrized testcases to be run in the UI in the same way as
non-parametrized testcases.

Includes small change to filtering logic. For parametrized testcases,
consider the filter a match if either the template name or full
generated testcase name is matched. This is required for the
testcases to run when triggered in the interactive UI, and I think
makes sense for cmdline filtering too.

NOTE: there is still a bug preventing _individual_ parametrized
testcases from being run in the interactive UI, this change only allows
_all_ of the testcases generated from a single parametrized test method
to be triggered to run at the same time.