### PR TITLE
WIP: Make the MultiTest before_start and after_start hooks default to…

### DIFF
--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -162,6 +162,12 @@ class MultiTest(testing_base.Test):
         # along with parametrization template methods)
         # update tag indices with native tags of this instance.
 
+        # these methods are by default PASS
+        if callable(before_start):
+            before_start._status = testplan.report.Status.PASSED
+        if callable(after_start):
+            after_start._status = testplan.report.Status.PASSED
+
         if self.cfg.tags:
             for suite in self.suites:
                 mtest_suite.propagate_tag_indices(suite, self.cfg.tags)


### PR DESCRIPTION
… PASSED rather than UNKNOWN