### PR TITLE
Redesign how interactive runner runs tests

### DIFF
--- a/testplan/common/entity/__init__.py
+++ b/testplan/common/entity/__init__.py
@@ -13,7 +13,6 @@ from .base import (
     RunnableStatus,
     RunnableConfig,
     RunnableResult,
-    RunnableIRunner,
     FailedAction,
     DEFAULT_RUNNABLE_ABORT_SIGNALS,
 )

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -588,28 +588,6 @@ class RunnableStatus(EntityStatus):
         return transitions
 
 
-class RunnableIRunner(object):
-    EMPTY_DICT = dict()
-    EMPTY_TUPLE = tuple()
-
-    def __init__(self, runnable):
-        self._runnable = runnable
-
-    @staticmethod
-    def set_run_status(func):
-        @functools.wraps(func)
-        def wrapper(self, *args, **kwargs):
-            self._runnable.status.change(Runnable.STATUS.RUNNING)
-            for result in func(self, *args, **kwargs):
-                yield result
-            self._runnable.status.change(Runnable.STATUS.FINISHED)
-
-        return wrapper
-
-    def run(self):
-        yield self._runnable.run, tuple(), dict()
-
-
 class RunnableConfig(EntityConfig):
     """
     Configuration object for
@@ -627,9 +605,6 @@ class RunnableConfig(EntityConfig):
                 "interactive_block",
                 default=hasattr(sys.modules["__main__"], "__file__"),
             ): bool,
-            ConfigOption(
-                "interactive_runner", default=RunnableIRunner
-            ): object,
         }
 
 
@@ -663,9 +638,6 @@ class Runnable(Entity):
     :type interactive: ``bool``
     :param interactive_no_block: Do not block on run() on interactive mode.
     :type interactive_no_block: ``bool``
-    :param interactive_runner: Interactive runner set for the runnable.
-    :type interactive_runner: Subclass of
-        :py:class:`~testplan.common.entity.base.RunnableIRunner`
 
     Also inherits all
     :py:class:`~testplan.common.entity.base.Entity` options.

--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -381,12 +381,8 @@ def generate_interactive_api(ihandler):
 
                 if should_run(current_testcase.runtime_status):
                     new_testcase.runtime_status = report.RuntimeStatus.RUNNING
-                    ihandler.run_parametrized_test_case(
-                        test_uid,
-                        suite_uid,
-                        testcase_uid,
-                        param_uid,
-                        await_results=False,
+                    ihandler.run_test_case(
+                        test_uid, suite_uid, param_uid, await_results=False
                     )
 
                 param_group[param_uid] = new_testcase

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -301,6 +301,29 @@ class Test(Runnable):
         if len(self.report):
             self.report.propagate_tag_indices()
 
+    def run_testcases_iter(self, testsuite_pattern="*", testcase_pattern="*"):
+        """
+        For a Test to be run interactively, it must implement this method.
+
+        It is expected to run tests iteratively and yield a tuple containing
+        a testcase report and the list of parent UIDs required to merge the
+        testcase report into the main report tree.
+
+        If it is not possible or very inefficient to run individual testcases
+        in an iteratie manner, this method may instead run all the testcases
+        in a batch and then return an iterator for the testcase reports and
+        parent UIDs.
+
+        :param testsuite_pattern: Filter pattern for testsuite level.
+        :type testsuite_pattern: ``str``
+        :param testcase_pattern: Filter pattern for testcase level.
+        :type testsuite_pattern: ``str``
+        :yield: generate tuples containing testcase reports and a list of the
+            UIDs required to merge this into the main report tree, starting
+            with the UID of this test.
+        """
+        raise NotImplementedError
+
 
 class ProcessRunnerTestConfig(TestConfig):
     """

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -17,7 +17,6 @@ from testplan.common.entity import (
     Runnable,
     RunnableResult,
     RunnableConfig,
-    RunnableIRunner,
 )
 from testplan.common.utils.process import subprocess_popen
 from testplan.common.utils.timing import parse_duration, format_duration
@@ -37,62 +36,6 @@ TEST_INST_INDENT = 2
 SUITE_INDENT = 4
 TESTCASE_INDENT = 6
 ASSERTION_INDENT = 8
