### PR TITLE
Hide horizontal scrollbar for nav breadcrumbs menu

### DIFF
--- a/testplan/web_ui/testing/src/Nav/NavBreadcrumbs.js
+++ b/testplan/web_ui/testing/src/Nav/NavBreadcrumbs.js
@@ -69,7 +69,7 @@ const styles = StyleSheet.create({
     height: '2em',
     width: '100%',
     backgroundColor: LIGHT_GREY,
-    overflowY: "hidden",
+    overflow: "hidden",
   },
   breadcrumbContainer: {
     listStyle: 'none',

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavBreadcrumbs.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavBreadcrumbs.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`NavBreadcrumbs shallow renders the correct HTML structure 1`] = `
 <div
-  className="navBreadcrumbs_1qja1s6"
+  className="navBreadcrumbs_koaten"
 >
   <ul
     className="breadcrumbContainer_1qdzaym"


### PR DESCRIPTION
This fixes the issue where long names are obscured by the horizontal scrollbar. Hide the overflow both vertically and horizontally.