### PR TITLE
Replace format_trace with traceback.format_exc()

### DIFF
--- a/testplan/common/exporters/__init__.py
+++ b/testplan/common/exporters/__init__.py
@@ -1,8 +1,7 @@
 """TODO."""
-import inspect
+import traceback
 
 from testplan.common.config import Config, Configurable
-from testplan.common.utils.exceptions import format_trace
 
 
 class ExporterResult(object):
@@ -22,8 +21,8 @@ class ExporterResult(object):
 
         try:
             exporter.export(source)
-        except Exception as exc:
-            result.traceback = format_trace(inspect.trace(), exc)
+        except Exception:
+            result.traceback = traceback.format_exc()
         return result
 
 

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -1,16 +1,14 @@
 import operator
-import inspect
 import decimal
 try:
     from collections.abc import Mapping, Iterable
 except ImportError:
     from collections import Mapping, Iterable
-
+import traceback
 
 import enum
 import six
 
-from .exceptions import format_trace
 from .reporting import Absent, fmt, NATIVE_TYPES, callable_name
 
 
@@ -36,8 +34,8 @@ def basic_compare(first, second, strict=False):
         else:
             result = first == second
         return result, None
-    except Exception as exc:
-        return None, format_trace(inspect.trace(), exc)
+    except Exception:
+        return None, traceback.format_exc()
 
 
 def is_comparator(value):
@@ -314,8 +312,8 @@ MAX_UNORDERED_COMPARE = 16
 def compare_with_callable(callable_obj, value):
     try:
         return bool(callable_obj(value)), None
-    except Exception as exc:
-        return False, format_trace(inspect.trace(), exc)
+    except Exception:
+        return False, traceback.format_exc()
 
 
 class RegexAdapter(object):
@@ -683,7 +681,7 @@ def untyped_fixtag(x, y):
                       for val in (x_, y_))
 
             ret = x_ == y_
-    
+
     return ret
 
 

--- a/testplan/common/utils/exceptions.py
+++ b/testplan/common/utils/exceptions.py
@@ -83,33 +83,3 @@ def _format_args(args):
     else:
         return '({})'.format(', '.join(rargs))
 
-
-def format_trace(trace, exception=None):
-    """
-    Return a string containing a stack trace, including an attempt
-    at displaying argument values, within a certain size.
-
-    Example::
-
-      >>> format_trace(inspect.trace(), exception)
-    """
-    output = ['Traceback (most recent call last):\n']
-    for frame, fpath, line, parent, code, _ in trace:
-        fmtted_args = ''
-        try:
-            args = inspect.getargvalues(frame)
-            args = [args.locals[name] for name in args.args]
-            fmtted_args = _format_args(args)
-        except Exception:
-            pass
-        finally:
-            del frame
-        output.append(
-            '  File "{}", line {}, in {}{}\n'.format(
-                fpath, line, parent, fmtted_args))
-        for line in code or []:
-            output.append('    {}\n'.format(line.strip()))
-    if exception is not None:
-        output.append('{}: {}'.format(
-            getattr(type(exception), '__name__', '<Unknown>'), exception))
-    return ''.join(output)

--- a/testplan/common/utils/timing.py
+++ b/testplan/common/utils/timing.py
@@ -9,9 +9,7 @@ import functools
 import time
 import datetime
 import threading
-import inspect
-
-from .exceptions import format_trace
+import traceback
 
 
 class TimeoutException(Exception):
@@ -97,9 +95,9 @@ def timeout(seconds, err_msg='Timeout after {} seconds.'):
         def _new_func(result, old_func, old_func_args, old_func_kwargs):
             try:
                 result.append(old_func(*old_func_args, **old_func_kwargs))
-            except Exception as exp:
+            except Exception:
                 result[0] = False
-                result.append(format_trace(inspect.trace(), exp))
+                result.append(traceback.format_exc())
 
         def wrapper(*args, **kwargs):
             result = [True]

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -48,9 +48,9 @@ import sys
 import copy
 import getpass
 import platform
-import inspect
 import hashlib
 import itertools
+import traceback
 
 from collections import Counter
 
@@ -59,7 +59,6 @@ from marshmallow import exceptions
 from testplan.common.report import (
     ExceptionLogger as ExceptionLoggerBase, Report, ReportGroup)
 from testplan.common.utils import timing
-from testplan.common.utils.exceptions import format_trace
 from testplan.testing import tagging
 
 
@@ -195,7 +194,7 @@ class ExceptionLogger(ExceptionLoggerBase):
                                                self.exception_classes):
 
             # Custom exception message with extra args
-            exc_msg = format_trace(inspect.trace(), exc_value)
+            exc_msg = traceback.format_tb(tb)
             self.report.logger.error(exc_msg)
 
             if self.fail:

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -194,7 +194,9 @@ class ExceptionLogger(ExceptionLoggerBase):
                                                self.exception_classes):
 
             # Custom exception message with extra args
