### PR TITLE
Test runnning parametrizations interactively in UT

### DIFF
--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -382,7 +382,11 @@ def generate_interactive_api(ihandler):
                 if should_run(current_testcase.runtime_status):
                     new_testcase.runtime_status = report.RuntimeStatus.RUNNING
                     ihandler.run_parametrized_test_case(
-                        test_uid, suite_uid, param_uid, await_results=False
+                        test_uid,
+                        suite_uid,
+                        testcase_uid,
+                        param_uid,
+                        await_results=False,
                     )
 
                 param_group[param_uid] = new_testcase

--- a/tests/unit/testplan/runnable/interactive/test_api.py
+++ b/tests/unit/testplan/runnable/interactive/test_api.py
@@ -473,7 +473,11 @@ class TestParametrizedTestCase(object):
         compare_json(rsp.get_json(), testcase_json)
 
         ihandler.run_parametrized_test_case.assert_called_once_with(
-            "MTest1", "MT1Suite1", "MT1S1TC2_0", await_results=False
+            "MTest1",
+            "MT1Suite1",
+            "MT1S1TC2",
+            "MT1S1TC2_0",
+            await_results=False,
         )
 
 


### PR DESCRIPTION
Includes a small change to interactive runner class for command-line usability and
testability purposes. Now, all methods to run a testcase or group of
testcases (suite, MultiTest etc.) will return a single report object
instead of a list of many report objects.