### PR TITLE
Disable line-too-long check in pylint

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -153,7 +153,6 @@ enable=syntax-error,
        astroid-error,
        parse-error,
        method-check-failed,
-       line-too-long
 
 
 [REPORTS]


### PR DESCRIPTION
Now we enforce black code-formatting, there is no real need to duplicate
this checking in pylint. black itself is quite lazy about enforcing
line-length and will occasionally produce lines that are >79 chars
anyway, when it makes more sense than truncating the line. Removing this
check from pylint should remove conflicts between black and pylint.