### PR TITLE
Fix internal test failure

### DIFF
--- a/tests/functional/testplan/testing/fixtures/base/sleeping/test.sh
+++ b/tests/functional/testplan/testing/fixtures/base/sleeping/test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 echo 'Sleeping for a bit'
-sleep 5
+sleep 10
 echo 'Woke up'


### PR DESCRIPTION
While testing ProcessTest with sleeping/test.sh, timeout (1s) exception is raised but process exit with 0, and it fails the testcase. The possible cause is that kill_proc also has a 5 sec default timeout as well. 