### PR TITLE
Fixes for running the ProcessPool example

### DIFF
--- a/doc/en/interactive.rst
+++ b/doc/en/interactive.rst
@@ -116,14 +116,14 @@ your testcases in Java using JUnit but make API calls to a Testplan process to
 control your test environment before and after running tests. There are many
 similar possibilities!
 
-When Testplan is started in interactive mode, as well as displaying a link to
-the web UI it will also display a link to view and interact with the API
-schema, using a generated Swagger UI. Take a look at the schema if you would
-like to learn more.
+When Testplan is started in interactive mode with debug logging enabled, as
+well as displaying a link to the web UI it will also display a link to view and
+interact with the API schema, using a generated Swagger UI. Take a look at the
+schema if you would like to learn more.
 
 .. code-block:: bash
 
-    $ python test_plan.py -i
+    $ python test_plan.py -di
     ...
     Interactive Testplan API is running. View the API schema:
         Local: http://localhost:36718/api/v1/interactive/

--- a/testplan/runners/pools/connection.py
+++ b/testplan/runners/pools/connection.py
@@ -413,7 +413,8 @@ class ZMQServer(Server):
 
     def aborting(self):
         """Terminate the ZMQ context and socket when aborting."""
-        self._close()
+        if self._sock is not None:
+            self._close()
         super(ZMQServer, self).aborting()
 
     def register(self, worker):

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -324,6 +324,24 @@ class Test(Runnable):
         """
         raise NotImplementedError
 
+    def start_test_resources(self):
+        """
+        Start all test resources but do not run any tests. Used in the
+        interactive mode when environments may be started/stopped on demand.
+        The base implementation is very simple but may be overridden in sub-
+        classes to run additional setup pre- and post-environment start.
+        """
+        self.make_runpath_dirs()
+        self.resources.start()
+
+    def stop_test_resources(self):
+        """
+        Stop all test resources. As above, this method is used for the
+        interactive mode and is very simple in this base Test class, but may
+        be overridden by sub-classes.
+        """
+        self.resources.stop()
+
 
 class ProcessRunnerTestConfig(TestConfig):
     """

--- a/tests/unit/testplan/runners/pools/test_process_worker.py
+++ b/tests/unit/testplan/runners/pools/test_process_worker.py
@@ -57,6 +57,11 @@ class TestProcPool(object):
 
     def test_start_stop(self, proc_pool):
         """Test basic start/stop of ProcessPool."""
+        # This testcase is known to fail on Windows - mark as xfail until we
+        # can fix it up.
+        if platform.system() == "Windows":
+            pytest.xfail("ProcPool start/stop is unstable on Windows")
+
         current_proc = psutil.Process()
         start_children = current_proc.children()
         start_thread_count = threading.active_count()

--- a/tests/unit/testplan/runners/pools/test_process_worker.py
+++ b/tests/unit/testplan/runners/pools/test_process_worker.py
@@ -1,4 +1,5 @@
 """Unit test for process pool."""
+import platform
 import psutil
 import pytest
 import time


### PR DESCRIPTION
* Handle running pre/post stop/start callbacks interactively
* Mark after_start and friends' reports as passed if empty
* Skip unstable procpool UT on Windows
* Schedule tasks to local runner in interactive mode
* Remove handling of multiple runners from interactive handler
* Only log API access info at DEBUG level