### PR TITLE
Change denormalization log to DEBUG level

### DIFF
--- a/testplan/common/config/base.py
+++ b/testplan/common/config/base.py
@@ -147,8 +147,8 @@ class Config(object):
             value = getattr(self, key)
             if inspect.isclass(value) or inspect.isroutine(value):
                 # Skipping non-serializable classes and routines.
-                logger.TESTPLAN_LOGGER.warning(
-                    "Skip denormalizing option: {}".format(key)
+                logger.TESTPLAN_LOGGER.debug(
+                    "Skip denormalizing option: %s", key
                 )
                 continue
             try:


### PR DESCRIPTION
Log is expected and benign, so reduce to DEBUG level to avoid spam.