### PR TITLE
Add _debug_logging_enabled to Loggable

### DIFF
--- a/testplan/common/utils/logger.py
+++ b/testplan/common/utils/logger.py
@@ -212,3 +212,13 @@ class Loggable(object):
         self.logger = logging.getLogger(logger_name)
 
         super(Loggable, self).__init__()
+
+    @property
+    def _debug_logging_enabled(self):
+        """
+        :return: True if the logging level is DEBUG (or lower) for the stdout
+            handler. We don't consider the file handler because that always
+            logs at DEBUG level.
+        :rtype: ``bool``
+        """
+        return STDOUT_HANDLER.level <= DEBUG


### PR DESCRIPTION
Check if the stdout handler is set to DEBUG level, which means that the testplan was started with -d / --debug flags or otherwise debug logging was enabled programmatically. Useful for deciding whether to enable debug logs in other applications/libraries that don't automatically inherit our logger object.