-            exc_msg = traceback.format_tb(tb)
+            exc_msg = ''.join(
+                traceback.format_exception(exc_type, exc_value, tb)
+            )
             self.report.logger.error(exc_msg)
 
             if self.fail:

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -344,7 +344,11 @@ class _ReportPlugin(object):
         if call.when in ('memocollect', 'collect'):
             # Failed to collect tests: log to console and mark the report as
             # ERROR.
-            self._report.logger.error(traceback.format_tb(call.excinfo.tb))
+            self._report.logger.error(''.join(traceback.format_exception(
+                call.excinfo.type,
+                call.excinfo.value,
+                call.excinfo.tb,
+            )))
             self._report.status_override = Status.ERROR
 
         elif self._current_case_report is not None:
@@ -381,7 +385,11 @@ class _ReportPlugin(object):
             self._report.logger.error(
                 'Exception occured outside of a testcase: during %s',
                 call.when)
-            self._report.logger.error(traceback.format_tb(call.excinfo.tb))
+            self._report.logger.error(''.join(traceback.format_exception(
+                call.excinfo.type,
+                call.excinfo.value,
+                call.excinfo.tb,
+            )))
 
     @pytest.hookimpl(trylast=True)
     def pytest_configure(self, config):

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -3,6 +3,7 @@ import collections
 import inspect
 import os
 import re
+import traceback
 
 import pytest
 import schema
@@ -17,7 +18,6 @@ from testplan.testing.multitest.entries.schemas.base import (
 from testplan.testing.multitest.entries.stdout.base import (
     registry as stdout_registry)
 from testplan.report import TestGroupReport, TestCaseReport, Status
-from testplan.common.utils.exceptions import format_trace
 from testplan.common.utils import validation
 
 
@@ -344,13 +344,12 @@ class _ReportPlugin(object):
         if call.when in ('memocollect', 'collect'):
             # Failed to collect tests: log to console and mark the report as
             # ERROR.
-            self._report.logger.error(format_trace(
-                inspect.getinnerframes(call.excinfo.tb), call.excinfo.value))
+            self._report.logger.error(traceback.format_tb(call.excinfo.tb))
             self._report.status_override = Status.ERROR
 
         elif self._current_case_report is not None:
             # Log assertion errors or exceptions in testcase report
-            traceback = call.excinfo.traceback[-1]
+            trace = call.excinfo.traceback[-1]
             message = getattr(call.excinfo.value, 'message', None) or \
                       getattr(call.excinfo.value, 'msg', None) or \
                      getattr(call.excinfo.value, 'args', None) or ''
@@ -361,11 +360,9 @@ class _ReportPlugin(object):
                 call.excinfo.typename == 'AssertionError' else
                 'Exception raised') if call.when == 'call' else
                     '{} - Fail'.format(call.when))
-            details = 'File: {}{}Line: {}{}{}: {}'.format(
-                traceback.path.strpath,
-                os.linesep,
-                traceback.lineno + 1,
-                os.linesep,
+            details = 'File: {}\nLine: {}\n{}: {}'.format(
+                trace.path.strpath,
+                trace.lineno + 1,
                 call.excinfo.typename,
                 message
             ) if call.excinfo.typename == 'AssertionError' else (
@@ -384,8 +381,7 @@ class _ReportPlugin(object):
             self._report.logger.error(
                 'Exception occured outside of a testcase: during %s',
                 call.when)
-            self._report.logger.error(format_trace(
-                inspect.getinnerframes(call.excinfo.tb), call.excinfo.value))
+            self._report.logger.error(traceback.format_tb(call.excinfo.tb))
 
     @pytest.hookimpl(trylast=True)
     def pytest_configure(self, config):

--- a/tests/unit/testplan/testing/multitest/entries/test_assertions.py
+++ b/tests/unit/testplan/testing/multitest/entries/test_assertions.py
@@ -1,14 +1,13 @@
 import collections
 import decimal
 import fractions
-import inspect
 import os
 import re
+import traceback
 
 import pytest
 import six
 
-from testplan.common.utils.exceptions import format_trace
 from testplan.testing.multitest.entries import assertions
 
 
@@ -1580,8 +1579,8 @@ class TestTableMatch(object):
         def error_func(value):
             try:
                 raise Exception('some message')
-            except Exception as exc:
-                error_ctx['msg'] = format_trace(inspect.trace(), exc)
+            except Exception:
+                error_ctx['msg'] = traceback.format_exc()
                 raise
 
         table = [


### PR DESCRIPTION
We may have a strong tradition of reinventing the wheel, but when there
is a function right there in the standard library that does what we
need, we really need to ask why we would use something else?

See traceback module docs: https://docs.python.org/3.7/library/traceback.html

@raoyitao I'm aware this will clash with your PR, I'm happy for you to merge yours
first and I can update this one.