### PR TITLE
Limit Werkzeug version to <1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ REQUIRED = [
     "validators",
     "ipaddress",
     "futures; python_version <= '2.7'",
+    "Werkzeug<1.0.0",
 ]
 
 setup(


### PR DESCRIPTION
To fix an issue caused by the release of Werkzeug 1.0.0, which Flask and flask-restplus both depend on. Temporary fix is to stick to the older version of Werkzeug, until flask-restplus is updated to work with the newer version: https://github.com/noirbizarre/flask-restplus/issues/777

This issue is blocking all Travis builds and new installs currently so needs merging ASAP.