### PR TITLE
testcase status default to 'passed' if runtime_status is 'finished'

### DIFF
--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -827,6 +827,9 @@ class TestCaseReport(Report):
         self._runtime_status = new_status
         if new_status == RuntimeStatus.RUNNING and self.entries:
             self.entries = []
+            self._status = Status.UNKNOWN
+        if new_status == 'finished':
+            self._status = Status.PASSED
 
     def _assertions_status(self):
         for entry in self:

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -437,7 +437,6 @@ class MultiTest(Test):
             if self._thread_pool_size > 0:
                 self._stop_thread_pool()
 
-        report.runtime_status = RuntimeStatus.FINISHED
         if patch_report is True:
             self.report.merge(report, strict=False)
 
@@ -530,6 +529,7 @@ class MultiTest(Test):
                             post_testcase=post_testcase,
                             testcase_report=testcase_report
                         )
+                        testcase_report.runtime_status = RuntimeStatus.FINISHED
                         if testcase_report.status == Status.ERROR:
                             if self.cfg.stop_on_error:
                                 self._thread_pool_available = False


### PR DESCRIPTION
If a testcase is of 'finished' runtime_status, its default status should be 'passed' instead of 'unknown' in case the testcase doesn't have any assertion entry.