### PR TITLE
Update black version + store black config in pyproject.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,36 @@ install:
   - python install-testplan-ui --verbose --dev
 
 script:
+  # Travis uses pyenv to manage a virtualenv / venv whose 'bin' dir is placed
+  # at the front of PATH. The version of Python depends on which version in the
+  # 'python' array is currently being tested.
+  #
+  # This command 'pyenv global 3.7' makes Python 3.7 the default Python when
+  # outside of the venv, and its 'bin' dir is placed lower in the PATH
+  # hierarchy.
+  # 
+  # Thus, when we're executing a Python2 build:
+  # `which python`  ==> /home/travis/virtualenv/python2.7.15/bin/python
+  # `which python2` ==> /home/travis/virtualenv/python2.7.15/bin/python2
+  # `which pip`     ==> /home/travis/virtualenv/python2.7.15/bin/pip
+  # `which pip2`    ==> /home/travis/virtualenv/python2.7.15/bin/pip2
+  # `which python3` ==> /opt/pyenv/shims/python3
+  # `which pip3`    ==> /opt/pyenv/shims/pip3
+  #
+  # And when we're in a Python3 build 
+  # `which python`     ==> /home/travis/virtualenv/python3.7.1/bin/python
+  # `which python3`    ==> /home/travis/virtualenv/python3.7.1/bin/python3
+  # `which pip`        ==> /home/travis/virtualenv/python3.7.1/bin/pip
+  # `which pip3`       ==> /home/travis/virtualenv/python3.7.1/bin/pip3
+  # `which -a python3` ==> /home/travis/virtualenv/python3.7.1/bin/python3
+  #                        ...
+  #                        /opt/pyenv/shims/python3
+  # `which -a pip3`    ==> /home/travis/virtualenv/python3.7.1/bin/pip3
+  #                        ...
+  #                        /opt/pyenv/shims/pip3
+  - pyenv global 3.7
   - ./scripts/utils/crlf_check.sh
-  - ./scripts/utils/black_check.py
+  - python3 -m black .  # black configuration lives in pyproject.toml
   - pylint --rcfile pylintrc testplan
   - pytest tests --verbose
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 dist: xenial  # required for Python >= 3.7
 language: python
 
+env:
+  - BLACK_VERSION: "19.10b0"
+
 python:
   - "2.7"
   - "3.7"
@@ -36,7 +39,7 @@ install:
   #                        ...
   #                        /opt/pyenv/shims/pip3
   - pyenv global 3.7
-  - pip3 install --no-use-pep517 .  # pulls requirements from pyproject.toml
+  - pip3 install black==$BLACK_VERSION
 
 script:
   - python3 -m black .  # black configuration lives in pyproject.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   #                        ...
   #                        /opt/pyenv/shims/pip3
   - pyenv global 3.7
-  - pip3 install .  # pulls requirements from pyproject.toml
+  - pip3 install --no-use-pep517 .  # pulls requirements from pyproject.toml
 
 script:
   - python3 -m black .  # black configuration lives in pyproject.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ python:
 install:
   - pip install -r requirements.txt -U
   - python install-testplan-ui --verbose --dev
-
-script:
   # Travis uses pyenv to manage a virtualenv / venv whose 'bin' dir is placed
   # at the front of PATH. The version of Python depends on which version in the
   # 'python' array is currently being tested.
@@ -38,8 +36,11 @@ script:
   #                        ...
   #                        /opt/pyenv/shims/pip3
   - pyenv global 3.7
-  - ./scripts/utils/crlf_check.sh
+  - pip3 install .  # pulls requirements from pyproject.toml
+
+script:
   - python3 -m black .  # black configuration lives in pyproject.toml
+  - ./scripts/utils/crlf_check.sh
   - pylint --rcfile pylintrc testplan
   - pytest tests --verbose
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - pip3 install black==$BLACK_VERSION
 
 script:
-  - python3 -m black .  # black configuration lives in pyproject.toml
+  - python3 -m black --check .  # black configuration lives in pyproject.toml
   - ./scripts/utils/crlf_check.sh
   - pylint --rcfile pylintrc testplan
   - pytest tests --verbose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 79
+exclude = '''(
+    vendor
+    | node_modules
+)'''
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,4 @@
 [tool.black]
 line-length = 79
-exclude = '''(
-  vendor
-  | node_modules
-)'''
+exclude = '''(/(vendor|node_modules)/)'''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,3 @@
-[build-system]
-requires = [
-  "black==19.10b0",
-  # see https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-  "setuptools>=40.8.0",
-  "wheel"
-]
-
 [tool.black]
 line-length = 79
 exclude = '''(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "black==19.10b0; python_version >= '3.0'",
+  "black==19.10b0",
   # see https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
   "setuptools>=40.8.0",
   "wheel"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,12 @@
+[build-system]
+requires = [
+  "black==19.10b0; python_version >= '3.0'"
+]
+
 [tool.black]
 line-length = 79
 exclude = '''(
-    vendor
-    | node_modules
+  vendor
+  | node_modules
 )'''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = [
-  "black==19.10b0; python_version >= '3.0'"
+  "black==19.10b0; python_version >= '3.0'",
+  # see https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
+  "setuptools>=40.8.0",
+  "wheel"
 ]
 
 [tool.black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e .
 pylint
 scikit-learn < 0.21.0
-black==18.9b0; python_version >= '3.0'
+black==19.10b0; python_version >= '3.0'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 -e .
 pylint
 scikit-learn < 0.21.0
-black==19.10b0; python_version >= '3.0'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -e .
 pylint
 scikit-learn < 0.21.0
+black==19.10b0; python_version >= '3.0'
 

--- a/tests/unit/testplan/report/test_testing.py
+++ b/tests/unit/testplan/report/test_testing.py
@@ -385,7 +385,7 @@ def test_report_json_serialization(dummy_test_plan_report):
 
 
 def test_report_json_binary_serialization(
-    dummy_test_plan_report_with_binary_asserts
+    dummy_test_plan_report_with_binary_asserts,
 ):
     """JSON Serialized & deserialized reports should be equal."""
     test_plan_schema = TestReportSchema(strict=True)


### PR DESCRIPTION
So this is one way to accomplish the goals of #366 without a wrapper, with some tradeoffs.

The upshot IMHO of this way is that it uses existing tools and introduces the pyproject.toml file into the project which ought to allow us to setup more sophisticated builds in the future. More info in these easy-to-read PEPs [here](https://www.python.org/dev/peps/pep-0517/) and [here](https://www.python.org/dev/peps/pep-0518/). And with a small amount of additional effort we could move the dependencies from both requirements files into the pyproject.toml.

One thing I'm not in love with here is specifying the version of `black` in both `.travis.yml` and `requirements.txt`. I'm pretty sure both can be consolidated into the pyproject.toml but I didn't know anything about pyproject.toml until a few hours ago so I'm not sure how to do this right now. The inelegant solution right now is what you see before you.