### PR TITLE
Display execution time for each entry in navigator

### DIFF
--- a/testplan/web_ui/testing/src/Common/defaults.js
+++ b/testplan/web_ui/testing/src/Common/defaults.js
@@ -15,6 +15,7 @@ const INTERACTIVE_COL_WIDTH = 28;  // wider to fit interactive buttons
 const INDENT_MULTIPLIER = 1.5;
 
 const TOOLBAR_BUTTONS_BATCH = [
+  {name: 'cl', type: 'clock'},
   {name: 'pr', type: 'print'},
   {name: 'if', type: 'info-circle'},
   {name: 'qu', type: 'question-circle'},

--- a/testplan/web_ui/testing/src/Nav/InteractiveNav.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNav.js
@@ -39,6 +39,7 @@ const InteractiveNav = (props) => {
         filter={null}
         displayEmpty={true}
         displayTags={false}
+        displayTime={false}
         selectedUid={GetSelectedUid(props.selected)}
         handlePlayClick={props.handlePlayClick}
         envCtrlCallback={props.envCtrlCallback}

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
@@ -59,10 +59,12 @@ InteractiveNavList.propTypes = {
   autoSelect: PropTypes.func,
   /** Entity filter */
   filter: PropTypes.string,
-  /** Flag to display tags on navbar */
-  displayEmpty: PropTypes.bool,
   /** Flag to display empty testcase on navbar */
+  displayEmpty: PropTypes.bool,
+  /** Flag to display tags on navbar */
   displayTags: PropTypes.bool,
+  /** Flag to display execution time on navbar */
+  displayTime: PropTypes.bool,
 };
 
 export default InteractiveNavList;

--- a/testplan/web_ui/testing/src/Nav/Nav.js
+++ b/testplan/web_ui/testing/src/Nav/Nav.js
@@ -29,6 +29,7 @@ const Nav = (props) => {
         filter={props.filter}
         displayEmpty={props.displayEmpty}
         displayTags={props.displayTags}
+        displayTime={props.displayTime}
         selectedUid={GetSelectedUid(props.selected)}
       />
     </>
@@ -46,6 +47,8 @@ Nav.propTypes = {
   filter: PropTypes.string,
   /** Flag to display tags on navbar */
   displayTags: PropTypes.bool,
+  /** Flag to display execution time on navbar */
+  displayTime: PropTypes.bool,
   /** Flag to display empty testcase on navbar */
   displayEmpty: PropTypes.bool,
   /** Callback when a navigation entry is clicked. */

--- a/testplan/web_ui/testing/src/Nav/NavBreadcrumbs.js
+++ b/testplan/web_ui/testing/src/Nav/NavBreadcrumbs.js
@@ -37,7 +37,10 @@ return (
         status={entry.status}
         type={entry.category}
         caseCountPassed={entry.counter.passed}
-        caseCountFailed={entry.counter.failed} />
+        caseCountFailed={entry.counter.failed}
+        executionTime={null}
+        displayTime={false}
+      />
     </div>
   </li>
 );});

--- a/testplan/web_ui/testing/src/Nav/NavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/NavEntry.js
@@ -22,6 +22,15 @@ import {
  */
 const NavEntry = (props) => {
   const badgeStyle = `${STATUS_CATEGORY[props.status]}Badge`;
+  const executionTime = (
+    props.displayTime && props.executionTime ? (
+      <i className={css(styles.entryIcon)} title='Execution time'>
+        <span className={css(styles[STATUS_CATEGORY[props.status]])}>
+          {props.executionTime}s
+        </span>
+      </i>
+    ) : null
+  );
   return (
     <div
       className='d-flex justify-content-between align-items-center'
@@ -34,6 +43,7 @@ const NavEntry = (props) => {
         {props.name}
       </div>
       <div className={css(styles.entryIcons)}>
+        {executionTime}
         <i className={css(styles.entryIcon)} title='passed/failed testcases'>
           <span className={css(styles.passed)}>{props.caseCountPassed}</span>
           /
@@ -61,6 +71,10 @@ NavEntry.propTypes = {
   caseCountPassed: PropTypes.number,
   /** Number of failing testcases entry has */
   caseCountFailed: PropTypes.number,
+  /** Execution time measured in seconds */
+  executionTime: PropTypes.number,
+  /** If to display execution time */
+  displayTime: PropTypes.bool,
 };
 
 const styles = StyleSheet.create({

--- a/testplan/web_ui/testing/src/Nav/NavList.js
+++ b/testplan/web_ui/testing/src/Nav/NavList.js
@@ -11,15 +11,23 @@ import {STATUS, COLUMN_WIDTH} from "../Common/defaults";
 const NavList = (props) => {
   const navButtons = CreateNavButtons(
     props,
-    (entry) => (
-      <NavEntry
-        name={entry.name}
-        status={entry.status}
-        type={entry.category}
-        caseCountPassed={entry.counter.passed}
-        caseCountFailed={entry.counter.failed}
-      />
-    ),
+    (entry) => {
+      const executionTime = (entry.timer && entry.timer.run) ? (
+        (new Date(entry.timer.run.end)).getTime() -
+        (new Date(entry.timer.run.start)).getTime()) / 1000 : null;
+
+      return (
+        <NavEntry
+          name={entry.name}
+          status={entry.status}
+          type={entry.category}
+          caseCountPassed={entry.counter.passed}
+          caseCountFailed={entry.counter.failed}
+          executionTime={executionTime}
+          displayTime={props.displayTime}
+        />
+      );
+    },
     props.selectedUid
   );
 
@@ -43,10 +51,12 @@ NavList.propTypes = {
   handleNavClick: PropTypes.func,
   /** Entity filter */
   filter: PropTypes.string,
-  /** Flag to display tags on navbar */
-  displayEmpty: PropTypes.bool,
   /** Flag to display empty testcase on navbar */
+  displayEmpty: PropTypes.bool,
+  /** Flag to display tags on navbar */
   displayTags: PropTypes.bool,
+  /** Flag to display execution time on navbar */
+  displayTime: PropTypes.bool,
   /** Entry uid to be focused */
   selectedUid: PropTypes.string,
 };

--- a/testplan/web_ui/testing/src/Nav/__tests__/InteractiveNav.test.js
+++ b/testplan/web_ui/testing/src/Nav/__tests__/InteractiveNav.test.js
@@ -25,6 +25,7 @@ describe('InteractiveNav', () => {
         filter={null}
         displayEmpty={true}
         displayTags={false}
+        displayTime={false}
         handleNavClick={jest.fn()}
         handlePlayClick={jest.fn()}
         envCtrlCallback={jest.fn()}

--- a/testplan/web_ui/testing/src/Nav/__tests__/InteractiveNavList.test.js
+++ b/testplan/web_ui/testing/src/Nav/__tests__/InteractiveNavList.test.js
@@ -27,6 +27,7 @@ describe('InteractiveNavList', () => {
         filter={null}
         displayEmpty={true}
         displayTags={false}
+        displayTime={false}
         handlePlayClick={(e) => undefined}
         envCtrlCallback={(e, action) => undefined}
       />

--- a/testplan/web_ui/testing/src/Nav/__tests__/NavList.test.js
+++ b/testplan/web_ui/testing/src/Nav/__tests__/NavList.test.js
@@ -23,6 +23,7 @@ function defaultProps() {
     filter: 'all',
     displayEmpty: true,
     displayTags: true,
+    displayTime: false,
     handleNavClick: jest.fn(),
   };
 }

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNav.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNav.test.js.snap
@@ -95,6 +95,7 @@ exports[`InteractiveNav shallow renders and matches snapshot 1`] = `
     breadcrumbLength={1}
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     entries={
       Array [
         Object {

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavBreadcrumbs.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavBreadcrumbs.test.js.snap
@@ -17,6 +17,8 @@ exports[`NavBreadcrumbs shallow renders the correct HTML structure 1`] = `
         <NavEntry
           caseCountFailed={0}
           caseCountPassed={0}
+          displayTime={false}
+          executionTime={null}
           name="test"
           status="passed"
           type="testplan"

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavList.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavList.test.js.snap
@@ -18,6 +18,8 @@ exports[`NavList shallow renders and matches snapshot 1`] = `
       <NavEntry
         caseCountFailed={0}
         caseCountPassed={1}
+        displayTime={false}
+        executionTime={null}
         name="test"
         status="passed"
       />

--- a/testplan/web_ui/testing/src/Nav/__tests__/navUtils.test.js
+++ b/testplan/web_ui/testing/src/Nav/__tests__/navUtils.test.js
@@ -22,6 +22,7 @@ describe('navUtils', () => {
       const props = {
         breadcrumbLength: 1,
         displayTags: false,
+        displayTime: false,
         displayEmpty: true,
         handleNavClick: jest.fn(),
         entries: TESTPLAN_REPORT.entries,

--- a/testplan/web_ui/testing/src/Report/BatchReport.js
+++ b/testplan/web_ui/testing/src/Report/BatchReport.js
@@ -3,6 +3,7 @@ import {StyleSheet, css} from 'aphrodite';
 import axios from 'axios';
 
 import Toolbar from '../Toolbar/Toolbar';
+import { TimeButton } from '../Toolbar/Buttons';
 import Nav from '../Nav/Nav';
 import {
   PropagateIndices,
@@ -26,6 +27,7 @@ class BatchReport extends React.Component {
     this.handleNavFilter = this.handleNavFilter.bind(this);
     this.updateFilter = this.updateFilter.bind(this);
     this.updateTagsDisplay = this.updateTagsDisplay.bind(this);
+    this.toggleTimeDisplay = this.toggleTimeDisplay.bind(this);
     this.updateDisplayEmpty = this.updateDisplayEmpty.bind(this);
     this.handleNavClick = this.handleNavClick.bind(this);
 
@@ -37,6 +39,7 @@ class BatchReport extends React.Component {
       error: null,
       filter: null,
       displayTags: false,
+      displayTime: false,
       displayEmpty: true,
       selectedUIDs: [],
     };
@@ -134,6 +137,12 @@ class BatchReport extends React.Component {
     this.setState({displayEmpty: displayEmpty});
   }
 
+  toggleTimeDisplay() {
+    this.setState(prevState => ({
+      displayTime: !prevState.displayTime
+    }));
+  }
+
   /**
    * Handle a navigation entry being clicked.
    */
@@ -169,6 +178,10 @@ class BatchReport extends React.Component {
           updateFilterFunc={this.updateFilter}
           updateEmptyDisplayFunc={this.updateDisplayEmpty}
           updateTagsDisplayFunc={this.updateTagsDisplay}
+          extraButtons={[<TimeButton
+            key="time-button"
+            toggleTimeDisplayCbk={this.toggleTimeDisplay}
+          />]}
         />
         <Nav
           report={this.state.report}
@@ -176,6 +189,7 @@ class BatchReport extends React.Component {
           filter={this.state.filter}
           displayEmpty={this.state.displayEmpty}
           displayTags={this.state.displayTags}
+          displayTime={this.state.displayTime}
           handleNavClick={this.handleNavClick}
         />
         {centerPane}

--- a/testplan/web_ui/testing/src/Report/EmptyReport.js
+++ b/testplan/web_ui/testing/src/Report/EmptyReport.js
@@ -7,6 +7,7 @@ import {StyleSheet, css} from 'aphrodite';
 
 import Message from '../Common/Message';
 import Toolbar from '../Toolbar/Toolbar';
+import { TimeButton } from '../Toolbar/Buttons';
 import Nav from '../Nav/Nav';
 import {COLUMN_WIDTH} from "../Common/defaults";
 
@@ -35,6 +36,10 @@ const EmptyReport = (props) => {
         updateFilterFunc={noop}
         updateEmptyDisplayFunc={noop}
         updateTagsDisplayFunc={noop}
+        extraButtons={[<TimeButton
+            key="time-button"
+            toggleTimeDisplayCbk={noop}
+          />]}
       />
       <Nav
         report={null}
@@ -42,6 +47,7 @@ const EmptyReport = (props) => {
         filter={undefined}
         displayEmpty={true}
         displayTags={false}
+        displayTime={false}
       />
       {centerPane}
     </div>

--- a/testplan/web_ui/testing/src/Report/InteractiveReport.js
+++ b/testplan/web_ui/testing/src/Report/InteractiveReport.js
@@ -499,7 +499,7 @@ class InteractiveReport extends React.Component {
           updateTagsDisplayFunc={noop}
           extraButtons={[<ResetButton
             resetStateCbk={this.resetReport}
-            resetting={this.state.resetting}
+            resetting={false}
           />]}
         />
         <InteractiveNav
@@ -508,6 +508,7 @@ class InteractiveReport extends React.Component {
           filter={null}
           displayEmpty={true}
           displayTags={false}
+          displayTime={false}
           handleNavClick={this.handleNavClick}
           handlePlayClick={this.handlePlayClick}
           envCtrlCallback={this.envCtrlCallback}

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
@@ -5,6 +5,13 @@ exports[`BatchReport loads a more complex report and autoselects entries 1`] = `
   className="batchReport_3hmsj"
 >
   <Toolbar
+    extraButtons={
+      Array [
+        <TimeButton
+          toggleTimeDisplayCbk={[Function]}
+        />,
+      ]
+    }
     handleNavFilter={[Function]}
     report={
       Object {
@@ -405,6 +412,7 @@ exports[`BatchReport loads a more complex report and autoselects entries 1`] = `
   <Nav
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     filter={null}
     handleNavClick={[Function]}
     report={
@@ -1204,6 +1212,13 @@ exports[`BatchReport loads a simple report and autoselects entries 1`] = `
   className="batchReport_3hmsj"
 >
   <Toolbar
+    extraButtons={
+      Array [
+        <TimeButton
+          toggleTimeDisplayCbk={[Function]}
+        />,
+      ]
+    }
     handleNavFilter={[Function]}
     report={
       Object {
@@ -1372,6 +1387,7 @@ exports[`BatchReport loads a simple report and autoselects entries 1`] = `
   <Nav
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     filter={null}
     handleNavClick={[Function]}
     report={
@@ -1924,6 +1940,13 @@ exports[`BatchReport shallow renders the correct HTML structure when report load
   className="batchReport_3hmsj"
 >
   <Toolbar
+    extraButtons={
+      Array [
+        <TimeButton
+          toggleTimeDisplayCbk={[Function]}
+        />,
+      ]
+    }
     handleNavFilter={[Function]}
     report={
       Object {
@@ -2191,6 +2214,7 @@ exports[`BatchReport shallow renders the correct HTML structure when report load
   <Nav
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     filter={null}
     handleNavClick={[Function]}
     report={

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/EmptyReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/EmptyReport.test.js.snap
@@ -5,6 +5,13 @@ exports[`EmptyReport renders a custom error message 1`] = `
   className="emptyReport_3hmsj"
 >
   <Toolbar
+    extraButtons={
+      Array [
+        <TimeButton
+          toggleTimeDisplayCbk={[Function]}
+        />,
+      ]
+    }
     handleNavFilter={[Function]}
     updateEmptyDisplayFunc={[Function]}
     updateFilterFunc={[Function]}
@@ -13,6 +20,7 @@ exports[`EmptyReport renders a custom error message 1`] = `
   <Nav
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     report={null}
     saveAssertions={[Function]}
   />
@@ -28,6 +36,13 @@ exports[`EmptyReport shallow renders and matches snapshot 1`] = `
   className="emptyReport_3hmsj"
 >
   <Toolbar
+    extraButtons={
+      Array [
+        <TimeButton
+          toggleTimeDisplayCbk={[Function]}
+        />,
+      ]
+    }
     handleNavFilter={[Function]}
     updateEmptyDisplayFunc={[Function]}
     updateFilterFunc={[Function]}
@@ -36,6 +51,7 @@ exports[`EmptyReport shallow renders and matches snapshot 1`] = `
   <Nav
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     report={null}
     saveAssertions={[Function]}
   />

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
@@ -22,6 +22,7 @@ exports[`InteractiveReport Handles environment being started 1`] = `
   <InteractiveNav
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     envCtrlCallback={[Function]}
     filter={null}
     handleNavClick={[Function]}
@@ -320,6 +321,7 @@ exports[`InteractiveReport Parially refreshes the report on update. 1`] = `
   <InteractiveNav
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     envCtrlCallback={[Function]}
     filter={null}
     handleNavClick={[Function]}
@@ -610,6 +612,7 @@ exports[`InteractiveReport Updates testcase state 1`] = `
   <InteractiveNav
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     envCtrlCallback={[Function]}
     filter={null}
     handleNavClick={[Function]}
@@ -874,6 +877,7 @@ exports[`InteractiveReport handles individual parametrizations being run 1`] = `
   <InteractiveNav
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     envCtrlCallback={[Function]}
     filter={null}
     handleNavClick={[Function]}
@@ -1170,6 +1174,7 @@ exports[`InteractiveReport handles individual test suites being run 1`] = `
   <InteractiveNav
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     envCtrlCallback={[Function]}
     filter={null}
     handleNavClick={[Function]}
@@ -1466,6 +1471,7 @@ exports[`InteractiveReport handles individual testcases being run 1`] = `
   <InteractiveNav
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     envCtrlCallback={[Function]}
     filter={null}
     handleNavClick={[Function]}
@@ -1762,6 +1768,7 @@ exports[`InteractiveReport handles navigation entries being clicked 1`] = `
   <InteractiveNav
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     envCtrlCallback={[Function]}
     filter={null}
     handleNavClick={[Function]}
@@ -2159,6 +2166,7 @@ exports[`InteractiveReport handles tests being run 1`] = `
   <InteractiveNav
     displayEmpty={true}
     displayTags={false}
+    displayTime={false}
     envCtrlCallback={[Function]}
     filter={null}
     handleNavClick={[Function]}

--- a/testplan/web_ui/testing/src/Toolbar/Buttons.js
+++ b/testplan/web_ui/testing/src/Toolbar/Buttons.js
@@ -1,0 +1,37 @@
+/**
+ * Toolbar buttons used for the common report.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import {NavItem} from 'reactstrap';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faClock} from '@fortawesome/free-solid-svg-icons';
+import {css} from 'aphrodite';
+
+import styles from './navStyles';
+
+/**
+ * Render a button to toggle the display of execution time on nav entries.
+ */
+const TimeButton = (props) => {
+  return (
+    <NavItem>
+      <div className={css(styles.buttonsBar)}>
+        <FontAwesomeIcon
+          key='toolbar-time'
+          className={css(styles.toolbarButton)}
+          icon={faClock}
+          title='Toggle execution time'
+          onClick={props.toggleTimeDisplayCbk}
+        />
+      </div>
+    </NavItem>
+  );
+};
+
+TimeButton.propTypes = {
+  /** Function to handle toggle of displaying execution time in the navbar */
+  toggleTimeDisplayCbk: PropTypes.func,
+};
+
+export {TimeButton};

--- a/testplan/web_ui/testing/src/Toolbar/InteractiveButtons.js
+++ b/testplan/web_ui/testing/src/Toolbar/InteractiveButtons.js
@@ -18,7 +18,7 @@ import styles from './navStyles';
 const ResetButton = (props) => {
   if (props.resetting) {
     return (
-      <NavItem key="reset-button" >
+      <NavItem key="reset-button">
         <div className={css(styles.buttonsBar)}>
           <FontAwesomeIcon
             key='toolbar-reset'
@@ -31,7 +31,7 @@ const ResetButton = (props) => {
     );
   } else {
     return (
-      <NavItem key="reset-button" >
+      <NavItem key="reset-button">
         <div className={css(styles.buttonsBar)}>
           <FontAwesomeIcon
             key='toolbar-reset'

--- a/testplan/web_ui/testing/src/Toolbar/Toolbar.js
+++ b/testplan/web_ui/testing/src/Toolbar/Toolbar.js
@@ -417,6 +417,8 @@ Toolbar.propTypes = {
   status: PropTypes.oneOf(STATUS),
   /** Report object to display information */
   report: PropTypes.object,
+  /** Additional buttons added to toolbar */
+  extraButtons: PropTypes.array,
   /** Function to handle filter changing in the Filter box */
   updateFilterFunc: PropTypes.func,
   /** Function to handle toggle of displaying empty entries in the navbar */

--- a/testplan/web_ui/testing/src/Toolbar/__tests__/Buttons.test.js
+++ b/testplan/web_ui/testing/src/Toolbar/__tests__/Buttons.test.js
@@ -1,0 +1,30 @@
+/**
+ * Unit tests for the Buttons module
+ */
+import React from "react";
+import {shallow} from "enzyme";
+import {StyleSheetTestUtils} from "aphrodite";
+
+import {TimeButton} from "../Buttons";
+
+describe("TimeButton", () => {
+  beforeEach(() => {
+    // Stop Aphrodite from injecting styles, this crashes the tests.
+    StyleSheetTestUtils.suppressStyleInjection();
+  });
+
+  afterEach(() => {
+    // Resume style injection once test is finished.
+    StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
+  });
+
+  it("Renders a clickable button", () => {
+    const toggleTimeDisplayCbk = jest.fn();
+    const button = shallow(
+      <TimeButton toggleTimeDisplayCbk={toggleTimeDisplayCbk} />
+    );
+    expect(button).toMatchSnapshot();
+    button.find({title: "Toggle execution time"}).simulate("click");
+    expect(toggleTimeDisplayCbk.mock.calls.length).toBe(1);
+  });
+});

--- a/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/Buttons.test.js.snap
+++ b/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/Buttons.test.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TimeButton Renders a clickable button 1`] = `
+<NavItem
+  tag="li"
+>
+  <div
+    className="buttonsBar_13xq1v"
+  >
+    <FontAwesomeIcon
+      border={false}
+      className="toolbarButton_z1gq62"
+      fixedWidth={false}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            512,
+            512,
+            Array [],
+            "f017",
+            "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm57.1 350.1L224.9 294c-3.1-2.3-4.9-5.9-4.9-9.7V116c0-6.6 5.4-12 12-12h48c6.6 0 12 5.4 12 12v137.7l63.5 46.2c5.4 3.9 6.5 11.4 2.6 16.8l-28.2 38.8c-3.9 5.3-11.4 6.5-16.8 2.6z",
+          ],
+          "iconName": "clock",
+          "prefix": "fas",
+        }
+      }
+      inverse={false}
+      key="toolbar-time"
+      listItem={false}
+      mask={null}
+      onClick={[MockFunction]}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size={null}
+      spin={false}
+      symbol={false}
+      title="Toggle execution time"
+      transform={null}
+    />
+  </div>
+</NavItem>
+`;


### PR DESCRIPTION
* On web UI the left pane is used for navigating among multitests,
  suites and testcases. Adding an option to display the execution
  time of each entry.