### PR TITLE
Testcase logger

### DIFF
--- a/doc/en/api/testplan.testing.multitest.rst
+++ b/doc/en/api/testplan.testing.multitest.rst
@@ -23,6 +23,16 @@ testplan.testing.multitest.base module
     :inherited-members:
 
 
+testplan.testing.multitest.logging module
++++++++++++++++++++++++++++++++++++++++++
+
+.. automodule:: testplan.testing.multitest.logging
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :inherited-members:
+
+
 testplan.testing.multitest.parametrization module
 +++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/doc/en/download/Multitest.rst
+++ b/doc/en/download/Multitest.rst
@@ -201,3 +201,17 @@ resource_manager.py
 ```````````````````
 .. literalinclude:: ../../../examples/Multitest/Parallel/resource_manager.py
 
+
+Logging
+-------
+
+.. _example_multitest_logging:
+
+Basic
++++++
+
+test_plan_logging.py
+````````````````````
+
+.. literalinclude:: ../../../examples/Multitest/Logging/test_plan_logging.py
+

--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -1331,7 +1331,7 @@ Python standard logging infrastructure can be used for logging, however testplan
 
 See also the :ref:`a downloadable example <example_multitest_logging>`.
 
-:py:class:`LogCaptureMixin <testplan.testing.multitest.logging.LogCaptureMixin>` when inherited provide a ``self.logger`` which will log to the normal testplan log. Furthermore the mixin provide a context manager :py:meth:`capture_log(result) <testplan.testing.multitest.logging.LogCaptureMixin.capture_log>` which can be used to automatically capture logs happening in teh context and attaching it to the result.
+:py:class:`LogCaptureMixin <testplan.testing.multitest.logging.LogCaptureMixin>` when inherited provide a ``self.logger`` which will log to the normal testplan log. Furthermore the mixin provide a context manager :py:meth:`capture_log(result) <testplan.testing.multitest.logging.LogCaptureMixin.capture_log>` which can be used to automatically capture logs happening in the context and attaching it to the result.
 
 .. code-block:: python
 

--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -1323,3 +1323,54 @@ If a test is expect to fail all the time, you can also use the `strict=True` the
     @xfail(reason='api changes', strict=True)
     def fail_testcase(self, env, result):
         ...
+
+Logging
+-------
+
+Python standard logging infrastructure can be used for logging, however testplan provide mixins to use a conveniently configured logger from testcases.
+
+See also the :ref:`a downloadable example <example_multitest_logging>`.
+
+:py:class:`LogCaptureMixin <testplan.testing.multitest.logging.LogCaptureMixin>` when inherited provide a ``self.logger`` which will log to the normal testplan log. Furthermore the mixin provide a context manager :py:meth:`capture_log(result) <testplan.testing.multitest.logging.LogCaptureMixin.capture_log>` which can be used to automatically capture logs happening in teh context and attaching it to the result.
+
+.. code-block:: python
+
+    @testsuite
+    class LoggingSuite(LogCaptureMixin):
+
+        @testcase
+        def testsuite_level(self, env, result):
+            with self.capture_log(
+                result
+            ) as logger:  # as convenience the logger is returned but is is really the same as self.logger
+                logger.info("Hello")
+                self.logger.info("Logged as well")
+
+The code above will capture the two log line and inject it into the result. The capture can be configured to capture log to a file and attach to the result. It also possible to capture the base testplan logger, or even the root logger during the execution of the context. If the default formatting is not good enough it can be changed for the report. For all these options see :py:meth:`LogCaptureMixin.capture_log <testplan.testing.multitest.logging.LogCaptureMixin.capture_log>`
+
+:py:class:`AutoLogCaptureMixin <testplan.testing.multitest.logging.AutoLogCaptureMixin>` when inherited it automatically capture and insert logs to the result for every testcase.
+
+.. code-block:: python
+
+    @testsuite
+    class AutoLoggingSuite(AutoLogCaptureMixin):
+        """
+        AutoLogCaptureMixin will automatically add captured log at the end of all testcase
+        """
+
+        @testcase
+        def case(self, env, result):
+            self.logger.info("Hello")
+
+        @testcase
+        def case2(self, env, result):
+            self.logger.info("Do it for all the testcases")
+
+The capture can be tweaked to set up ``self.log_capture_config`` during construction time, very similar to the :py:meth:`LogCaptureMixin.capture_log <testplan.testing.multitest.logging.LogCaptureMixin.capture_log>`
+
+.. code-block:: python
+
+    def __init__(self):
+        super(AutoLoggingSuiteThatAttach, self).__init__()
+        self.log_capture_config.attach_log = True
+

--- a/examples/Multitest/Logging/test_plan_logging.py
+++ b/examples/Multitest/Logging/test_plan_logging.py
@@ -1,0 +1,158 @@
+import logging
+
+from testplan import test_plan
+from testplan.report import Status
+from testplan.report.testing.styles import Style, StyleEnum
+from testplan.testing.base import ASSERTION_INDENT
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+from testplan.testing.multitest.logging import (
+    CaptureLevel,
+    LogCaptureMixin,
+    AutoLogCaptureMixin,
+)
+
+
+@testsuite
+class LoggingSuite(LogCaptureMixin):
+    """
+    Demonstrate how logging can added to testcase and possibly captured in the result from test suite.
+    Add LogCaptureMixin and self.logger will be available for logging. self.capture_log(result) can be
+    used as a context manager to capture log in the result. It is possible to format the log as needed,
+    and also to attach the captured log as a file.
+
+    The log can be captured at 3 leveles, -TESTSUITE: only the logs logged through self.logger will be captured,
+    -TESTPLAN: all testplan related loggs captured (so drivers logs will be included as well), -ROOT: all logs
+    will be captured at the level the root logger is set normally WARNING
+    """
+
+    @testcase
+    def testsuite_level(self, env, result):
+        with self.capture_log(
+            result
+        ) as logger:  # as convenience the logger is returned but is is really the same as
+            logger.info("Hello")
+            self.logger.info("Logged as well")
+            self.logger.parent.info("Not captured")
+            logging.getLogger().warning("Not captured either")
+
+    @testcase
+    def testplan_level(self, env, result):
+        with self.capture_log(
+            result, capture_level=CaptureLevel.TESTPLAN
+        ) as logger:
+            logger.info("Hello")
+            self.logger.info("Logged as well")
+            self.logger.parent.info("Now captured")
+            logging.getLogger().warning("Not captured either")
+
+    @testcase
+    def root_level(self, env, result):
+        with self.capture_log(
+            result, capture_level=CaptureLevel.ROOT
+        ) as logger:
+            logger.info("Hello")
+            self.logger.info("Logged as well")
+            self.logger.parent.info("Now captured")
+            logging.getLogger().warning("This captured too")
+
+    @testcase
+    def attach(self, env, result):
+        with self.capture_log(result, attach_log=True) as logger:
+            logger.info("Attached Log")
+
+    @testcase
+    def format(self, env, result):
+        with self.capture_log(
+            result,
+            format="%(asctime)-24s %(name)-50s %(levelname)-15s %(message)s",
+        ) as logger:
+            logger.info("Formatted")
+
+    @testcase
+    def multiple(self, env, result):
+        with self.capture_log(result):
+            self.logger.info("CaptureGroup 1")
+            self.logger.error(
+                "To have some color"
+            )  # This level goes to stdout too
+
+        # do an assertion to separate the blocks
+        result.true(True, "This is so true")
+
+        with self.capture_log(result):
+            self.logger.info("CaptureGroup 2")
+            self.logger.warning(
+                "To have some color"
+            )  # This level goes to stdout too
+
+    @testcase
+    def specials(self, env, result):
+        with self.capture_log(result):
+            self.logger.test_info("Test info log: goes to the consol as well")
+            self.logger.log_test_status(
+                "A mandatory check", Status.PASSED, indent=ASSERTION_INDENT
+            )
+
+
+@testsuite
+class AutoLoggingSuite(AutoLogCaptureMixin):
+    """
+    AutoLogCaptureMixin will automatically add captured log at the end of all testcase
+    """
+
+    @testcase
+    def case(self, env, result):
+        self.logger.info("Hello")
+
+    @testcase
+    def case2(self, env, result):
+        self.logger.info("Do it for all the testcases")
+
+
+@testsuite
+class AutoLoggingSuiteThatAttach(AutoLogCaptureMixin):
+    def __init__(self):
+        super(AutoLoggingSuiteThatAttach, self).__init__()
+        self.log_capture_config.attach_log = True
+
+    @testcase
+    def case(self, env, result):
+        self.logger.info("Hello Attached")
+
+
+@testsuite
+class AutoLoggingSuiteThatFormat(AutoLogCaptureMixin):
+    def __init__(self):
+        super(AutoLoggingSuiteThatFormat, self).__init__()
+        self.log_capture_config.format = (
+            "%(asctime)-24s %(name)-50s %(levelname)-15s %(message)s"
+        )
+
+    @testcase
+    def case(self, env, result):
+        self.logger.info("Hello Formatted")
+
+
+@test_plan(
+    name="Logging",
+    pdf_path="report.pdf",
+    pdf_style=Style(
+        passing=StyleEnum.ASSERTION_DETAIL, failing=StyleEnum.ASSERTION_DETAIL
+    ),
+)
+def main(plan):
+    plan.add(
+        MultiTest(
+            name="Logging",
+            suites=[
+                LoggingSuite(),
+                AutoLoggingSuite(),
+                AutoLoggingSuiteThatAttach(),
+                AutoLoggingSuiteThatFormat(),
+            ],
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ REQUIRED = [
     "python-dateutil",
     "reportlab",
     "marshmallow==3.0.0b2",
-    "mock",
     "termcolor",
     "colorama",
     "enum34",
@@ -43,6 +42,7 @@ REQUIRED = [
     "ipaddress",
     "futures; python_version <= '2.7'",
     "Werkzeug<1.0.0",
+    "mock; python_version <= '2.7'",
 ]
 
 setup(

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -804,7 +804,7 @@ class MultiTest(testing_base.Test):
         return method_report
 
     def _run_case_related(self, method, testcase, case_result):
-        interface.check_signature(method, ["name", "self", "env", "result"])
+        interface.check_signature(method, ["self", "name", "env", "result"])
         method(testcase.__name__, self.resources, case_result)
 
     def _run_testcase(self, testcase, pre_testcase, post_testcase):

--- a/testplan/testing/multitest/logging.py
+++ b/testplan/testing/multitest/logging.py
@@ -51,9 +51,7 @@ class LogCaptureConfig(object):
 
 
 class LogCaptureMixin(Loggable):
-    """ Mixin to add easy logging support to any @multitest.testsuite
-
-    """
+    """ Mixin to add easy logging support to any @multitest.testsuite"""
 
     _LogCaptureInfo = namedtuple(
         "LogCaptureInfo", ["result", "handler", "attach_file", "capture_level"]

--- a/testplan/testing/multitest/logging.py
+++ b/testplan/testing/multitest/logging.py
@@ -1,0 +1,166 @@
+from __future__ import absolute_import
+
+import logging
+from collections import namedtuple
+from contextlib import contextmanager
+from six import StringIO
+from logging import StreamHandler
+from tempfile import NamedTemporaryFile
+
+from testplan.common.utils.logger import _LOGFILE_FORMAT, Loggable
+
+CAPTURED_LOG_DESCRIPTION = "Auto Captured Log"
+
+
+class CaptureLevel(object):
+    """Capture level Enum like object
+
+    ROOT:
+        Capture all logs reaching the root logger, it contains all testplan logs plus other lib logs
+    TESTPLAN:
+        Capture all testplan logs, eg driver logs
+    TESTSUITE:
+        Whatever is logged from the testcases
+    """
+
+    ROOT = staticmethod(lambda suite: logging.getLogger())
+    TESTPLAN = staticmethod(lambda suite: suite.logger.parent)
+    TESTSUITE = staticmethod(lambda suite: suite.logger)
+
+
+class LogCaptureConfig(object):
+    """
+    Configuration for log capture
+
+    Attributes
+    ----------
+    capture_level CaptureLevel:
+        initial value: CaptureLevel.TESTSUITE The level the log are captured, TESTSUITE (default), TESTPLAN or ROOT
+    attach_log bool:
+        If True the logs captured to file and then attached to the result
+    format str:
+        A format string can be passed to the loghandler
+
+
+    """
+
+    def __init__(self):
+        self.capture_level = CaptureLevel.TESTSUITE
+        self.attach_log = False
+        self.format = _LOGFILE_FORMAT
+
+
+class LogCaptureMixin(Loggable):
+    """ Mixin to add easy logging support to any @multitest.testsuite
+
+    """
+
+    _LogCaptureInfo = namedtuple(
+        "LogCaptureInfo", ["result", "handler", "attach_file", "capture_level"]
+    )
+
+    def __init__(self):
+        super(LogCaptureMixin, self).__init__()
+        self.__log_capture_config = LogCaptureConfig()
+
+    @property
+    def log_capture_config(self):
+        return self.__log_capture_config
+
+    @log_capture_config.setter
+    def log_capture_config(self, value):
+        return self.__log_capture_config == value
+
+    def _attach_handler(
+        self,
+        result,
+        capture_level_override=None,
+        attach_log_override=None,
+        format_override=None,
+    ):
+        def override(value, _with):
+            return value if _with is None else _with
+
+        capture_level = override(
+            self.log_capture_config.capture_level, capture_level_override
+        )
+        save_to_file = override(
+            self.log_capture_config.attach_log, attach_log_override
+        )
+        format_string = override(
+            self.log_capture_config.format, format_override
+        )
+
+        if save_to_file:
+            stream = NamedTemporaryFile(
+                "w+t", dir=result._scratch, suffix=".log", delete=False
+            )
+        else:
+            stream = StringIO()
+
+        handler = StreamHandler(stream)
+        handler.setFormatter(logging.Formatter(format_string))
+
+        logger = self.select_logger(capture_level)
+
+        logger.addHandler(handler)
+
+        return self._LogCaptureInfo(
+            result, handler, save_to_file, capture_level
+        )
+
+    def _detach_handler(self, log_capture_info):
+        self.select_logger(log_capture_info.capture_level).removeHandler(
+            log_capture_info.handler
+        )
+        log_capture_info.handler.flush()
+        log_capture_info.handler.close()
+        if log_capture_info.attach_file:
+            log_capture_info.result.attach(
+                log_capture_info.handler.stream.name, CAPTURED_LOG_DESCRIPTION
+            )
+        else:
+            log_capture_info.result.log(
+                log_capture_info.handler.stream.getvalue(),
+                CAPTURED_LOG_DESCRIPTION,
+            )
+
+    @contextmanager
+    def capture_log(
+        self, result, capture_level=None, attach_log=None, format=None
+    ):
+        """Context manager to capture logs, capture the log in the provided result.
+
+        :param result: The result where to inject the log
+        :param CaptureLevel capture_level:  The level the log are captured, TESTSUITE (default), TESTPLAN or ROOT
+        :param bool attach_log: If True the logs captured to file and then attached to the result
+        :param str format: A format string can be passed to the loghandler
+        :return: returns the suite level logger
+        :rtype: logging.Logger
+        """
+        try:
+            info = self._attach_handler(
+                result,
+                capture_level_override=capture_level,
+                attach_log_override=attach_log,
+                format_override=format,
+            )
+
+            yield self.logger
+        finally:
+            self._detach_handler(info)
+
+    def select_logger(self, capture_level):
+        return capture_level(self)
+
+
+class AutoLogCaptureMixin(LogCaptureMixin):
+    def __init__(self):
+        super(AutoLogCaptureMixin, self).__init__()
+        self._state = None
+
+    def pre_testcase(self, name, env, result):
+        self._state = self._attach_handler(result)
+
+    def post_testcase(self, name, env, result):
+        self._detach_handler(self._state)

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -274,6 +274,7 @@ def _testsuite(klass):
         if not (
             attrib.startswith("__")
             or callable(getattr(klass, attrib))
+            or isinstance(getattr(klass, attrib), property)
             or attrib in klass.__testcases__
             or getattr(
                 getattr(klass, attrib), "__parametrization_template__", False

--- a/tests/functional/testplan/testing/multitest/test_logging.py
+++ b/tests/functional/testplan/testing/multitest/test_logging.py
@@ -1,0 +1,296 @@
+import re
+import six
+import logging
+import pytest
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
+
+import testplan
+from testplan.testing import multitest
+from testplan.testing.filtering import Pattern, Filter
+from testplan.testing.multitest.logging import (
+    LogCaptureMixin,
+    CaptureLevel,
+    AutoLogCaptureMixin,
+)
+
+SIMPLE_LOG = "Simple log"
+LOGGER_LEVEL_PATTERN = r"([^ ]*) *([^ ]*) *{}$".format(SIMPLE_LOG)
+
+
+@multitest.testsuite
+class LoggingSuite(LogCaptureMixin):
+    @multitest.testcase
+    def just_log(self, env, result):
+        self.logger.info(SIMPLE_LOG)
+
+    @multitest.testcase
+    def capture_log_single_scope(self, env, result):
+        with self.capture_log(result):
+            self.logger.info(SIMPLE_LOG)
+
+    @multitest.testcase
+    def capture_log_multiple_scope(self, env, result):
+        with self.capture_log(result):
+            self.logger.info(SIMPLE_LOG + "1")
+        result.true(True)
+        with self.capture_log(result):
+            self.logger.info(SIMPLE_LOG + "2")
+
+    @multitest.testcase
+    def testsuite_level(self, env, result):
+        with self.capture_log(result, capture_level=CaptureLevel.TESTSUITE):
+            self.logger.info(SIMPLE_LOG)
+            self.logger.parent.debug(SIMPLE_LOG)
+            logging.getLogger().warning(SIMPLE_LOG)
+
+    @multitest.testcase
+    def testplan_level(self, env, result):
+        with self.capture_log(result, capture_level=CaptureLevel.TESTPLAN):
+            self.logger.info(SIMPLE_LOG)
+            self.logger.parent.debug(SIMPLE_LOG)
+            logging.getLogger().warning(SIMPLE_LOG)
+
+    @multitest.testcase
+    def root_level(self, env, result):
+        with self.capture_log(result, capture_level=CaptureLevel.ROOT):
+            self.logger.info(SIMPLE_LOG)
+            self.logger.parent.debug(SIMPLE_LOG)
+            logging.getLogger().warning(SIMPLE_LOG)
+
+    @multitest.testcase
+    def attach_log(self, env, result):
+        with self.capture_log(result, attach_log=True):
+            self.logger.info(SIMPLE_LOG)
+
+
+@multitest.testsuite
+class AutoLoggingSuite(AutoLogCaptureMixin):
+    @multitest.testcase
+    def auto_log_capture(self, env, result):
+        self.logger.info(SIMPLE_LOG)
+
+
+@pytest.fixture
+def suites():
+    return [LoggingSuite(), AutoLoggingSuite()]
+
+
+@pytest.fixture
+def get_filtered_plan(suites):
+    def _factory(pattern=None):
+        plan = testplan.Testplan(
+            name="Logging TestPlan",
+            parse_cmdline=False,
+            test_filter=Pattern(pattern) if pattern else Filter(),
+        )
+        plan.add(multitest.MultiTest(name="Logging Test", suites=suites))
+        return plan
+
+    return _factory
+
+
+class LoggerSpy(object):
+    def __init__(self, name):
+        self.patcher = {}
+        logger = logging.getLogger(name)
+        for method in ["info", "debug", "warning"]:
+            self.patcher[method] = mock.patch.object(
+                logger, method, wraps=logger.__getattribute__(method)
+            )
+
+    def __enter__(self):
+        for method, patcher in six.iteritems(self.patcher):
+            self.__setattr__(method, patcher.__enter__())
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for method, patcher in six.iteritems(self.patcher):
+            patcher.__exit__(exc_type, exc_val, exc_tb)
+            self.__delattr__(method)
+
+
+@pytest.fixture
+def suite_logger_spy():
+    return LoggerSpy("testplan.LoggingSuite")
+
+
+@pytest.fixture
+def auto_suite_logger_spy():
+    return LoggerSpy("testplan.AutoLoggingSuite")
+
+
+@pytest.fixture
+def testplan_logger_spy():
+    return LoggerSpy("testplan")
+
+
+@pytest.fixture
+def root_logger_spy():
+    return LoggerSpy("")
+
+
+def get_case_result(plan_result):
+    return plan_result.report.entries[0].entries[0].entries[0]
+
+
+def test_logging(get_filtered_plan, suite_logger_spy):
+    plan = get_filtered_plan("*:*:just_log")
+    with suite_logger_spy as spy:
+        plan.run()
+
+        spy.info.assert_called_once_with(SIMPLE_LOG)
+
+
+def test_capture_single_scope(get_filtered_plan, suite_logger_spy):
+    # Given
+    plan = get_filtered_plan("*:*:capture_log_single_scope")
+    with suite_logger_spy as spy:
+        # When
+        plan_result = plan.run()
+
+        # Then
+        spy.info.assert_called_once_with(SIMPLE_LOG)
+
+        case_result = get_case_result(plan_result)
+
+        assert len(case_result.entries) == 1
+        assert case_result.entries[0]["type"] == "Log"
+        assert SIMPLE_LOG in case_result.entries[0]["message"]
+
+
+def test_capture_multiple_scope(get_filtered_plan, suite_logger_spy):
+    # Given
+    plan = get_filtered_plan("*:*:capture_log_multiple_scope")
+    with suite_logger_spy as spy:
+        # When
+        plan_result = plan.run()
+
+        # Then
+        assert spy.info.call_count == 2
+
+        case_result = get_case_result(plan_result)
+
+        assert len(case_result.entries) == 3
+        assert case_result.entries[0]["type"] == "Log"
+        assert SIMPLE_LOG + "1" in case_result.entries[0]["message"]
+        assert case_result.entries[1]["type"] == "IsTrue"
+        assert case_result.entries[2]["type"] == "Log"
+        assert SIMPLE_LOG + "2" in case_result.entries[2]["message"]
+
+
+def test_suite_level(
+    get_filtered_plan, suite_logger_spy, testplan_logger_spy, root_logger_spy
+):
+    # Given
+    plan = get_filtered_plan("*:*:testsuite_level")
+    with suite_logger_spy as suite_spy, testplan_logger_spy as testplan_spy, root_logger_spy as root_spy:
+        # When
+        plan_result = plan.run()
+
+        # Then all the logger got called
+        suite_spy.info.assert_called_once_with(SIMPLE_LOG)
+        testplan_spy.debug.assert_any_call(SIMPLE_LOG)
+        root_spy.warning.assert_any_call(SIMPLE_LOG)
+
+        # But the attached log has the suite level only
+        case_result = get_case_result(plan_result)
+
+        assert len(case_result.entries) == 1
+        assert case_result.entries[0]["type"] == "Log"
+        assert case_result.entries[0]["message"].count(SIMPLE_LOG) == 1
+
+
+def test_plan_level(
+    get_filtered_plan, suite_logger_spy, testplan_logger_spy, root_logger_spy
+):
+    # Given
+    plan = get_filtered_plan("*:*:testplan_level")
+    with suite_logger_spy as suite_spy, testplan_logger_spy as testplan_spy, root_logger_spy as root_spy:
+        # When
+        plan_result = plan.run()
+
+        # Then all the logger got called
+        suite_spy.info.assert_called_once_with(SIMPLE_LOG)
+        testplan_spy.debug.assert_any_call(SIMPLE_LOG)
+        root_spy.warning.assert_any_call(SIMPLE_LOG)
+
+        # But the attached log has the suite level only
+        case_result = get_case_result(plan_result)
+
+        assert len(case_result.entries) == 1
+        assert case_result.entries[0]["type"] == "Log"
+        message = case_result.entries[0]["message"]
+        assert message.count(SIMPLE_LOG) == 2
+        assert re.findall(LOGGER_LEVEL_PATTERN, message, re.M) == [
+            ("testplan.LoggingSuite", "INFO"),
+            ("testplan", "DEBUG"),
+        ]
+
+
+def test_root_level(
+    get_filtered_plan, suite_logger_spy, testplan_logger_spy, root_logger_spy
+):
+    # Given
+    plan = get_filtered_plan("*:*:root_level")
+    with suite_logger_spy as suite_spy, testplan_logger_spy as testplan_spy, root_logger_spy as root_spy:
+        # When
+        plan_result = plan.run()
+
+        # Then all the logger got called
+        suite_spy.info.assert_called_once_with(SIMPLE_LOG)
+        testplan_spy.debug.assert_any_call(SIMPLE_LOG)
+        root_spy.warning.assert_any_call(SIMPLE_LOG)
+
+        # And the log has all 3 log in different level
+        case_result = get_case_result(plan_result)
+
+        assert len(case_result.entries) == 1
+        assert case_result.entries[0]["type"] == "Log"
+        message = case_result.entries[0]["message"]
+        assert message.count(SIMPLE_LOG) == 3
+        assert re.findall(LOGGER_LEVEL_PATTERN, message, re.M) == [
+            ("testplan.LoggingSuite", "INFO"),
+            ("testplan", "DEBUG"),
+            ("root", "WARNING"),
+        ]
+
+
+def test_attach_log(get_filtered_plan, suite_logger_spy):
+    # Given
+    plan = get_filtered_plan("*:*:attach_log")
+    with suite_logger_spy as spy:
+        # When
+        plan_result = plan.run()
+
+        # The We have an attachment and it has the log
+        spy.info.assert_called_once_with(SIMPLE_LOG)
+
+        case_result = get_case_result(plan_result)
+
+        assert len(case_result.entries) == 1
+        assert case_result.entries[0]["type"] == "Attachment"
+        assert len(case_result.attachments) == 1
+
+        with open(case_result.attachments[0].source_path) as logfile:
+            assert SIMPLE_LOG in logfile.readline()
+
+
+def test_auto_log_capture(get_filtered_plan, auto_suite_logger_spy):
+    # Given
+    plan = get_filtered_plan("*:*:auto_log_capture")
+    with auto_suite_logger_spy as spy:
+        # When
+        plan_result = plan.run()
+
+        # Then
+        spy.info.assert_called_once_with(SIMPLE_LOG)
+
+        case_result = get_case_result(plan_result)
+
+        assert len(case_result.entries) == 1
+        assert case_result.entries[0]["type"] == "Log"
+        assert SIMPLE_LOG in case_result.entries[0]["message"]

--- a/tests/unit/testplan/common/report/test_base.py
+++ b/tests/unit/testplan/common/report/test_base.py
@@ -1,9 +1,15 @@
 import logging
 import functools
 import re
+import six
 
 import pytest
-import mock
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
+
 
 from testplan.common import report
 from testplan.common.report.log import LOGGER

--- a/tests/unit/testplan/report/test_testing.py
+++ b/tests/unit/testplan/report/test_testing.py
@@ -1,7 +1,13 @@
 import functools
 import json
+import six
 import pytest
-import mock
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
+
 
 from testplan.common.utils.testing import disable_log_propagation
 

--- a/tests/unit/testplan/runnable/interactive/test_api.py
+++ b/tests/unit/testplan/runnable/interactive/test_api.py
@@ -6,7 +6,14 @@ from __future__ import absolute_import
 from future import standard_library
 
 standard_library.install_aliases()
-import mock
+
+import six
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
+
 import pytest
 
 from testplan.runnable.interactive import http

--- a/tests/unit/testplan/runnable/interactive/test_irunner.py
+++ b/tests/unit/testplan/runnable/interactive/test_irunner.py
@@ -1,5 +1,11 @@
 """Test the interactive test runner."""
-import mock
+import six
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
+
 import pytest
 
 from testplan import defaults

--- a/tests/unit/testplan/runnable/interactive/test_reloader.py
+++ b/tests/unit/testplan/runnable/interactive/test_reloader.py
@@ -6,7 +6,13 @@ from builtins import range
 from future import standard_library
 
 standard_library.install_aliases()
-import mock
+import six
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
+
 import modulefinder
 import os
 import time

--- a/tests/unit/testplan/testing/multitest/test_result.py
+++ b/tests/unit/testplan/testing/multitest/test_result.py
@@ -1,7 +1,13 @@
 """Unit tests for the testplan.testing.multitest.result module."""
 
 import collections
-import mock
+import six
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
+
 import os
 
 import pytest

--- a/tests/unit/testplan/web_ui/testing/test_jest.py
+++ b/tests/unit/testplan/web_ui/testing/test_jest.py
@@ -46,4 +46,4 @@ def test_testplan_ui():
 )
 def test_eslint():
     """Run eslint over the UI source code."""
-    subprocess.check_call(["npm", "run", "lint"], cwd=TESTPLAN_UI_DIR)
+    subprocess.check_call("npm run lint", shell=True, cwd=TESTPLAN_UI_DIR)


### PR DESCRIPTION
Two mixins to test suite that enable 

- logging in the suite through testplan namespace, captured to testplan log
- logs can be auto captured in result as log assertion or attachments
- can capture  with context manager per testcase or for all case in a suite with minimal boilerplate

see example:  Multitest/Logging