### PR TITLE
Add `extra_attributes` for test suite report

### DIFF
--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -594,7 +594,7 @@ class TestGroupReport(BaseReportGroup):
         self.part = part  # i.e. (m, n), while 0 <= m < n and n > 1
         self.part_report_lookup = {}
 
-        self.extra_attributes = extra_attributes
+        self.extra_attributes = extra_attributes or {}
 
         self.fix_spec_path = fix_spec_path
 

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -533,6 +533,7 @@ class MultiTest(testing_base.Test):
             category=testplan.report.ReportCategories.TESTSUITE,
             uid=mtest_suite.get_testsuite_name(testsuite),
             tags=testsuite.__tags__,
+            extra_attributes=testsuite.__extra_attributes__,
         )
 
     def _new_testcase_report(self, testcase):


### PR DESCRIPTION
* This member in `TestGroupReport` of suite is removed during code
  change and make a internal test case fail, just add it back.
* This might be changed because there is a new design about adding
  attributes for test suite and testcase.