### PR TITLE
Use untyped_fixtag instead of stringify for fix tag comparison

### DIFF
--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -1253,7 +1253,7 @@ class FixMatch(DictMatch):
         if typed_value and typed_expected:
             value_cmp_func = comparison.COMPARE_FUNCTIONS["check_types"]
         else:
-            value_cmp_func = comparison.COMPARE_FUNCTIONS["stringify"]
+            value_cmp_func = comparison.COMPARE_FUNCTIONS["untyped_fixtag"]
 
         super(FixMatch, self).__init__(
             value=value,


### PR DESCRIPTION
One minor leftover change for pyom python3 migration.