### PR TITLE
Extendable list of listers that can be accessed from commandline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 Thumbs.db
+
+/doc/en/_build/
+/doc/en/html
+/pip-wheel-metadata

--- a/doc/en/download/Multitest.rst
+++ b/doc/en/download/Multitest.rst
@@ -35,6 +35,18 @@ test_plan.py
 ````````````
 .. literalinclude:: ../../../examples/Multitest/Listing/Custom Listers/test_plan.py
 
+.. _example_multitest_listing_custom_cmd:
+
+Custom with commandline
++++++++++++++++++++++++
+
+Required files:
+  - :download:`test_plan_command_line.py <../../../examples/Multitest/Listing/Custom Listers/test_plan_command_line.py>`
+
+test_plan_commandline.py
+````````````````````````
+.. literalinclude:: ../../../examples/Multitest/Listing/Custom Listers/test_plan_command_line.py
+
 .. _example_multitest_ordering:
 
 Ordering

--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -276,10 +276,9 @@ and overriding ``get_output`` method.
 An example implementation of custom test lister can be seen
 :ref:`here <example_multitest_listing_custom>`.
 
-If the lister provide, name and description it can be used to extend the ``--info`` commandline
-parameter and the lister can be selected from the commandline.
+Listers can be registered to be used with the ``--info`` commandline parameter the same way as the built in listers.
 
-The class should provide:
+The custom lister class should provide:
 
 * it's name either setting the :py:attr:`NAME <testplan.testing.listing.BaseLister.NAME>` or override the
   :py:meth:`name() <testplan.testing.listing.BaseLister.name>` method. This should be an Enum name like ``NAME_FULL``.
@@ -302,7 +301,7 @@ and it need to be registered with :py:data:`testplan.testing.listing.listing_reg
     def get_output(self, instance):
         return "Hello World"
 
-  testing_registry.add_lister(HelloWorldLister())
+  listing_registry.add_lister(HelloWorldLister())
 
   # check --info hello-world
   @test_plan()

--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -305,7 +305,7 @@ and it need to be registered with :py:data:`testplan.testing.listing.listing_reg
   testing_registry.add_lister(HelloWorldLister())
 
   # check --info hello-world
-  @test_plan():
+  @test_plan()
   def main(plan):
     ....
 

--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -276,6 +276,40 @@ and overriding ``get_output`` method.
 An example implementation of custom test lister can be seen
 :ref:`here <example_multitest_listing_custom>`.
 
+If the lister provide, name and description it can be used to extend the ``--info`` commandline
+parameter and the lister can be selected from the commandline.
+
+The class should provide:
+
+* it's name either setting the :py:attr:`NAME <testplan.testing.listing.BaseLister.NAME>` or override the
+  :py:meth:`name() <testplan.testing.listing.BaseLister.name>` method. This should be an Enum name like ``NAME_FULL``.
+  The name will be used to derive the commandline param which is the kebab-case version of the name.
+* and it's description either setting the :py:attr:`DESCRIPTION <testplan.testing.listing.BaseLister.DESCRIPTION>` or
+  override the :py:meth:`description() <testplan.testing.listing.BaseLister.description>` method
+
+and it need to be registered with :py:data:`testplan.testing.listing.listing_registry` as follows
+
+.. code-block:: python
+
+  from testplan.testing.listing import BaseLister, listing_registry
+  from testplan import test_plan
+
+  class HelloWorldLister(BaseLister):
+
+    NAME = "HELLO_WORLD"
+    DESCRIPTION = "This lister print Hello World for each multitest"
+
+    def get_output(self, instance):
+        return "Hello World"
+
+  testing_registry.add_lister(HelloWorldLister())
+
+  # check --info hello-world
+  @test_plan():
+  def main(plan):
+    ....
+
+the full example can be found :ref:`here <example_multitest_listing_custom_cmd>`.
 
 .. warning::
 

--- a/examples/Multitest/Listing/Custom Listers/test_plan_command_line.py
+++ b/examples/Multitest/Listing/Custom Listers/test_plan_command_line.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+"""
+    This example shows how to implement a custom lister for
+    displaying test context of a test plan.
+"""
+import sys
+
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+
+from testplan import test_plan
+from testplan.testing.listing import BaseLister, listing_registry
+
+
+@testsuite
+class Alpha(object):
+    @testcase
+    def test_a(self, env, result):
+        pass
+
+    @testcase(tags="server")
+    def test_b(self, env, result):
+        pass
+
+    @testcase(tags={"color": "blue"})
+    def test_c(self, env, result):
+        pass
+
+
+@testsuite(tags="server")
+class Beta(object):
+    @testcase(tags="client")
+    def test_a(self, env, result):
+        pass
+
+    @testcase(tags={"color": "red"})
+    def test_b(self, env, result):
+        pass
+
+    @testcase(tags={"color": ("blue", "yellow")})
+    def test_c(self, env, result):
+        pass
+
+
+@testsuite(tags="client")
+class Gamma(object):
+    @testcase
+    def test_a(self, env, result):
+        pass
+
+    @testcase(tags={"color": ("yellow", "red")})
+    def test_b(self, env, result):
+        pass
+
+    @testcase(parameters=list(range(100)))
+    def test_c(self, env, result, val):
+        pass
+
+
+# To implement a custom lister, we need to inherit from `listing.BaseLister`
+# override `get_output` method and return a string representation of
+# the current test instance (e.g. multitest) and possibly its test
+#  context, like suites & testcases.
+#
+# To use in the commandline add NAME and DESCRIPTION and register with
+# listing_registry
+
+
+class HelloWorldLister(BaseLister):
+    """
+        Displays 'Hello World" for each MultiTest
+
+        e.g.
+
+            Hello World: Primary
+            Hello World: Secondary
+    """
+
+    NAME = "HELLO_WORLD"
+    DESCRIPTION = "This lister print Hello World for each multitest"
+
+    def get_output(self, instance):
+        return "Hello World: {}".format(instance.name)
+
+
+listing_registry.add_lister(HelloWorldLister())
+
+
+# use --info hello-world to see the action
+#
+# it is also there in the --help text
+#
+#   --info TEST_INFO      (default: None)
+#                         "pattern" - List tests in `--patterns` / `--tags` compatible format.
+#                                 Max 25 testcases per suite will be displayed
+#                         "name" - List tests in readable format.
+#                                 Max 25 testcases per suite will be displayed
+#                         "pattern-full" - List tests in `--patterns` / `--tags` compatible format.
+#                         "name-full" - List tests in readable format.
+#                         "count" - Lists top level instances and total number of suites & testcases per instance.
+#                         "hello-world" - This lister print Hello World for each multitest
+@test_plan(name="Custom test lister example")
+def main(plan):
+    test1 = MultiTest(name="Primary", suites=[Alpha(), Beta()])
+    test2 = MultiTest(name="Secondary", suites=[Gamma()])
+    plan.add(test1)
+    plan.add(test2)
+
+
+if __name__ == "__main__":
+    sys.exit(not main())

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -76,7 +76,7 @@ class TestplanParser(object):
             "--info",
             dest="test_lister",
             metavar="TEST_INFO",
