### PR TITLE
Add a button to reset testcase state in interactive UI

### DIFF
--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
@@ -5,6 +5,14 @@ exports[`InteractiveReport Handles environment being started 1`] = `
   className=""
 >
   <Toolbar
+    extraButtons={
+      Array [
+        <ResetButton
+          resetStateCbk={[Function]}
+          resetting={false}
+        />,
+      ]
+    }
     handleNavFilter={[Function]}
     status="unknown"
     updateEmptyDisplayFunc={[Function]}
@@ -295,6 +303,14 @@ exports[`InteractiveReport Parially refreshes the report on update. 1`] = `
   className=""
 >
   <Toolbar
+    extraButtons={
+      Array [
+        <ResetButton
+          resetStateCbk={[Function]}
+          resetting={false}
+        />,
+      ]
+    }
     handleNavFilter={[Function]}
     status="unknown"
     updateEmptyDisplayFunc={[Function]}
@@ -577,6 +593,14 @@ exports[`InteractiveReport Updates testcase state 1`] = `
   className=""
 >
   <Toolbar
+    extraButtons={
+      Array [
+        <ResetButton
+          resetStateCbk={[Function]}
+          resetting={false}
+        />,
+      ]
+    }
     handleNavFilter={[Function]}
     status="unknown"
     updateEmptyDisplayFunc={[Function]}
@@ -833,6 +857,14 @@ exports[`InteractiveReport handles individual parametrizations being run 1`] = `
   className=""
 >
   <Toolbar
+    extraButtons={
+      Array [
+        <ResetButton
+          resetStateCbk={[Function]}
+          resetting={false}
+        />,
+      ]
+    }
     handleNavFilter={[Function]}
     status="unknown"
     updateEmptyDisplayFunc={[Function]}
@@ -1121,6 +1153,14 @@ exports[`InteractiveReport handles individual test suites being run 1`] = `
   className=""
 >
   <Toolbar
+    extraButtons={
+      Array [
+        <ResetButton
+          resetStateCbk={[Function]}
+          resetting={false}
+        />,
+      ]
+    }
     handleNavFilter={[Function]}
     status="unknown"
     updateEmptyDisplayFunc={[Function]}
@@ -1409,6 +1449,14 @@ exports[`InteractiveReport handles individual testcases being run 1`] = `
   className=""
 >
   <Toolbar
+    extraButtons={
+      Array [
+        <ResetButton
+          resetStateCbk={[Function]}
+          resetting={false}
+        />,
+      ]
+    }
     handleNavFilter={[Function]}
     status="unknown"
     updateEmptyDisplayFunc={[Function]}
@@ -1697,6 +1745,14 @@ exports[`InteractiveReport handles navigation entries being clicked 1`] = `
   className=""
 >
   <Toolbar
+    extraButtons={
+      Array [
+        <ResetButton
+          resetStateCbk={[Function]}
+          resetting={false}
+        />,
+      ]
+    }
     handleNavFilter={[Function]}
     status="unknown"
     updateEmptyDisplayFunc={[Function]}
@@ -2086,6 +2142,14 @@ exports[`InteractiveReport handles tests being run 1`] = `
   className=""
 >
   <Toolbar
+    extraButtons={
+      Array [
+        <ResetButton
+          resetStateCbk={[Function]}
+          resetting={false}
+        />,
+      ]
+    }
     handleNavFilter={[Function]}
     status="unknown"
     updateEmptyDisplayFunc={[Function]}

--- a/testplan/web_ui/testing/src/Toolbar/InteractiveButtons.js
+++ b/testplan/web_ui/testing/src/Toolbar/InteractiveButtons.js
@@ -1,0 +1,50 @@
+/**
+ * Toolbar buttons used for the interactive report.
+ */
+import React from 'react';
+import {NavItem} from 'reactstrap';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faRedo} from '@fortawesome/free-solid-svg-icons';
+import {css} from 'aphrodite';
+
+import styles from './navStyles';
+
+/**
+ * Render a button to trigger the report state to be reset.
+ *
+ * If the reset action is currently in progress, display a spinning icon
+ * instead.
+ */
+const ResetButton = (props) => {
+  if (props.resetting) {
+    return (
+      <NavItem key="reset-button" >
+        <div className={css(styles.buttonsBar)}>
+          <FontAwesomeIcon
+            key='toolbar-reset'
+            className={css(styles.toolbarButton, styles.toolbarInactive)}
+            icon={faRedo}
+            title='Resetting...'
+            spin
+          />
+        </div>
+      </NavItem>
+    );
+  } else {
+    return (
+      <NavItem key="reset-button" >
+        <div className={css(styles.buttonsBar)}>
+          <FontAwesomeIcon
+            key='toolbar-reset'
+            className={css(styles.toolbarButton)}
+            icon={faRedo}
+            title='Reset state'
+            onClick={props.resetStateCbk}
+          />
+        </div>
+      </NavItem>
+    );
+  }
+};
+
+export {ResetButton};

--- a/testplan/web_ui/testing/src/Toolbar/Toolbar.js
+++ b/testplan/web_ui/testing/src/Toolbar/Toolbar.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {StyleSheet, css} from 'aphrodite';
+import {css} from 'aphrodite';
 import {
   Button,
   Collapse,
@@ -21,9 +21,7 @@ import {
 } from 'reactstrap';
 
 import FilterBox from "../Toolbar/FilterBox";
-import {
-  GREEN, RED, ORANGE, BLACK, DARK_GREY, STATUS, STATUS_CATEGORY
-} from "../Common/defaults";
+import {STATUS, STATUS_CATEGORY} from "../Common/defaults";
 
 import {library} from '@fortawesome/fontawesome-svg-core';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
@@ -36,6 +34,8 @@ import {
   faTags,
   faQuestionCircle,
 } from '@fortawesome/free-solid-svg-icons';
+
+import styles from "./navStyles";
 
 
 library.add(
@@ -109,222 +109,308 @@ class Toolbar extends Component {
     }));
   }
 