-
-
-class TestIRunner(RunnableIRunner):
-    """
-    Interactive runner for Test case class.
-    """
-
-    @RunnableIRunner.set_run_status
-    def start_resources(self):
-        """
-        Generator to start Test resources.
-        """
-        if self._runnable.cfg.before_start:
-            yield (
-                self._runnable.cfg.before_start,
-                (self._runnable.resources,),
-                dict(),
-            )
-        for resource in self._runnable.resources:
-            yield (resource.start, tuple(), dict())
-            yield (resource._wait_started, tuple(), dict())
-        if self._runnable.cfg.after_start:
-            yield (
-                self._runnable.cfg.after_start,
-                (self._runnable.resources,),
-                dict(),
-            )
-
-    @RunnableIRunner.set_run_status
-    def stop_resources(self):
-        """
-        Generator to stop Test resources.
-        """
-        if self._runnable.cfg.before_stop:
-            yield (
-                self._runnable.cfg.before_stop,
-                (self._runnable.resources,),
-                RunnableIRunner.EMPTY_DICT,
-            )
-        for resource in self._runnable.resources:
-            yield (
-                resource.stop,
-                RunnableIRunner.EMPTY_TUPLE,
-                RunnableIRunner.EMPTY_DICT,
-            )
-            yield (
-                resource._wait_stopped,
-                RunnableIRunner.EMPTY_TUPLE,
-                RunnableIRunner.EMPTY_DICT,
-            )
-        if self._runnable.cfg.after_stop:
-            yield (
-                self._runnable.cfg.after_stop,
-                (self._runnable.resources,),
-                RunnableIRunner.EMPTY_DICT,
-            )
 
 
 class TestConfig(RunnableConfig):

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
@@ -9,7 +9,6 @@ import {
   faToggleOff,
   faToggleOn
 } from '@fortawesome/free-solid-svg-icons';