-            **listing.ListingArg.get_parser_context(
+            **listing.listing_registry.to_arg().get_parser_context(
                 default=self._default_options["test_lister"]
             )
         )

--- a/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -42,7 +42,7 @@ class SuiteKillingWorker(object):
     @testcase
     def test_comparison(self, env, result):
         parent = psutil.Process(self._parent_pid)
-        if len(parent.children(recursive=True)) == self._size:
+        if len(parent.children(recursive=False)) == self._size:
             print("Killing worker {}".format(os.getpid()))
             os.kill(os.getpid(), 9)
         result.equal(1, 1, "equality description")

--- a/tests/unit/testplan/common/utils/test_path.py
+++ b/tests/unit/testplan/common/utils/test_path.py
@@ -38,7 +38,7 @@ def test_hashfile(tmpdir):
         sha_output = subprocess.check_output(
             ["sha1sum", tmpfile], universal_newlines=True
         )
-        ref_sha = re.match(r"([0-9a-f]+)\s+.*", sha_output).group(1)
+        ref_sha = re.match(r"\\?([0-9a-f]+)\s+.*", sha_output).group(1)
     except OSError:
         pytest.skip("Cannot call sha1sum to generate reference SHA.")
         return

--- a/tests/unit/testplan/testing/test_listing.py
+++ b/tests/unit/testplan/testing/test_listing.py
@@ -1,0 +1,58 @@
+import os
+import re
+
+import pytest
+
+from testplan.common.utils.parser import ArgMixin
+from testplan.testing.listing import (
+    ListingRegistry,
+    listing_registry,
+    NameLister,
+    CountLister,
+    ExpandedNameLister,
+)
+
+
+def test_defaults():
+    assert len(listing_registry.listers) == 5
+    arg_enum = listing_registry.to_arg()
+    assert issubclass(arg_enum, ArgMixin)
+
+    for enum in ["NAME", "NAME_FULL", "COUNT", "PATTERN", "PATTERN_FULL"]:
+        assert arg_enum[enum]
+
+
+def test_duplicate():
+    registry = ListingRegistry()
+
+    registry.add_lister(NameLister())
+    assert len(registry.listers) == 1
+
+    # let the enum creation handle the duplicate check for free
+    registry.add_lister(NameLister())
+    assert len(registry.listers) == 2
+
+    with pytest.raises(TypeError):
+        registry.to_arg()
+
+
+def test_help_text():
+    registry = ListingRegistry()
+    registry.add_lister(CountLister())
+    registry.add_lister(ExpandedNameLister())
+
+    arg_enum = registry.to_arg()
+
+    help_text = arg_enum.get_help_text(None).split(os.linesep)
+
+    assert len(help_text) == 3  # the default + the two lister
+
+    for help_line in help_text[1:]:
+        match = re.match('"([^"]*)" - (.*)', help_line)
+        assert match
+
+        name, text = match.groups()
+        lister = arg_enum.parse(name)
+        assert lister
+
+        assert lister.description() == text

--- a/tests/unit/testplan/testing/test_listing.py
+++ b/tests/unit/testplan/testing/test_listing.py
@@ -43,7 +43,7 @@ def test_help_text():
 
     arg_enum = registry.to_arg()
 
-    help_text = arg_enum.get_help_text(None).split(os.linesep)
+    help_text = arg_enum.get_help_text(None).split("\n")
 
     assert len(help_text) == 3  # the default + the two lister
 


### PR DESCRIPTION
I have refactored the test listers to be self contained so they provide their name and description, provided a listing_registry so testplan users can add their own listers. The registry can build the required enum, so not much change in the --info parameter parsing, just use the registry created enum.

and an extra: Fix unit tests on windows

- Kill one worker expect that there are 4 worker as child of the master.
  On windows if python running from venv, the interpreter is spawning the
  real interpreter as it's child, so the process tree is one layer deeper
  than expected so the recursive children count is double as expected

- sha1sum which bundled with git is printing a leading \ before the hash on windows, so prepare the regexp for that

> sha1sum C:\Users\..\AppData\Local\Temp\pytest-of-kn\pytest-1\test_hashfile0\hash_me.txt
\4a22175c7be0588626bcd19694f6572c9808597d *C:\\Users\\..\\AppData\\Local\\Temp\\pytest-of-..\\pytest-1\\test_hashfile0\\hash_me.txt