-  printOnClick() {
-    window.print();
+  /**
+   * Return the info button which toggles the info modal.
+   */
+  infoButton() {
+    return (
+      <NavItem>
+        <div className={css(styles.buttonsBar)}>
+          <FontAwesomeIcon
+            key='toolbar-info'
+            className={css(styles.toolbarButton)}
+            icon='info'
+            title='Info'
+            onClick={this.toggleInfoOnClick}
+          />
+        </div>
+      </NavItem>
+    );
   }
 
-  getInfoTable(report) {
-    if (report && report.information) {
-      const infoList = report.information.map((item, i) => {
-        return (
-          <tr key={i}>
-            <td className={css(styles.infoTableKey)}>{item[0]}</td>
-            <td className={css(styles.infoTableValue)}>{item[1]}</td>
-          </tr>
-        );
-      });
-      if (report.timer && report.timer.run) {
-        if (report.timer.run.start) {
-          infoList.push(
-            <tr key='start'>
-              <td>start</td>
-              <td>{report.timer.run.start}</td>
-            </tr>
-          );
-        }
-        if (report.timer.run.end) {
-          infoList.push(
-            <tr key='end'>
-              <td>end</td>
-              <td>{report.timer.run.end}</td>
-            </tr>
-          );
-        }
-      }
-      return (
-        <Table bordered responsive className={css(styles.infoTable)}>
-          <tbody>
-            {infoList}
-          </tbody>
-        </Table>
-      );
-    } else {
-      return null;
-    }
+  /**
+   * Return the filter button which opens a drop-down menu.
+   */
+  filterButton(toolbarStyle) {
+    return (
+      <UncontrolledDropdown nav inNavbar>
+        <div className={css(styles.buttonsBar)}>
+          <DropdownToggle nav className={toolbarStyle}>
+            <FontAwesomeIcon
+              key='toolbar-filter'
+              icon='filter'
+              title='Choose filter'
+              className={css(styles.toolbarButton)}
+            />
+          </DropdownToggle>
+        </div>
+        <DropdownMenu className={css(styles.filterDropdown)}>
+          <DropdownItem toggle={false}
+            className={css(styles.dropdownItem)}>
+            <Label check className={css(styles.filterLabel)}>
+              <Input type="radio" name="filter" value='all'
+                checked={this.state.filter === 'all'}
+                onChange={this.filterOnClick}/>{' '}
+              All
+            </Label>
+          </DropdownItem>
+          <DropdownItem toggle={false}
+            className={css(styles.dropdownItem)}>
+            <Label check className={css(styles.filterLabel)}>
+              <Input type="radio" name="filter" value='fail'
+                checked={this.state.filter === 'fail'}
+                onChange={this.filterOnClick}/>{' '}
+              Failed only
+            </Label>
+          </DropdownItem>
+          <DropdownItem toggle={false}
+            className={css(styles.dropdownItem)}>
+            <Label check className={css(styles.filterLabel)}>
+              <Input type="radio" name="filter" value='pass'
+                checked={this.state.filter === 'pass'}
+                onChange={this.filterOnClick}/>{' '}
+              Passed only
+            </Label>
+          </DropdownItem>
+          <DropdownItem divider />
+          <DropdownItem toggle={false}
+            className={css(styles.dropdownItem)}>
+            <Label check className={css(styles.filterLabel)}>
+              <Input type="checkbox" name="displayEmptyTest"
+                checked={!this.state.displayEmpty}
+                onChange={this.toggleEmptyDisplay}/>{' '}
+              Hide empty testcase
+            </Label>
+          </DropdownItem>
+        </DropdownMenu>
+      </UncontrolledDropdown>
+    );
   }
 
-  render() {
-    var toolbarStyle;
-    switch (STATUS_CATEGORY[this.props.status]){
-        case 'passed':
-            toolbarStyle = css(styles.toolbar, styles.toolbarPassed);
-            break;
-        case 'failed':
-        case 'error':
-            toolbarStyle = css(styles.toolbar, styles.toolbarFailed);
-            break;
-        case 'unstable':
-            toolbarStyle = css(styles.toolbar, styles.toolbarUnstable);
-            break;
-        default:
-            toolbarStyle = css(styles.toolbar, styles.toolbarUnknown);
-    }
+  /**
+   * Return the button which prints the current testplan.
+   */
+  printButton() {
+    return (
+      <NavItem>
+        <div className={css(styles.buttonsBar)}>
+          <FontAwesomeIcon
+            key='toolbar-print'
+            className={css(styles.toolbarButton)}
+            icon='print'
+            title='Print page'
+            onClick={window.print}
+          />
+        </div>
+      </NavItem>
+    );
+  }
+
+  /**
+   * Return the button which toggles the display of tags.
+   */
+  tagsButton() {
+    return (
+      <NavItem>
+        <div className={css(styles.buttonsBar)}>
+          <FontAwesomeIcon
+            key='toolbar-tags'
+            className={css(styles.toolbarButton)}
+            icon='tags'
+            title='Toggle tags'
+            onClick={this.toggleTagsDisplay}
+          />
+        </div>
+      </NavItem>
+    );
+  }
+
+  /**
+   * Return the button which toggles the help modal.
+   */
+  helpButton() {
+    return (
+      <NavItem>
+        <div className={css(styles.buttonsBar)}>
+          <FontAwesomeIcon
+            key='toolbar-question'
+            className={css(styles.toolbarButton)}
+            icon='question-circle'
+            title='Help'
+            onClick={this.toggleHelpOnClick}
+          />
+        </div>
+      </NavItem>
+    );
+  }
+
+  /**
+   * Return the button which links to the documentation.
+   */
+  documentationButton() {
+    return (
+      <NavItem>
+        <a href='http://testplan.readthedocs.io'
+          rel='noopener noreferrer' target='_blank'
+          className={css(styles.buttonsBar)}>
+          <FontAwesomeIcon
+            key='toolbar-document'
+            className={css(styles.toolbarButton)}
+            icon='book'
+            title='Documentation'
+          />
+        </a>
+      </NavItem>
+    );
+  }
+
+  /**
+   * Return the navbar including all buttons.
+   */
+  navbar() {
+    const toolbarStyle = getToolbarStyle(this.props.status);
 
     return (
+      <Navbar light expand="md" className={css(styles.toolbar)}>
+        <div className={css(styles.filterBox)}>
+          <FilterBox handleNavFilter={this.props.handleNavFilter}/>
+        </div>
+        <Collapse isOpen={this.state.isOpen} navbar className={toolbarStyle}>
+          <Nav navbar className='ml-auto'>
+            {this.props.extraButtons}
+            {this.infoButton()}
+            {this.filterButton(toolbarStyle)}
+            {this.printButton()}
+            {this.tagsButton()}
+            {this.helpButton()}
+            {this.documentationButton()}
+          </Nav>
+        </Collapse>
+      </Navbar>
+    );
+  }
+
+  /**
+   * Return the help modal.
+   */
+  helpModal() {
+    return (
+      <Modal
+        isOpen={this.state.helpModal}
+        toggle={this.toggleHelpOnClick}
+        className='HelpModal'
+      >
+        <ModalHeader toggle={this.toggleHelpOnClick}>Help</ModalHeader>
+        <ModalBody>
+          This is filter box help!
+        </ModalBody>
+        <ModalFooter>
+          <Button color="light" onClick={this.toggleHelpOnClick}>
+            Close
+          </Button>
+        </ModalFooter>
+      </Modal>
+    );
+  }
+
+  /**
+   * Return the information modal.
+   */
+  infoModal() {
+    return (
+      <Modal
+        isOpen={this.state.infoModal}
+        toggle={this.toggleInfoOnClick}
+        size='lg'
+        className='infoModal'
+      >
+        <ModalHeader toggle={this.toggleInfoOnClick}>
+          Information
+        </ModalHeader>
+        <ModalBody>
+          {getInfoTable(this.props.report)}
+        </ModalBody>
+        <ModalFooter>
+          <Button color="light" onClick={this.toggleInfoOnClick}>
+            Close
+          </Button>
+        </ModalFooter>
+      </Modal>
+    );
+  }
+
+  /**
+   * Render the toolbar component.
+   */
+  render() {
+    return (
       <div>
-        <Navbar light expand="md" className={css(styles.toolbar)}>
-          <div className={css(styles.filterBox)}>
-            <FilterBox handleNavFilter={this.props.handleNavFilter}/>
-          </div>
-          <Collapse isOpen={this.state.isOpen} navbar className={toolbarStyle}>
-            <Nav navbar className='ml-auto'>
-              <NavItem>
-                <div className={css(styles.buttonsBar)}>
-                  <FontAwesomeIcon
-                    key='toolbar-info'
-                    className={css(styles.toolbarButton)}
-                    icon='info'
-                    title='Documentation'
-                    onClick={this.toggleInfoOnClick}
-                  />
-                </div>
-              </NavItem>
-              <UncontrolledDropdown nav inNavbar>
-                <div className={css(styles.buttonsBar)}>
-                  <DropdownToggle nav className={toolbarStyle}>
-                    <FontAwesomeIcon
-                      key='toolbar-filter'
-                      icon='filter'
-                      title='Choose filter'
-                      className={css(styles.toolbarButton)}
-                    />
-                  </DropdownToggle>
-                </div>
-                <DropdownMenu className={css(styles.filterDropdown)}>
-                  <DropdownItem toggle={false}
-                    className={css(styles.dropdownItem)}>
-                    <Label check className={css(styles.filterLabel)}>
-                      <Input type="radio" name="filter" value='all'
-                        checked={this.state.filter === 'all'}
-                        onChange={this.filterOnClick}/>{' '}
-                      All
-                    </Label>
-                  </DropdownItem>
-                  <DropdownItem toggle={false}
-                    className={css(styles.dropdownItem)}>
-                    <Label check className={css(styles.filterLabel)}>
-                      <Input type="radio" name="filter" value='fail'
-                        checked={this.state.filter === 'fail'}
-                        onChange={this.filterOnClick}/>{' '}
-                      Failed only
-                    </Label>
-                  </DropdownItem>
-                  <DropdownItem toggle={false}
-                    className={css(styles.dropdownItem)}>
-                    <Label check className={css(styles.filterLabel)}>
-                      <Input type="radio" name="filter" value='pass'
-                        checked={this.state.filter === 'pass'}
-                        onChange={this.filterOnClick}/>{' '}
-                      Passed only
-                    </Label>
-                  </DropdownItem>
-                  <DropdownItem divider />
-                  <DropdownItem toggle={false}
-                    className={css(styles.dropdownItem)}>
-                    <Label check className={css(styles.filterLabel)}>
-                      <Input type="checkbox" name="displayEmptyTest"
-                        checked={!this.state.displayEmpty}
-                        onChange={this.toggleEmptyDisplay}/>{' '}
-                      Hide empty testcase
-                    </Label>
-                  </DropdownItem>
-                </DropdownMenu>
-              </UncontrolledDropdown>
-              <NavItem>
-                <div className={css(styles.buttonsBar)}>
-                  <FontAwesomeIcon
-                    key='toolbar-print'
-                    className={css(styles.toolbarButton)}
-                    icon='print'
-                    title='Print page'
-                    onClick={this.printOnClick}
-                  />
-                </div>
-              </NavItem>
-              <NavItem>
-                <div className={css(styles.buttonsBar)}>
-                  <FontAwesomeIcon
-                    key='toolbar-tags'
-                    className={css(styles.toolbarButton)}
-                    icon='tags'
-                    title='Toggle tags'
-                    onClick={this.toggleTagsDisplay}
-                  />
-                </div>
-              </NavItem>
-              <NavItem>
-                <div className={css(styles.buttonsBar)}>
-                  <FontAwesomeIcon
-                    key='toolbar-question'
-                    className={css(styles.toolbarButton)}
-                    icon='question-circle'
-                    title='Help'
-                    onClick={this.toggleHelpOnClick}
-                  />
-                </div>
-              </NavItem>
-              <NavItem>
-                <a href='http://testplan.readthedocs.io'
-                  rel='noopener noreferrer' target='_blank'
-                  className={css(styles.buttonsBar)}>
-                  <FontAwesomeIcon
-                    key='toolbar-document'
-                    className={css(styles.toolbarButton)}
-                    icon='book'
-                    title='Documentation'
-                  />
-                </a>
-              </NavItem>
-            </Nav>
-          </Collapse>
-        </Navbar>
-        <Modal
-            isOpen={this.state.helpModal}
-            toggle={this.toggleHelpOnClick}
-            className='HelpModal'
-          >
-            <ModalHeader toggle={this.toggleHelpOnClick}>Help</ModalHeader>
-            <ModalBody>
-              This is filter box help!
-            </ModalBody>
-            <ModalFooter>
-              <Button color="light" onClick={this.toggleHelpOnClick}>
-                Close
-              </Button>
-            </ModalFooter>
-          </Modal>
-          <Modal
-            isOpen={this.state.infoModal}
-            toggle={this.toggleInfoOnClick}
-            size='lg'
-            className='infoModal'
-          >
-            <ModalHeader toggle={this.toggleInfoOnClick}>
-              Information
-            </ModalHeader>
-            <ModalBody>
-              {this.getInfoTable(this.props.report)}
-            </ModalBody>
-            <ModalFooter>
-              <Button color="light" onClick={this.toggleInfoOnClick}>
-                Close
-              </Button>
-            </ModalFooter>
-          </Modal>
+        {this.navbar()}
+        {this.helpModal()}
+        {this.infoModal()}
       </div>
     );
   }
 }
+
+/**
+ * Get the current toolbar style based on the testplan status.
+ */
+const getToolbarStyle = (status) => {
+  switch (STATUS_CATEGORY[status]){
+    case 'passed':
+        return css(styles.toolbar, styles.toolbarPassed);
+    case 'failed':
+    case 'error':
+        return css(styles.toolbar, styles.toolbarFailed);
+    case 'unstable':
+        return css(styles.toolbar, styles.toolbarUnstable);
+    default:
+        return css(styles.toolbar, styles.toolbarUnknown);
+  }
+};
+
+/**
+ * Get the metadata from the report and render it as a table.
+ */
+const getInfoTable = (report) => {
+  if (!report || !report.information) {
+    return "No information to display.";
+  }
+  const infoList = report.information.map((item, i) => {
+    return (
+      <tr key={i}>
+        <td className={css(styles.infoTableKey)}>{item[0]}</td>
+        <td className={css(styles.infoTableValue)}>{item[1]}</td>
+      </tr>
+    );
+  });
+  if (report.timer && report.timer.run) {
+    if (report.timer.run.start) {
+      infoList.push(
+        <tr key='start'>
+          <td>start</td>
+          <td>{report.timer.run.start}</td>
+        </tr>
+      );
+    }
+    if (report.timer.run.end) {
+      infoList.push(
+        <tr key='end'>
+          <td>end</td>
+          <td>{report.timer.run.end}</td>
+        </tr>
+      );
+    }
+  }
+  return (
+    <Table bordered responsive className={css(styles.infoTable)}>
+      <tbody>
+        {infoList}
+      </tbody>
+    </Table>
+  );
+};
 
 Toolbar.propTypes = {
   /** Testplan report's status */
@@ -340,78 +426,5 @@ Toolbar.propTypes = {
   /** Function to handle expressions entered into the Filter box */
   handleNavFilter: PropTypes.func,
 };
-
-const styles = StyleSheet.create({
-  toolbar: {
-    padding: '0',
-  },
-
-  filterBox: {
-    float: 'left',
-    height: '100%',
-  },
-  buttonsBar: {
-    float: 'left',
-    height: '100%',
-    color: 'white',
-  },
-  filterLabel: {
-    width: '100%',
-    display: 'inlinde-block',
-    cursor: 'pointer',
-    padding: '0.2em',
-    'margin-left': '2em',
-  },
-  dropdownItem: {
-    padding: '0',
-    ':focus': {
-      outline: '0',
-    },
-  },
-  toolbarButton: {
-    textDecoration: 'none',
-    position: 'relative',
-    display: 'inline-block',
-    height: '2.4em',
-    width: '2.4em',
-    cursor: 'pointer',
-    color: 'white',
-    padding: '0.7em 0em 0.7em 0em',
-    transition: 'all 0.3s ease-out 0s',
-    ':hover': {
-        color: DARK_GREY
-    }
-  },
-  toolbarUnstable: {
-    backgroundColor: ORANGE,
-    color: 'white'
-  },
-  toolbarUnknown: {
-    backgroundColor: BLACK,
-    color: 'white'
-  },
-  toolbarPassed: {
-    backgroundColor: GREEN,
-    color: 'white'
-  },
-  toolbarFailed: {
-    backgroundColor: RED,
-    color: 'white'
-  },
-  filterDropdown: {
-    'margin-top': '-0.3em'
-  },
-  infoTable: {
-    'table-layout': 'fixed',
-    width: '100%'
-  },
-  infoTableKey: {
-    width: '25%',
-  },
-  infoTableValue: {
-    'word-wrap': 'break-word',
-    'overflow-wrap': 'break-word',
-  }
-});
 
 export default Toolbar;

--- a/testplan/web_ui/testing/src/Toolbar/__tests__/InteractiveButtons.test.js
+++ b/testplan/web_ui/testing/src/Toolbar/__tests__/InteractiveButtons.test.js
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for the InteractiveButtons module
+ */
+import React from "react";
+import {shallow} from "enzyme";
+import {StyleSheetTestUtils} from "aphrodite";
+
+import {ResetButton} from "../InteractiveButtons";
+
+describe("ResetButton", () => {
+  beforeEach(() => {
+    // Stop Aphrodite from injecting styles, this crashes the tests.
+    StyleSheetTestUtils.suppressStyleInjection();
+  });
+
+  afterEach(() => {
+    // Resume style injection once test is finished.
+    StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
+  });
+
+  it("Renders a clickable button", () => {
+    const resetCbk = jest.fn();
+    const button = shallow(
+      <ResetButton resetStateCbk={resetCbk} resetting={false} />
+    );
+    expect(button).toMatchSnapshot();
+    button.find({title: "Reset state"}).simulate("click");
+    expect(resetCbk.mock.calls.length).toBe(1);
+  });
+
+  it("Renders a spinning icon when reset is in-progress", () => {
+    const resetCbk = jest.fn();
+    const button = shallow(
+      <ResetButton resetStateCbk={resetCbk} resetting={true} />
+    );
+    expect(button).toMatchSnapshot();
+  });
+
+});

--- a/testplan/web_ui/testing/src/Toolbar/__tests__/Toolbar.test.js
+++ b/testplan/web_ui/testing/src/Toolbar/__tests__/Toolbar.test.js
@@ -7,6 +7,7 @@ import {
   TOOLBAR_BUTTONS_BATCH,
   TOOLBAR_BUTTONS_INTERACTIVE
 } from "../../Common/defaults";
+import {ResetButton} from "../InteractiveButtons";
 
 function defaultProps() {
   return {
@@ -68,6 +69,13 @@ describe('Toolbar', () => {
     const toolbar = renderToolbar();
     const container = toolbar.find('Collapse').get(0);
     expect(container.props.className).toMatch(/toolbar.+toolbarUnknown/);
+  });
+
+  it('inserts extra buttons into the toolbar', () => {
+    const resetCbk = jest.fn()
+    props.extraButtons = [ResetButton(resetCbk, false)];
+    const toolbar = renderToolbar();
+    expect(toolbar).toMatchSnapshot();
   });
 
 });

--- a/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/InteractiveButtons.test.js.snap
+++ b/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/InteractiveButtons.test.js.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResetButton Renders a clickable button 1`] = `
+<NavItem
+  key="reset-button"
+  tag="li"
+>
+  <div
+    className="buttonsBar_13xq1v"
+  >
+    <FontAwesomeIcon
+      border={false}
+      className="toolbarButton_z1gq62"
+      fixedWidth={false}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            512,
+            512,
+            Array [],
+            "f01e",
+            "M500.333 0h-47.411c-6.853 0-12.314 5.729-11.986 12.574l3.966 82.759C399.416 41.899 331.672 8 256.001 8 119.34 8 7.899 119.526 8 256.187 8.101 393.068 119.096 504 256 504c63.926 0 122.202-24.187 166.178-63.908 5.113-4.618 5.354-12.561.482-17.433l-33.971-33.971c-4.466-4.466-11.64-4.717-16.38-.543C341.308 415.448 300.606 432 256 432c-97.267 0-176-78.716-176-176 0-97.267 78.716-176 176-176 60.892 0 114.506 30.858 146.099 77.8l-101.525-4.865c-6.845-.328-12.574 5.133-12.574 11.986v47.411c0 6.627 5.373 12 12 12h200.333c6.627 0 12-5.373 12-12V12c0-6.627-5.373-12-12-12z",
+          ],
+          "iconName": "redo",
+          "prefix": "fas",
+        }
+      }
+      inverse={false}
+      key="toolbar-reset"
+      listItem={false}
+      mask={null}
+      onClick={[MockFunction]}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size={null}
+      spin={false}
+      symbol={false}
+      title="Reset state"
+      transform={null}
+    />
+  </div>
+</NavItem>
+`;
+
+exports[`ResetButton Renders a spinning icon when reset is in-progress 1`] = `
+<NavItem
+  key="reset-button"
+  tag="li"
+>
+  <div
+    className="buttonsBar_13xq1v"
+  >
+    <FontAwesomeIcon
+      border={false}
+      className="toolbarButton_z1gq62-o_O-toolbarInactive_mqm918"
+      fixedWidth={false}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            512,
+            512,
+            Array [],
+            "f01e",
+            "M500.333 0h-47.411c-6.853 0-12.314 5.729-11.986 12.574l3.966 82.759C399.416 41.899 331.672 8 256.001 8 119.34 8 7.899 119.526 8 256.187 8.101 393.068 119.096 504 256 504c63.926 0 122.202-24.187 166.178-63.908 5.113-4.618 5.354-12.561.482-17.433l-33.971-33.971c-4.466-4.466-11.64-4.717-16.38-.543C341.308 415.448 300.606 432 256 432c-97.267 0-176-78.716-176-176 0-97.267 78.716-176 176-176 60.892 0 114.506 30.858 146.099 77.8l-101.525-4.865c-6.845-.328-12.574 5.133-12.574 11.986v47.411c0 6.627 5.373 12 12 12h200.333c6.627 0 12-5.373 12-12V12c0-6.627-5.373-12-12-12z",
+          ],
+          "iconName": "redo",
+          "prefix": "fas",
+        }
+      }
+      inverse={false}
+      key="toolbar-reset"
+      listItem={false}
+      mask={null}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size={null}
+      spin={true}
+      symbol={false}
+      title="Resetting..."
+      transform={null}
+    />
+  </div>
+</NavItem>
+`;

--- a/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/Toolbar.test.js.snap
+++ b/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/Toolbar.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] = `
+exports[`Toolbar inserts extra buttons into the toolbar 1`] = `
 <div>
   <Navbar
     className="toolbar_l6n5rs"
@@ -41,6 +41,46 @@ exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] =
         vertical={false}
       >
         <NavItem
+          key="reset-button"
+          tag="li"
+        >
+          <div
+            className="buttonsBar_13xq1v"
+          >
+            <FontAwesomeIcon
+              border={false}
+              className="toolbarButton_z1gq62"
+              fixedWidth={false}
+              flip={null}
+              icon={
+                Object {
+                  "icon": Array [
+                    512,
+                    512,
+                    Array [],
+                    "f01e",
+                    "M500.333 0h-47.411c-6.853 0-12.314 5.729-11.986 12.574l3.966 82.759C399.416 41.899 331.672 8 256.001 8 119.34 8 7.899 119.526 8 256.187 8.101 393.068 119.096 504 256 504c63.926 0 122.202-24.187 166.178-63.908 5.113-4.618 5.354-12.561.482-17.433l-33.971-33.971c-4.466-4.466-11.64-4.717-16.38-.543C341.308 415.448 300.606 432 256 432c-97.267 0-176-78.716-176-176 0-97.267 78.716-176 176-176 60.892 0 114.506 30.858 146.099 77.8l-101.525-4.865c-6.845-.328-12.574 5.133-12.574 11.986v47.411c0 6.627 5.373 12 12 12h200.333c6.627 0 12-5.373 12-12V12c0-6.627-5.373-12-12-12z",
+                  ],
+                  "iconName": "redo",
+                  "prefix": "fas",
+                }
+              }
+              inverse={false}
+              key="toolbar-reset"
+              listItem={false}
+              mask={null}
+              pull={null}
+              pulse={false}
+              rotation={null}
+              size={null}
+              spin={false}
+              symbol={false}
+              title="Reset state"
+              transform={null}
+            />
+          </div>
+        </NavItem>
+        <NavItem
           tag="li"
         >
           <div
@@ -63,7 +103,7 @@ exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] =
               size={null}
               spin={false}
               symbol={false}
-              title="Documentation"
+              title="Info"
               transform={null}
             />
           </div>
@@ -436,7 +476,463 @@ exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] =
     </ModalHeader>
     <ModalBody
       tag="div"
-    />
+    >
+      No information to display.
+    </ModalBody>
+    <ModalFooter
+      tag="div"
+    >
+      <Button
+        color="light"
+        onClick={[Function]}
+        tag="button"
+      >
+        Close
+      </Button>
+    </ModalFooter>
+  </Modal>
+</div>
+`;
+
+exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] = `
+<div>
+  <Navbar
+    className="toolbar_l6n5rs"
+    expand="md"
+    light={true}
+    tag="nav"
+  >
+    <div
+      className="filterBox_1kzbnzj"
+    >
+      <FilterBox
+        handleNavFilter={[MockFunction]}
+      />
+    </div>
+    <Collapse
+      appear={false}
+      className="toolbar_l6n5rs-o_O-toolbarPassed_1bjpgj2"
+      enter={true}
+      exit={true}
+      in={false}
+      isOpen={false}
+      mountOnEnter={false}
+      navbar={true}
+      onEnter={[Function]}
+      onEntered={[Function]}
+      onEntering={[Function]}
+      onExit={[Function]}
+      onExited={[Function]}
+      onExiting={[Function]}
+      tag="div"
+      timeout={350}
+      unmountOnExit={false}
+    >
+      <Nav
+        className="ml-auto"
+        navbar={true}
+        tag="ul"
+        vertical={false}
+      >
+        <NavItem
+          tag="li"
+        >
+          <div
+            className="buttonsBar_13xq1v"
+          >
+            <FontAwesomeIcon
+              border={false}
+              className="toolbarButton_z1gq62"
+              fixedWidth={false}
+              flip={null}
+              icon="info"
+              inverse={false}
+              key="toolbar-info"
+              listItem={false}
+              mask={null}
+              onClick={[Function]}
+              pull={null}
+              pulse={false}
+              rotation={null}
+              size={null}
+              spin={false}
+              symbol={false}
+              title="Info"
+              transform={null}
+            />
+          </div>
+        </NavItem>
+        <UncontrolledDropdown
+          inNavbar={true}
+          nav={true}
+        >
+          <div
+            className="buttonsBar_13xq1v"
+          >
+            <DropdownToggle
+              aria-haspopup={true}
+              className="toolbar_l6n5rs-o_O-toolbarPassed_1bjpgj2"
+              color="secondary"
+              nav={true}
+            >
+              <FontAwesomeIcon
+                border={false}
+                className="toolbarButton_z1gq62"
+                fixedWidth={false}
+                flip={null}
+                icon="filter"
+                inverse={false}
+                key="toolbar-filter"
+                listItem={false}
+                mask={null}
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size={null}
+                spin={false}
+                symbol={false}
+                title="Choose filter"
+                transform={null}
+              />
+            </DropdownToggle>
+          </div>
+          <DropdownMenu
+            className="filterDropdown_biw13d"
+            flip={true}
+            tag="div"
+          >
+            <DropdownItem
+              className="dropdownItem_1bl0z5g"
+              tag="button"
+              toggle={false}
+            >
+              <Label
+                check={true}
+                className="filterLabel_17zzvy"
+                tag="label"
+                widths={
+                  Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ]
+                }
+              >
+                <Input
+                  checked={true}
+                  name="filter"
+                  onChange={[Function]}
+                  type="radio"
+                  value="all"
+                />
+                 
+                All
+              </Label>
+            </DropdownItem>
+            <DropdownItem
+              className="dropdownItem_1bl0z5g"
+              tag="button"
+              toggle={false}
+            >
+              <Label
+                check={true}
+                className="filterLabel_17zzvy"
+                tag="label"
+                widths={
+                  Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ]
+                }
+              >
+                <Input
+                  checked={false}
+                  name="filter"
+                  onChange={[Function]}
+                  type="radio"
+                  value="fail"
+                />
+                 
+                Failed only
+              </Label>
+            </DropdownItem>
+            <DropdownItem
+              className="dropdownItem_1bl0z5g"
+              tag="button"
+              toggle={false}
+            >
+              <Label
+                check={true}
+                className="filterLabel_17zzvy"
+                tag="label"
+                widths={
+                  Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ]
+                }
+              >
+                <Input
+                  checked={false}
+                  name="filter"
+                  onChange={[Function]}
+                  type="radio"
+                  value="pass"
+                />
+                 
+                Passed only
+              </Label>
+            </DropdownItem>
+            <DropdownItem
+              divider={true}
+              tag="button"
+              toggle={true}
+            />
+            <DropdownItem
+              className="dropdownItem_1bl0z5g"
+              tag="button"
+              toggle={false}
+            >
+              <Label
+                check={true}
+                className="filterLabel_17zzvy"
+                tag="label"
+                widths={
+                  Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ]
+                }
+              >
+                <Input
+                  checked={false}
+                  name="displayEmptyTest"
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                 
+                Hide empty testcase
+              </Label>
+            </DropdownItem>
+          </DropdownMenu>
+        </UncontrolledDropdown>
+        <NavItem
+          tag="li"
+        >
+          <div
+            className="buttonsBar_13xq1v"
+          >
+            <FontAwesomeIcon
+              border={false}
+              className="toolbarButton_z1gq62"
+              fixedWidth={false}
+              flip={null}
+              icon="print"
+              inverse={false}
+              key="toolbar-print"
+              listItem={false}
+              mask={null}
+              onClick={[Function]}
+              pull={null}
+              pulse={false}
+              rotation={null}
+              size={null}
+              spin={false}
+              symbol={false}
+              title="Print page"
+              transform={null}
+            />
+          </div>
+        </NavItem>
+        <NavItem
+          tag="li"
+        >
+          <div
+            className="buttonsBar_13xq1v"
+          >
+            <FontAwesomeIcon
+              border={false}
+              className="toolbarButton_z1gq62"
+              fixedWidth={false}
+              flip={null}
+              icon="tags"
+              inverse={false}
+              key="toolbar-tags"
+              listItem={false}
+              mask={null}
+              onClick={[Function]}
+              pull={null}
+              pulse={false}
+              rotation={null}
+              size={null}
+              spin={false}
+              symbol={false}
+              title="Toggle tags"
+              transform={null}
+            />
+          </div>
+        </NavItem>
+        <NavItem
+          tag="li"
+        >
+          <div
+            className="buttonsBar_13xq1v"
+          >
+            <FontAwesomeIcon
+              border={false}
+              className="toolbarButton_z1gq62"
+              fixedWidth={false}
+              flip={null}
+              icon="question-circle"
+              inverse={false}
+              key="toolbar-question"
+              listItem={false}
+              mask={null}
+              onClick={[Function]}
+              pull={null}
+              pulse={false}
+              rotation={null}
+              size={null}
+              spin={false}
+              symbol={false}
+              title="Help"
+              transform={null}
+            />
+          </div>
+        </NavItem>
+        <NavItem
+          tag="li"
+        >
+          <a
+            className="buttonsBar_13xq1v"
+            href="http://testplan.readthedocs.io"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <FontAwesomeIcon
+              border={false}
+              className="toolbarButton_z1gq62"
+              fixedWidth={false}
+              flip={null}
+              icon="book"
+              inverse={false}
+              key="toolbar-document"
+              listItem={false}
+              mask={null}
+              pull={null}
+              pulse={false}
+              rotation={null}
+              size={null}
+              spin={false}
+              symbol={false}
+              title="Documentation"
+              transform={null}
+            />
+          </a>
+        </NavItem>
+      </Nav>
+    </Collapse>
+  </Navbar>
+  <Modal
+    autoFocus={true}
+    backdrop={true}
+    backdropTransition={
+      Object {
+        "mountOnEnter": true,
+        "timeout": 150,
+      }
+    }
+    centered={false}
+    className="HelpModal"
+    fade={true}
+    isOpen={false}
+    keyboard={true}
+    modalTransition={
+      Object {
+        "timeout": 300,
+      }
+    }
+    onClosed={[Function]}
+    onOpened={[Function]}
+    role="dialog"
+    toggle={[Function]}
+    zIndex={1050}
+  >
+    <ModalHeader
+      closeAriaLabel="Close"
+      tag="h5"
+      toggle={[Function]}
+      wrapTag="div"
+    >
+      Help
+    </ModalHeader>
+    <ModalBody
+      tag="div"
+    >
+      This is filter box help!
+    </ModalBody>
+    <ModalFooter
+      tag="div"
+    >
+      <Button
+        color="light"
+        onClick={[Function]}
+        tag="button"
+      >
+        Close
+      </Button>
+    </ModalFooter>
+  </Modal>
+  <Modal
+    autoFocus={true}
+    backdrop={true}
+    backdropTransition={
+      Object {
+        "mountOnEnter": true,
+        "timeout": 150,
+      }
+    }
+    centered={false}
+    className="infoModal"
+    fade={true}
+    isOpen={false}
+    keyboard={true}
+    modalTransition={
+      Object {
+        "timeout": 300,
+      }
+    }
+    onClosed={[Function]}
+    onOpened={[Function]}
+    role="dialog"
+    size="lg"
+    toggle={[Function]}
+    zIndex={1050}
+  >
+    <ModalHeader
+      closeAriaLabel="Close"
+      tag="h5"
+      toggle={[Function]}
+      wrapTag="div"
+    >
+      Information
+    </ModalHeader>
+    <ModalBody
+      tag="div"
+    >
+      No information to display.
+    </ModalBody>
     <ModalFooter
       tag="div"
     >
@@ -515,7 +1011,7 @@ exports[`Toolbar shallow renders the correct HTML structure for interactive mode
               size={null}
               spin={false}
               symbol={false}