-import {BarLoader} from 'react-spinners';
 
 import {
   RED,
@@ -33,9 +32,8 @@ import {
  */
 const InteractiveNavEntry = (props) => {
   const badgeStyle = `${STATUS_CATEGORY[props.status]}Badge`;
-
   const statusIcon = getStatusIcon(
-    props.runtime_status, props.handlePlayClick
+    props.runtime_status, props.handlePlayClick, props.suiteRelated,
   );
   const envStatusIcon = getEnvStatusIcon(
     props.envStatus, props.envCtrlCallback
@@ -81,8 +79,16 @@ const InteractiveNavEntry = (props) => {
  *   something is being run.
  *
  * * When the entry has been run, render a replay button.
+ *
+ * * Special suite-related "testcase" entries, such as setup and teardown
+ *   reports, cannot be directly run and are instead run automatically as
+ *   required. So we do not render buttons to control them.
  */
-const getStatusIcon = (entryStatus, handlePlayClick) => {
+const getStatusIcon = (entryStatus, handlePlayClick, suiteRelated) => {
+  if (suiteRelated) {
+    return null;
+  }
+
   switch (entryStatus) {
     case 'ready':
       return (
@@ -96,10 +102,11 @@ const getStatusIcon = (entryStatus, handlePlayClick) => {
 
     case 'running':
       return (
-        <BarLoader
-          color={'#123abc'}
-          loading={true}
-          size={4}
+        <FontAwesomeIcon
+          className={css(styles.entryButton)}
+          icon={faRedo}
+          title='Running...'
+          spin
         />
       );
 

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
@@ -30,6 +30,7 @@ const InteractiveNavList = (props) => {
         envCtrlCallback={
           (e, action) => props.envCtrlCallback(e, entry, action)
         }
+        suiteRelated={entry.suite_related}
       />
     ),
     props.selectedUid,

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
@@ -257,15 +257,35 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
     >
       C
     </Badge>
-    <Loader
-      color="#123abc"
-      css={Object {}}
-      height={4}
-      heightUnit="px"
-      loading={true}
-      size={4}
-      width={100}
-      widthUnit="px"
+    <FontAwesomeIcon
+      border={false}
+      className="entryButton_yr2g96"
+      fixedWidth={false}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            512,
+            512,
+            Array [],
+            "f01e",
+            "M500.333 0h-47.411c-6.853 0-12.314 5.729-11.986 12.574l3.966 82.759C399.416 41.899 331.672 8 256.001 8 119.34 8 7.899 119.526 8 256.187 8.101 393.068 119.096 504 256 504c63.926 0 122.202-24.187 166.178-63.908 5.113-4.618 5.354-12.561.482-17.433l-33.971-33.971c-4.466-4.466-11.64-4.717-16.38-.543C341.308 415.448 300.606 432 256 432c-97.267 0-176-78.716-176-176 0-97.267 78.716-176 176-176 60.892 0 114.506 30.858 146.099 77.8l-101.525-4.865c-6.845-.328-12.574 5.133-12.574 11.986v47.411c0 6.627 5.373 12 12 12h200.333c6.627 0 12-5.373 12-12V12c0-6.627-5.373-12-12-12z",
+          ],
+          "iconName": "redo",
+          "prefix": "fas",
+        }
+      }
+      inverse={false}
+      listItem={false}
+      mask={null}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size={null}
+      spin={true}
+      symbol={false}
+      title="Running..."
+      transform={null}
     />
   </div>
 </div>

--- a/tests/unit/testplan/runnable/interactive/test_api.py
+++ b/tests/unit/testplan/runnable/interactive/test_api.py
@@ -472,12 +472,8 @@ class TestParametrizedTestCase(object):
         assert rsp.status == "200 OK"
         compare_json(rsp.get_json(), testcase_json)
 
-        ihandler.run_parametrized_test_case.assert_called_once_with(
-            "MTest1",
-            "MT1Suite1",
-            "MT1S1TC2",
-            "MT1S1TC2_0",
-            await_results=False,
+        ihandler.run_test_case.assert_called_once_with(
+            "MTest1", "MT1Suite1", "MT1S1TC2_0", await_results=False
         )
 
 

--- a/tests/unit/testplan/runnable/interactive/test_irunner.py
+++ b/tests/unit/testplan/runnable/interactive/test_irunner.py
@@ -90,20 +90,13 @@ def test_run_all_tests(irunner, sync):
 
     ret = irunner.run_all_tests(await_results=sync)
 
-    # If tests were run synchronously, we should have the report object.
-    # Otherwise, we will have async result objects which we can await.
-    if sync:
-        tp_report = ret
-    else:
-        tp_report = ret.result()
-    assert isinstance(tp_report, report.TestReport)
-    assert tp_report.passed
-    assert len(tp_report.entries) == 3
-    for test_report in tp_report:
-        assert test_report.passed
+    # If the tests were run asynchronously, await the results.
+    if not sync:
+        assert ret.result() is None
 
-    # The test report should have been updated as a side effect.
+    # The report tree should have been updated as a side-effect.
     assert irunner.report.passed
+    assert len(irunner.report.entries) == 3
     for test_report in irunner.report:
         assert test_report.passed
 
@@ -113,17 +106,8 @@ def test_run_test(irunner, sync):
     """Test running a single test."""
     ret = irunner.run_test("test_1", await_results=sync)
 
-    # If tests were run synchronously, we should have the report object.
-    # Otherwise, we will have async result objects which we can await.
-    if sync:
-        test_report = ret
-    else:
-        test_report = ret.result()
-
-    assert isinstance(test_report, report.TestGroupReport)
-    assert test_report.passed
-    assert test_report.name == "test_1"
-    assert len(test_report.entries) == 1  # Expect 1 suite.
+    if not sync:
+        assert ret.result() is None
 
     # The test report should have been updated as a side effect.
     assert irunner.report["test_1"].passed
@@ -134,17 +118,8 @@ def test_run_suite(irunner, sync):
     """Test running a single test suite."""
     ret = irunner.run_test_suite("test_1", "Suite", await_results=sync)
 
-    # If tests were run synchronously, we should have the report object.
-    # Otherwise, we will have async result objects which we can await.
-    if sync:
-        suite_report = ret
-    else:
-        suite_report = ret.result()
-
-    assert isinstance(suite_report, report.TestGroupReport)
-    assert suite_report.passed
-    assert suite_report.name == "Suite"
-    assert len(suite_report.entries) == 2  # Two testcases.
+    if not sync:
+        assert ret.result() is None
 
     # The test report should have been updated as a side effect.
     assert irunner.report["test_1"]["Suite"].passed
@@ -155,15 +130,8 @@ def test_run_testcase(irunner, sync):
     """Test running a single testcase."""
     ret = irunner.run_test_case("test_1", "Suite", "case", await_results=sync)
 
-    # If tests were run synchronously, we should have the report object.
-    # Otherwise, we will have async result objects which we can await.
-    if sync:
-        testcase_report = ret
-    else:
-        testcase_report = ret.result()
-
-    assert isinstance(testcase_report, report.TestCaseReport)
-    assert testcase_report.passed
+    if not sync:
+        assert ret.result() is None
 
     # The test report should have been updated as a side effect.
     assert irunner.report["test_1"]["Suite"]["case"].passed
@@ -172,23 +140,12 @@ def test_run_testcase(irunner, sync):
 @pytest.mark.parametrize("sync", [True, False])
 def test_run_parametrization(irunner, sync):
     """Test running a single parametrization of a testcase."""
-    ret = irunner.run_parametrized_test_case(
-        "test_1",
-        "Suite",
-        "parametrized",
-        "parametrized__val_1",
-        await_results=sync,
+    ret = irunner.run_test_case(
+        "test_1", "Suite", "parametrized__val_1", await_results=sync
     )
 
-    # If tests were run synchronously, we should have the report object.
-    # Otherwise, we will have async result objects which we can await.
-    if sync:
-        testcase_report = ret
-    else:
-        testcase_report = ret.result()
-
-    assert isinstance(testcase_report, report.TestCaseReport)
-    assert testcase_report.passed
+    if not sync:
+        assert ret.result() is None
 
     # The test report should have been updated as a side effect.
     assert irunner.report["test_1"]["Suite"]["parametrized"][


### PR DESCRIPTION
Implement new design for the interaction between the interactive runner
and individual MultiTests to run tests:

* Add new method to MultiTest to run testscases iteratively and yield
  individual testcase reports as they are run. The interactive runner
  handles merging testcase reports into its main report tree. This way,
  setup and teardown methods are only run once per suite and return
  appropriate report entries that can be rendered in the UI.
* Remove separate MultiTestIRunner class that is no longer required.
* Remove run buttons from special "suite related" report entries such as
  testsuite setup/teardown. These methods are run automatically by the
  backend as required and it does not really make sense for them to be
  manually run on their own.
* Small aesthetic tweak to UI to use a spinning icon instead of a bar
  loader when running tests.