### PR TITLE
Fixes for python3.8

### DIFF
--- a/testplan/common/utils/timing.py
+++ b/testplan/common/utils/timing.py
@@ -117,7 +117,7 @@ def timeout(seconds, err_msg="Timeout after {} seconds."):
             thd = KThread(target=_new_func, args=(), kwargs=new_kwargs)
             thd.start()
             thd.join(seconds)
-            if thd.isAlive():
+            if thd.is_alive():
                 thd.kill()
                 thd.join()
                 raise TimeoutException(err_msg.format(seconds))

--- a/testplan/exporters/testing/pdf/renderers/entries/assertions.py
+++ b/testplan/exporters/testing/pdf/renderers/entries/assertions.py
@@ -1,5 +1,12 @@
 import re
-from cgi import escape
+import functools
+
+try:
+    from html import escape as _orig_escape
+
+    escape = functools.partial(_orig_escape, quote=False)
+except ImportError:
+    from cgi import escape
 
 from reportlab.lib import colors
 from reportlab.platypus import Paragraph


### PR DESCRIPTION
- Use thread.is_alive() spelling to avoid deprecation warning
- cgi.escape is removed in Python3.8 so try to use html.escape in preference (introduced in Py3.2). Fall back to cgi.escape if not available (i.e. on Py2)