### PR TITLE
Interactive example fixes

### DIFF
--- a/examples/Assertions/Graph/test_plan.py
+++ b/examples/Assertions/Graph/test_plan.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 These examples show usage of graphs
 """

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -742,4 +742,9 @@ class TestRunnerIHandler(entity.Entity):
                 for uid in parent_uids:
                     parent_entry = parent_entry[uid]
 
+                for attachment in report.attachments:
+                    self.report.attachments[
+                        attachment.dst_path
+                    ] = attachment.source_path
+
                 parent_entry[report.uid] = report

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -81,6 +81,11 @@ class TestRunnerIHandler(entity.Entity):
         finally:
             self.teardown()
 
+    @property
+    def exit_code(self):
+        """Code to indicate success or failure."""
+        return int(not self.report.passed)
+
     def setup(self):
         """Set up the task pool and HTTP handler."""
         self.logger.test_info(

--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -429,6 +429,34 @@ def generate_interactive_api(ihandler):
                 param_group[param_uid] = new_testcase
                 return param_group[param_uid].serialize()
 
+    @api.route("/attachments")
+    class AllAttachments(flask_restplus.Resource):
+        """
+        Represents all files currently attached to the Testplan interactive
+        report.
+        """
+
+        def get(self):
+            """Return a list of all attachment UIDs."""
+            with ihandler.report_mutex:
+                return list(ihandler.report.attachments.keys())
+
+    @api.route("/attachments/<path:attachment_uid>")
+    class SingleAttachment(flask_restplus.Resource):
+        """
+        Represents a specific file attached to the Testplan interactive report.
+        """
+
+        def get(self, attachment_uid):
+            """Get a file attachment."""
+            with ihandler.report_mutex:
+                try:
+                    filepath = ihandler.report.attachments[attachment_uid]
+                except KeyError:
+                    raise werkzeug.exceptions.NotFound
+
+            return flask.send_file(filepath)
+
     return app, api
 
 

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -316,12 +316,12 @@ class MultiTest(testing_base.Test):
             if not self.active:
                 break
 
-        # In python 3 we would use "yield from" but have to explicitly write
-        # out the loop for python 2 support...
-        for testcase_report, parent_uids in self._run_testsuite_iter(
-            testsuite, testcases
-        ):
-            yield testcase_report, parent_uids
+            # In python 3 we would use "yield from" but have to explicitly write
+            # out the loop for python 2 support...
+            for testcase_report, parent_uids in self._run_testsuite_iter(
+                testsuite, testcases
+            ):
+                yield testcase_report, parent_uids
 
     def append_pre_post_step_report(self):
         """

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/AttachmentAssertions.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/AttachmentAssertions.js
@@ -31,7 +31,12 @@ export const AttachmentAssertion = (props) => {
 const getAttachmentContent = (assertion, reportUid) => {
   const file_type = assertion.orig_filename.split('.').pop();
   const file_path = assertion.dst_path;
-  const get_path = `/api/v1/reports/${reportUid}/attachments/${file_path}`;
+  let get_path;
+  if (reportUid) {
+    get_path = `/api/v1/reports/${reportUid}/attachments/${file_path}`;
+  } else {
+    get_path = `/api/v1/interactive/attachments/${file_path}`;
+  }
 
   switch (file_type) {
     case 'txt':

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/AttachmentAssertions.test.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/AttachmentAssertions.test.js
@@ -81,6 +81,26 @@ describe('AttachmentAssertion', () => {
     );
     expect(shallowComponent).toMatchSnapshot();
   });
+
+  it('renders an attachment using interactive API', () => {
+    const assertionProps = {
+      ...defaultAssertionProps,
+      type: "Attachment",
+      dst_path: 'tmpthpcdtwn-cd4f4c6e94971896a71b4a1d47785a90b19f6565-900.txt',
+      filesize: 900,
+      hash: 'cd4f4c6e94971896a71b4a1d47785a90b19f6565',
+      orig_filename: 'tmpthpcdtwn.txt',
+      source_path: '/tmp/tmpthpcdtwn.txt',
+    }
+    const shallowComponent = shallow(
+      <AttachmentAssertion
+        assertion={assertionProps}
+        reportUid={null}
+      />
+    );
+    expect(shallowComponent).toMatchSnapshot();
+  });
+
 });
 
 describe('MatplotAssertion', () => {

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/AttachmentAssertions.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/AttachmentAssertions.test.js.snap
@@ -77,6 +77,37 @@ exports[`AttachmentAssertion renders an attached text file 1`] = `
 </Fragment>
 `;
 
+exports[`AttachmentAssertion renders an attachment using interactive API 1`] = `
+<Fragment>
+  <Row
+    tag="div"
+  >
+    <Col
+      className="contentSpan_12mhtst"
+      lg="6"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <span>
+        <TextAttachment
+          devMode={false}
+          file_name="tmpthpcdtwn.txt"
+          src="/api/v1/interactive/attachments/tmpthpcdtwn-cd4f4c6e94971896a71b4a1d47785a90b19f6565-900.txt"
+        />
+      </span>
+    </Col>
+  </Row>
+</Fragment>
+`;
+
 exports[`AttachmentAssertion renders an unknown filetype 1`] = `
 <Fragment>
   <Row


### PR DESCRIPTION
* Fix for running multiple testsuites interactively
* Add exit_code property to ihandler to avoid exception on exit
* Retrieve attachments correctly in interactive mode
