### PR TITLE
Remove duplication of docstrings from parametrization

### DIFF
--- a/examples/Multitest/Parametrization/test_plan.py
+++ b/examples/Multitest/Parametrization/test_plan.py
@@ -151,7 +151,7 @@ class ProductTest(object):
 
 # Discard the original docstring, convert kwargs to str
 def kwargs_to_string(docstring, kwargs):
-    return str(kwargs)
+    return "\n".join([docstring, str(kwargs)])
 
 
 # Use the original docstring, formatting

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -523,9 +523,10 @@ class MultiTest(testing_base.Test):
         """
         :return: A new and empty report for a parametrization group.
         """
+        # Don't include the template method's docstring in the report to
+        # avoid duplication with the generated testcases.
         return testplan.report.TestGroupReport(
             name=param_template,
-            description=param_method.__doc__,
             category=testplan.report.ReportCategories.PARAMETRIZATION,
             uid=param_template,
             tags=param_method.__tags__,

--- a/testplan/testing/multitest/parametrization.py
+++ b/testplan/testing/multitest/parametrization.py
@@ -226,9 +226,13 @@ def _generate_func(
     def _generated(self, env, result):
         return function(self, env, result, **kwargs)
 
-    _generated.__doc__ = (
-        docstring_func(function.__doc__, kwargs) if docstring_func else None
-    )
+    # If we were given a docstring function, we use it to generate the
+    # docstring for each testcase. Otherwise we just copy the docstring from
+    # the template method.
+    if docstring_func:
+        _generated.__doc__ = docstring_func(function.__doc__, kwargs)
+    else:
+        _generated.__doc__ = function.__doc__
 
     _generated.__name__ = _name_func_wrapper(
         name_func=name_func, func_name=function.__name__, kwargs=kwargs

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -290,7 +290,7 @@ EXPECTED_INITIAL_GET = [
                     "total": 3,
                     "unknown": 3,
                 },
-                "description": "Parametrized testcase.",
+                "description": None,
                 "entry_uids": [
                     "test_parametrized__val_1",
                     "test_parametrized__val_2",
@@ -344,7 +344,7 @@ EXPECTED_INITIAL_GET = [
         [
             {
                 "category": "testcase",
-                "description": None,
+                "description": "Parametrized testcase.",
                 "entries": [],
                 "logs": [],
                 "name": "test_parametrized__val_1",
@@ -366,7 +366,7 @@ EXPECTED_INITIAL_GET = [
             },
             {
                 "category": "testcase",
-                "description": None,
+                "description": "Parametrized testcase.",
                 "entries": [],
                 "logs": [],
                 "name": "test_parametrized__val_2",
@@ -388,7 +388,7 @@ EXPECTED_INITIAL_GET = [
             },
             {
                 "category": "testcase",
-                "description": None,
+                "description": "Parametrized testcase.",
                 "entries": [],
                 "logs": [],
                 "name": "test_parametrized__val_3",
@@ -415,7 +415,7 @@ EXPECTED_INITIAL_GET = [
         "test_parametrized/parametrizations/test_parametrized__val_1",
         {
             "category": "testcase",
-            "description": None,
+            "description": "Parametrized testcase.",
             "entries": [],
             "logs": [],
             "name": "test_parametrized__val_1",

--- a/tests/functional/testplan/testing/multitest/test_parametrization.py
+++ b/tests/functional/testplan/testing/multitest/test_parametrization.py
@@ -67,23 +67,26 @@ def test_basic_parametrization():
 
     parametrization_group = TestGroupReport(
         name="test_add",
-        description="Simple docstring",
         category=ReportCategories.PARAMETRIZATION,
         entries=[
             TestCaseReport(
                 name="test_add__a_1__b_2__expected_3",
+                description="Simple docstring",
                 entries=[{"type": "Equal", "first": 3, "second": 3}],
             ),
             TestCaseReport(
                 name="test_add__0",
+                description="Simple docstring",
                 entries=[{"type": "Equal", "first": 0, "second": 0}],
             ),
             TestCaseReport(
                 name="test_add__1",
+                description="Simple docstring",
                 entries=[{"type": "Equal", "first": 0, "second": 0}],
             ),
             TestCaseReport(
                 name="test_add__a_3__b_1__expected_4",
+                description="Simple docstring",
                 entries=[{"type": "Equal", "first": 4, "second": 4}],
             ),
         ],
@@ -337,7 +340,9 @@ def test_tag_func(tag_func, expected_tags, expected_tags_index):
 @pytest.mark.parametrize(
     "docstring_func, expected_docstring",
     (
-        (None, None),  # by default generated testcases have no docstring
+        # By default, generated testcases inherit the docstring from the
+        # template method.
+        (None, "Original docstring"),
         (lambda docstring, kwargs: "foo", "foo"),
         (
             lambda docstring, kwargs: "{docstring} "

--- a/tests/unit/testplan/testing/multitest/test_multitest.py
+++ b/tests/unit/testplan/testing/multitest/test_multitest.py
@@ -131,23 +131,25 @@ EXPECTED_REPORT_SKELETON = report.TestGroupReport(
                 ),
                 report.TestGroupReport(
                     name="parametrized",
-                    description="Parametrized testcase.",
                     category=report.ReportCategories.PARAMETRIZATION,
                     uid="parametrized",
                     parent_uids=["MTest", "Suite"],
                     entries=[
                         report.TestCaseReport(
                             name="parametrized__val_1",
+                            description="Parametrized testcase.",
                             uid="parametrized__val_1",
                             parent_uids=["MTest", "Suite", "parametrized"],
                         ),
                         report.TestCaseReport(
                             name="parametrized__val_2",
+                            description="Parametrized testcase.",
                             uid="parametrized__val_2",
                             parent_uids=["MTest", "Suite", "parametrized"],
                         ),
                         report.TestCaseReport(
                             name="parametrized__val_3",
+                            description="Parametrized testcase.",
                             uid="parametrized__val_3",
                             parent_uids=["MTest", "Suite", "parametrized"],
                         ),


### PR DESCRIPTION
Move description out of the parametrization group and into the
individual generated testcases. This ensures no duplication when
docstring generation is used.