-              title="Documentation"
+              title="Info"
               transform={null}
             />
           </div>
@@ -888,7 +1384,9 @@ exports[`Toolbar shallow renders the correct HTML structure for interactive mode
     </ModalHeader>
     <ModalBody
       tag="div"
-    />
+    >
+      No information to display.
+    </ModalBody>
     <ModalFooter
       tag="div"
     >

--- a/testplan/web_ui/testing/src/Toolbar/navStyles.js
+++ b/testplan/web_ui/testing/src/Toolbar/navStyles.js
@@ -1,0 +1,87 @@
+/**
+ * Styles for the toolbar component.
+ */
+import {StyleSheet} from 'aphrodite';
+
+import {
+  GREEN, RED, ORANGE, BLACK, DARK_GREY,
+} from "../Common/defaults";
+
+
+const styles = StyleSheet.create({
+  toolbar: {
+    padding: '0',
+  },
+
+  filterBox: {
+    float: 'left',
+    height: '100%',
+  },
+  buttonsBar: {
+    float: 'left',
+    height: '100%',
+    color: 'white',
+  },
+  filterLabel: {
+    width: '100%',
+    display: 'inlinde-block',
+    cursor: 'pointer',
+    padding: '0.2em',
+    'margin-left': '2em',
+  },
+  dropdownItem: {
+    padding: '0',
+    ':focus': {
+      outline: '0',
+    },
+  },
+  toolbarButton: {
+    textDecoration: 'none',
+    position: 'relative',
+    display: 'inline-block',
+    height: '2.4em',
+    width: '2.4em',
+    cursor: 'pointer',
+    color: 'white',
+    padding: '0.7em 0em 0.7em 0em',
+    transition: 'all 0.3s ease-out 0s',
+    ':hover': {
+        color: DARK_GREY
+    }
+  },
+  toolbarInactive: {
+    cursor: 'auto',
+  },
+  toolbarUnstable: {
+    backgroundColor: ORANGE,
+    color: 'white'
+  },
+  toolbarUnknown: {
+    backgroundColor: BLACK,
+    color: 'white'
+  },
+  toolbarPassed: {
+    backgroundColor: GREEN,
+    color: 'white'
+  },
+  toolbarFailed: {
+    backgroundColor: RED,
+    color: 'white'
+  },
+  filterDropdown: {
+    'margin-top': '-0.3em'
+  },
+  infoTable: {
+    'table-layout': 'fixed',
+    width: '100%'
+  },
+  infoTableKey: {
+    width: '25%',
+  },
+  infoTableValue: {
+    'word-wrap': 'break-word',
+    'overflow-wrap': 'break-word',
+  }
+});
+
+export default styles;


### PR DESCRIPTION
Adds a new button into the toolbar for interactive mode, which triggers
report state to be reset. Since most of the state of MultiTests and suites
derives from that of testcases, and testcases derive their state from
their entries, it is enough to simply update the testcase entries to
contain no assertion entries.

Includes a refactor of the Toolbar component, to split the massive 150+
line render method into sensible sub-functions, and to add a new prop to
allow new buttons to be injected into the toolbar just for interactive
mode (so that this reset button doesn't appear for batch reports).