### PR TITLE
Display time info for testplan assertions

### DIFF
--- a/testplan/web_ui/testing/src/AssertionPane/AssertionHeader.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionHeader.js
@@ -4,15 +4,9 @@ import {css, StyleSheet} from 'aphrodite';
 import {CardHeader, Tooltip} from 'reactstrap';
 import {library} from '@fortawesome/fontawesome-svg-core';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {
-  faClock,
-  faLayerGroup,
-} from '@fortawesome/free-solid-svg-icons';
+import {faLayerGroup} from '@fortawesome/free-solid-svg-icons';
 
-library.add(
-  faClock,
-  faLayerGroup
-);
+library.add(faLayerGroup);
 
 /**
  * Header component of an assertion.
@@ -21,71 +15,103 @@ class AssertionHeader extends Component {
   constructor(props) {
     super(props);
 
-    this.state = {isTooltipOpen: false};
-    this.toggleTooltip = this.toggleTooltip.bind(this);
+    this.state = {
+      isUTCTooltipOpen: false,
+      isDurationTooltipOpen: false,
+    };
+    this.toggleUTCTooltip = this.toggleUTCTooltip.bind(this);
+    this.toggleDurationTooltip = this.toggleDurationTooltip.bind(this);
   }
 
   /**
-   * Toggle the visibility of the header's tooltip.
+   * Toggle the visibility of tooltip of assertion start time.
    */
-  toggleTooltip() {
-    this.setState({
-      isTooltipOpen: !this.state.isTooltipOpen
-    });
+  toggleUTCTooltip() {
+    this.setState(prevState => ({
+      isUTCTooltipOpen: !prevState.isUTCTooltipOpen
+    }));
+  }
+
+  /**
+   * Toggle the visibility of tooltip of duration between assertions.
+   */
+  toggleDurationTooltip() {
+    this.setState(prevState => ({
+      isDurationTooltipOpen: !prevState.isDurationTooltipOpen
+    }));
   }
 
   render() {
-    let tooltip = null;
-    let starterIcon = null;
-    const tooltipId = 'tooltip_' + this.props.index;
     const cardHeaderStyle = this.props.assertion.passed === undefined
       ? styles.cardHeaderColorLog
       : this.props.assertion.passed
         ? styles.cardHeaderColorPassed
         : styles.cardHeaderColorFailed;
 
-    if (this.props.assertion.utc_time === undefined) {
-      starterIcon =
-        <FontAwesomeIcon
+    const timeInfoArray = this.props.assertion.timeInfoArray || [];
+    let component = (this.props.assertion.utc_time === undefined) ? (
+      <span className={css(styles.cardHeaderAlignRight)}>
+        <FontAwesomeIcon  // Should be a nested assertion group
           size='sm'
           key='faLayerGroup'
           icon='layer-group'
           className={css(styles.icon)}
-        />;
-    } else {
-      let tooltipDate = new Date(this.props.assertion.utc_time);
-
-      starterIcon =
-        <FontAwesomeIcon
-          size='sm'
-          key='faClock'
-          icon='clock'
-          className={css(styles.icon)}
-          id={tooltipId}
-        />;
-
-      tooltip =
-        <Tooltip
-          placement='bottom'
-          isOpen={this.state.isTooltipOpen}
-          target={tooltipId}
-          toggle={this.toggleTooltip}
-        >
-          {tooltipDate.toUTCString()}
-        </Tooltip>;
-    }
+        />
+      </span>
+    ) : ((timeInfoArray.length === 0) ? (
+        <span className={css(styles.cardHeaderAlignRight)}></span>
+      ) : (
+        <>
+          <span
+            className={css(styles.cardHeaderAlignRight)}
+            id={`tooltip_duration_${timeInfoArray[0]}`}
+          >
+            {timeInfoArray[2]}
+          </span>
+          <span className={css(styles.cardHeaderAlignRight)}>
+            &nbsp;&nbsp;
+          </span>
+          <span
+            className={css(styles.cardHeaderAlignRight)}
+            id={`tooltip_utc_${timeInfoArray[0]}`}
+          >
+            {timeInfoArray[1]}
+          </span>
+          <Tooltip
+            placement='bottom'
+            isOpen={this.state.isUTCTooltipOpen}
+            target={`tooltip_utc_${timeInfoArray[0]}`}
+            toggle={this.toggleUTCTooltip}
+          >
+            {"Assertion start time"}
+          </Tooltip>
+          <Tooltip
+            placement='bottom'
+            isOpen={this.state.isDurationTooltipOpen}
+            target={`tooltip_duration_${timeInfoArray[0]}`}
+            toggle={this.toggleDurationTooltip}
+          >
+            {"Assertion duration"}
+          </Tooltip>
+        </>
+      )
+    );
 
     return (
       <CardHeader
         className={css(styles.cardHeader, cardHeaderStyle)}
         onClick={this.props.onClick}
       >
-        {starterIcon}
-        {tooltip}
         <span>
-          <strong>{this.props.assertion.description}</strong>
+          <strong>
+            {this.props.assertion.description ? (
+             this.props.assertion.description + " ") : ""}
+          </strong>
+        </span>
+        <span>
           ({this.props.assertion.type})
         </span>
+        {component}
         {/*
           TODO will be implemented when complete permalink feature
           linkIcon
@@ -126,6 +152,10 @@ const styles = StyleSheet.create({
   cardHeaderColorFailed: {
     borderBottomColor: '#dc3545', // Move to defaults
     color: '#dc3545', // Move to defaults
+  },
+
+  cardHeaderAlignRight: {
+    float: 'right',
   },
 
   collapseDiv: {

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionPane.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionPane.js
@@ -90,7 +90,7 @@ class AssertionPane extends Component {
     if (this.props.assertions.length !== 0 || this.props.logs.length !==0) {
       return (
         <div style={assertionPaneStyle}>
-          <DescriptionPane 
+          <DescriptionPane
             descriptionEntries={this.props.descriptionEntries}
           />
           <div className={css(styles.buttonsDiv)}>

--- a/testplan/web_ui/testing/src/AssertionPane/__tests__/__snapshots__/AssertionHeader.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/__tests__/__snapshots__/AssertionHeader.test.js.snap
@@ -6,48 +6,16 @@ exports[`AssertionHeader shallow renders the correct HTML structure 1`] = `
   onClick={[MockFunction]}
   tag="div"
 >
-  <FontAwesomeIcon
-    border={false}
-    className="icon_erbgzi"
-    fixedWidth={false}
-    flip={null}
-    icon="clock"
-    id="tooltip_0"
-    inverse={false}
-    key="faClock"
-    listItem={false}
-    mask={null}
-    pull={null}
-    pulse={false}
-    rotation={null}
-    size="sm"
-    spin={false}
-    symbol={false}
-    title=""
-    transform={null}
-  />
-  <Tooltip
-    autohide={true}
-    delay={
-      Object {
-        "hide": 250,
-        "show": 0,
-      }
-    }
-    hideArrow={false}
-    isOpen={false}
-    placement="bottom"
-    placementPrefix="bs-tooltip"
-    target="tooltip_0"
-    toggle={[Function]}
-  >
-    Tue, 12 Feb 2019 17:41:42 GMT
-  </Tooltip>
   <span>
     <strong />
+  </span>
+  <span>
     (
     Equal
     )
   </span>
+  <span
+    className="cardHeaderAlignRight_107ja4p"
+  />
 </CardHeader>
 `;

--- a/testplan/web_ui/testing/src/Common/defaults.js
+++ b/testplan/web_ui/testing/src/Common/defaults.js
@@ -2,8 +2,11 @@
  * Constants used across the entire application.
  */
 const GREEN = '#228F1D';
+const DARK_GREEN = '#1A721D';
 const RED = '#A2000C';
+const DARK_RED = '#840008';
 const ORANGE = '#FFA500';
+const DARK_ORANGE = '#DD8800';
 const LIGHT_GREY = '#F3F3F3';
 const MEDIUM_GREY = '#D0D0D0';
 const DARK_GREY = '#ADADAD';
@@ -172,8 +175,11 @@ const POLL_MS = 1000;
 
 export {
   GREEN,
+  DARK_GREEN,
   RED,
+  DARK_RED,
   ORANGE,
+  DARK_ORANGE,
   LIGHT_GREY,
   MEDIUM_GREY,
   DARK_GREY,

--- a/testplan/web_ui/testing/src/Nav/Column.js
+++ b/testplan/web_ui/testing/src/Nav/Column.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Component} from 'react';
 import {StyleSheet, css} from 'aphrodite';
 
 import {LIGHT_GREY, MIN_COLUMN_WIDTH} from "../Common/defaults";
@@ -7,7 +7,7 @@ import {LIGHT_GREY, MIN_COLUMN_WIDTH} from "../Common/defaults";
  * Vertical column for navigation bar.
  */
 
-class Column extends React.Component {
+class Column extends Component {
   constructor(props) {
     super(props);
     this.mouseDown = this.mouseDown.bind(this);

--- a/testplan/web_ui/testing/src/Report/BatchReport.js
+++ b/testplan/web_ui/testing/src/Report/BatchReport.js
@@ -3,7 +3,7 @@ import {StyleSheet, css} from 'aphrodite';
 import axios from 'axios';
 
 import Toolbar from '../Toolbar/Toolbar';
-import { TimeButton } from '../Toolbar/Buttons';
+import {TimeButton} from '../Toolbar/Buttons';
 import Nav from '../Nav/Nav';
 import {
   PropagateIndices,
@@ -27,7 +27,7 @@ class BatchReport extends React.Component {
     this.handleNavFilter = this.handleNavFilter.bind(this);
     this.updateFilter = this.updateFilter.bind(this);
     this.updateTagsDisplay = this.updateTagsDisplay.bind(this);
-    this.toggleTimeDisplay = this.toggleTimeDisplay.bind(this);
+    this.updateTimeDisplay = this.updateTimeDisplay.bind(this);
     this.updateDisplayEmpty = this.updateDisplayEmpty.bind(this);
     this.handleNavClick = this.handleNavClick.bind(this);
     this.handleColumnResizing = this.handleColumnResizing.bind(this);
@@ -130,18 +130,34 @@ class BatchReport extends React.Component {
     this.setState({filter: filter});
   }
 
+  /**
+   * Update tag display of each navigation entry.
+   *
+   * @param {boolean} displayTags.
+   * @public
+   */
   updateTagsDisplay(displayTags) {
     this.setState({displayTags: displayTags});
   }
 
+  /**
+   * Update navigation pane to show/hide entries of empty testcases.
+   *
+   * @param {boolean} displayEmpty.
+   * @public
+   */
   updateDisplayEmpty(displayEmpty) {
     this.setState({displayEmpty: displayEmpty});
   }
 
-  toggleTimeDisplay() {
-    this.setState(prevState => ({
-      displayTime: !prevState.displayTime
-    }));
+  /**
+   * Update execution time display of each navigation entry and each assertion.
+   *
+   * @param {boolean} displayTime.
+   * @public
+   */
+  updateTimeDisplay(displayTime) {
+    this.setState({displayTime: displayTime});
   }
 
   /**
@@ -188,7 +204,8 @@ class BatchReport extends React.Component {
           updateTagsDisplayFunc={this.updateTagsDisplay}
           extraButtons={[<TimeButton
             key="time-button"
-            toggleTimeDisplayCbk={this.toggleTimeDisplay}
+            status={reportStatus}
+            updateTimeDisplayCbk={this.updateTimeDisplay}
           />]}
         />
         <Nav

--- a/testplan/web_ui/testing/src/Report/EmptyReport.js
+++ b/testplan/web_ui/testing/src/Report/EmptyReport.js
@@ -7,7 +7,7 @@ import {StyleSheet, css} from 'aphrodite';
 
 import Message from '../Common/Message';
 import Toolbar from '../Toolbar/Toolbar';
-import { TimeButton } from '../Toolbar/Buttons';
+import {TimeButton} from '../Toolbar/Buttons';
 import Nav from '../Nav/Nav';
 import {COLUMN_WIDTH} from "../Common/defaults";
 
@@ -39,7 +39,8 @@ const EmptyReport = (props) => {
         updateTagsDisplayFunc={noop}
         extraButtons={[<TimeButton
             key="time-button"
-            toggleTimeDisplayCbk={noop}
+            status={undefined}
+            updateTimeDisplayCbk={noop}
           />]}
       />
       <Nav

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
@@ -8,7 +8,8 @@ exports[`BatchReport loads a more complex report and autoselects entries 1`] = `
     extraButtons={
       Array [
         <TimeButton
-          toggleTimeDisplayCbk={[Function]}
+          status="failed"
+          updateTimeDisplayCbk={[Function]}
         />,
       ]
     }
@@ -1218,7 +1219,8 @@ exports[`BatchReport loads a simple report and autoselects entries 1`] = `
     extraButtons={
       Array [
         <TimeButton
-          toggleTimeDisplayCbk={[Function]}
+          status="failed"
+          updateTimeDisplayCbk={[Function]}
         />,
       ]
     }
@@ -1949,7 +1951,8 @@ exports[`BatchReport shallow renders the correct HTML structure when report load
     extraButtons={
       Array [
         <TimeButton
-          toggleTimeDisplayCbk={[Function]}
+          status="failed"
+          updateTimeDisplayCbk={[Function]}
         />,
       ]
     }

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/EmptyReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/EmptyReport.test.js.snap
@@ -8,7 +8,7 @@ exports[`EmptyReport renders a custom error message 1`] = `
     extraButtons={
       Array [
         <TimeButton
-          toggleTimeDisplayCbk={[Function]}
+          updateTimeDisplayCbk={[Function]}
         />,
       ]
     }
@@ -40,7 +40,7 @@ exports[`EmptyReport shallow renders and matches snapshot 1`] = `
     extraButtons={
       Array [
         <TimeButton
-          toggleTimeDisplayCbk={[Function]}
+          updateTimeDisplayCbk={[Function]}
         />,
       ]
     }

--- a/testplan/web_ui/testing/src/Toolbar/Buttons.js
+++ b/testplan/web_ui/testing/src/Toolbar/Buttons.js
@@ -1,37 +1,67 @@
 /**
  * Toolbar buttons used for the common report.
  */
-import React from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import {css} from 'aphrodite';
 import {NavItem} from 'reactstrap';
+
+import {library} from '@fortawesome/fontawesome-svg-core';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faClock} from '@fortawesome/free-solid-svg-icons';
-import {css} from 'aphrodite';
 
 import styles from './navStyles';
+import {getToggledButtonStyle} from './Toolbar';
+
+library.add(faClock);
 
 /**
  * Render a button to toggle the display of execution time on nav entries.
  */
-const TimeButton = (props) => {
-  return (
-    <NavItem>
-      <div className={css(styles.buttonsBar)}>
-        <FontAwesomeIcon
-          key='toolbar-time'
-          className={css(styles.toolbarButton)}
-          icon={faClock}
-          title='Toggle execution time'
-          onClick={props.toggleTimeDisplayCbk}
-        />
-      </div>
-    </NavItem>
-  );
-};
+class TimeButton extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      displayTime: props.displayTime,
+    };
+
+    this.toggleTimeDisplay = this.toggleTimeDisplay.bind(this);
+  }
+
+  toggleTimeDisplay() {
+    this.props.updateTimeDisplayCbk(!this.state.displayTime);
+    this.setState(prevState => ({
+      displayTime: !prevState.displayTime
+    }));
+  }
+
+  render() {
+    const toolbarButtonStyle = this.state.displayTime ? (
+      getToggledButtonStyle(this.props.status)): css(styles.toolbarButton);
+    const iconTooltip = this.state.displayTime ? (
+      "Hide time information") : "Display time information";
+
+    return (
+      <NavItem>
+        <div className={css(styles.buttonsBar)}>
+          <FontAwesomeIcon
+            key='toolbar-time'
+            className={toolbarButtonStyle}
+            icon={faClock}
+            title={iconTooltip}
+            onClick={this.toggleTimeDisplay}
+          />
+        </div>
+      </NavItem>
+    );
+  }
+}
 
 TimeButton.propTypes = {
   /** Function to handle toggle of displaying execution time in the navbar */
-  toggleTimeDisplayCbk: PropTypes.func,
+  updateTimeDisplayCbk: PropTypes.func,
 };
 
-export {TimeButton};
+export {
+  TimeButton,
+};

--- a/testplan/web_ui/testing/src/Toolbar/Toolbar.js
+++ b/testplan/web_ui/testing/src/Toolbar/Toolbar.js
@@ -210,14 +210,18 @@ class Toolbar extends Component {
    * Return the button which toggles the display of tags.
    */
   tagsButton() {
+    const toolbarButtonStyle = this.state.displayTags ? (
+      getToggledButtonStyle(this.props.status)): css(styles.toolbarButton);
+    const iconTooltip = this.state.displayTags ? "Hide tags" : "Display tags";
+
     return (
       <NavItem>
         <div className={css(styles.buttonsBar)}>
           <FontAwesomeIcon
             key='toolbar-tags'
-            className={css(styles.toolbarButton)}
+            className={toolbarButtonStyle}
             icon='tags'
-            title='Toggle tags'
+            title={iconTooltip}
             onClick={this.toggleTagsDisplay}
           />
         </div>
@@ -360,7 +364,7 @@ class Toolbar extends Component {
  * Get the current toolbar style based on the testplan status.
  */
 const getToolbarStyle = (status) => {
-  switch (STATUS_CATEGORY[status]){
+  switch (STATUS_CATEGORY[status]) {
     case 'passed':
         return css(styles.toolbar, styles.toolbarPassed);
     case 'failed':
@@ -370,6 +374,23 @@ const getToolbarStyle = (status) => {
         return css(styles.toolbar, styles.toolbarUnstable);
     default:
         return css(styles.toolbar, styles.toolbarUnknown);
+  }
+};
+
+/**
+ * Get the current toggled toolbar button style in based on the testplan status.
+ */
+const getToggledButtonStyle = (status) => {
+  switch (STATUS_CATEGORY[status]) {
+    case 'passed':
+        return css(styles.toolbarButton, styles.toolbarButtonToggledPassed);
+    case 'failed':
+    case 'error':
+        return css(styles.toolbarButton, styles.toolbarButtonToggledFailed);
+    case 'unstable':
+        return css(styles.toolbarButton, styles.toolbarButtonToggledUnstable);
+    default:
+        return css(styles.toolbarButton, styles.toolbarButtonToggledUnknown);
   }
 };
 
@@ -433,3 +454,4 @@ Toolbar.propTypes = {
 };
 
 export default Toolbar;
+export {getToggledButtonStyle};

--- a/testplan/web_ui/testing/src/Toolbar/__tests__/Buttons.test.js
+++ b/testplan/web_ui/testing/src/Toolbar/__tests__/Buttons.test.js
@@ -19,12 +19,12 @@ describe("TimeButton", () => {
   });
 
   it("Renders a clickable button", () => {
-    const toggleTimeDisplayCbk = jest.fn();
+    const updateTimeDisplayCbk = jest.fn();
     const button = shallow(
-      <TimeButton toggleTimeDisplayCbk={toggleTimeDisplayCbk} />
+      <TimeButton updateTimeDisplayCbk={updateTimeDisplayCbk} />
     );
     expect(button).toMatchSnapshot();
-    button.find({title: "Toggle execution time"}).simulate("click");
-    expect(toggleTimeDisplayCbk.mock.calls.length).toBe(1);
+    button.find({title: "Display time information"}).simulate("click");
+    expect(updateTimeDisplayCbk.mock.calls.length).toBe(1);
   });
 });

--- a/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/Buttons.test.js.snap
+++ b/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/Buttons.test.js.snap
@@ -5,11 +5,11 @@ exports[`TimeButton Renders a clickable button 1`] = `
   tag="li"
 >
   <div
-    className="buttonsBar_13xq1v"
+    className="buttonsBar_6zsntc"
   >
     <FontAwesomeIcon
       border={false}
-      className="toolbarButton_z1gq62"
+      className="toolbarButton_1d6e8oq"
       fixedWidth={false}
       flip={null}
       icon={
@@ -29,14 +29,14 @@ exports[`TimeButton Renders a clickable button 1`] = `
       key="toolbar-time"
       listItem={false}
       mask={null}
-      onClick={[MockFunction]}
+      onClick={[Function]}
       pull={null}
       pulse={false}
       rotation={null}
       size={null}
       spin={false}
       symbol={false}
-      title="Toggle execution time"
+      title="Display time information"
       transform={null}
     />
   </div>

--- a/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/InteractiveButtons.test.js.snap
+++ b/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/InteractiveButtons.test.js.snap
@@ -6,11 +6,11 @@ exports[`ResetButton Renders a clickable button 1`] = `
   tag="li"
 >
   <div
-    className="buttonsBar_13xq1v"
+    className="buttonsBar_6zsntc"
   >
     <FontAwesomeIcon
       border={false}
-      className="toolbarButton_z1gq62"
+      className="toolbarButton_1d6e8oq"
       fixedWidth={false}
       flip={null}
       icon={
@@ -50,11 +50,11 @@ exports[`ResetButton Renders a spinning icon when reset is in-progress 1`] = `
   tag="li"
 >
   <div
-    className="buttonsBar_13xq1v"
+    className="buttonsBar_6zsntc"
   >
     <FontAwesomeIcon
       border={false}
-      className="toolbarButton_z1gq62-o_O-toolbarInactive_51g7gx"
+      className="toolbarButton_1d6e8oq-o_O-toolbarInactive_51g7gx"
       fixedWidth={false}
       flip={null}
       icon={

--- a/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/Toolbar.test.js.snap
+++ b/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/Toolbar.test.js.snap
@@ -45,11 +45,11 @@ exports[`Toolbar inserts extra buttons into the toolbar 1`] = `
           tag="li"
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon={
@@ -84,11 +84,11 @@ exports[`Toolbar inserts extra buttons into the toolbar 1`] = `
           tag="li"
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="info"
@@ -113,7 +113,7 @@ exports[`Toolbar inserts extra buttons into the toolbar 1`] = `
           nav={true}
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <DropdownToggle
               aria-haspopup={true}
@@ -123,7 +123,7 @@ exports[`Toolbar inserts extra buttons into the toolbar 1`] = `
             >
               <FontAwesomeIcon
                 border={false}
-                className="toolbarButton_z1gq62"
+                className="toolbarButton_1d6e8oq"
                 fixedWidth={false}
                 flip={null}
                 icon="filter"
@@ -277,11 +277,11 @@ exports[`Toolbar inserts extra buttons into the toolbar 1`] = `
           tag="li"
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="print"
@@ -305,11 +305,11 @@ exports[`Toolbar inserts extra buttons into the toolbar 1`] = `
           tag="li"
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="tags"
@@ -324,7 +324,7 @@ exports[`Toolbar inserts extra buttons into the toolbar 1`] = `
               size={null}
               spin={false}
               symbol={false}
-              title="Toggle tags"
+              title="Display tags"
               transform={null}
             />
           </div>
@@ -333,11 +333,11 @@ exports[`Toolbar inserts extra buttons into the toolbar 1`] = `
           tag="li"
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="question-circle"
@@ -361,14 +361,14 @@ exports[`Toolbar inserts extra buttons into the toolbar 1`] = `
           tag="li"
         >
           <a
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
             href="http://testplan.readthedocs.io"
             rel="noopener noreferrer"
             target="_blank"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="book"
@@ -538,11 +538,11 @@ exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] =
           tag="li"
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="info"
@@ -567,7 +567,7 @@ exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] =
           nav={true}
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <DropdownToggle
               aria-haspopup={true}
@@ -577,7 +577,7 @@ exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] =
             >
               <FontAwesomeIcon
                 border={false}
-                className="toolbarButton_z1gq62"
+                className="toolbarButton_1d6e8oq"
                 fixedWidth={false}
                 flip={null}
                 icon="filter"
@@ -731,11 +731,11 @@ exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] =
           tag="li"
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="print"
@@ -759,11 +759,11 @@ exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] =
           tag="li"
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="tags"
@@ -778,7 +778,7 @@ exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] =
               size={null}
               spin={false}
               symbol={false}
-              title="Toggle tags"
+              title="Display tags"
               transform={null}
             />
           </div>
@@ -787,11 +787,11 @@ exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] =
           tag="li"
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="question-circle"
@@ -815,14 +815,14 @@ exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] =
           tag="li"
         >
           <a
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
             href="http://testplan.readthedocs.io"
             rel="noopener noreferrer"
             target="_blank"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="book"
@@ -992,11 +992,11 @@ exports[`Toolbar shallow renders the correct HTML structure for interactive mode
           tag="li"
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="info"
@@ -1021,7 +1021,7 @@ exports[`Toolbar shallow renders the correct HTML structure for interactive mode
           nav={true}
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <DropdownToggle
               aria-haspopup={true}
@@ -1031,7 +1031,7 @@ exports[`Toolbar shallow renders the correct HTML structure for interactive mode
             >
               <FontAwesomeIcon
                 border={false}
-                className="toolbarButton_z1gq62"
+                className="toolbarButton_1d6e8oq"
                 fixedWidth={false}
                 flip={null}
                 icon="filter"
@@ -1185,11 +1185,11 @@ exports[`Toolbar shallow renders the correct HTML structure for interactive mode
           tag="li"
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="print"
@@ -1213,11 +1213,11 @@ exports[`Toolbar shallow renders the correct HTML structure for interactive mode
           tag="li"
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="tags"
@@ -1232,7 +1232,7 @@ exports[`Toolbar shallow renders the correct HTML structure for interactive mode
               size={null}
               spin={false}
               symbol={false}
-              title="Toggle tags"
+              title="Display tags"
               transform={null}
             />
           </div>
@@ -1241,11 +1241,11 @@ exports[`Toolbar shallow renders the correct HTML structure for interactive mode
           tag="li"
         >
           <div
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="question-circle"
@@ -1269,14 +1269,14 @@ exports[`Toolbar shallow renders the correct HTML structure for interactive mode
           tag="li"
         >
           <a
-            className="buttonsBar_13xq1v"
+            className="buttonsBar_6zsntc"
             href="http://testplan.readthedocs.io"
             rel="noopener noreferrer"
             target="_blank"
           >
             <FontAwesomeIcon
               border={false}
-              className="toolbarButton_z1gq62"
+              className="toolbarButton_1d6e8oq"
               fixedWidth={false}
               flip={null}
               icon="book"

--- a/testplan/web_ui/testing/src/Toolbar/navStyles.js
+++ b/testplan/web_ui/testing/src/Toolbar/navStyles.js
@@ -4,7 +4,7 @@
 import {StyleSheet} from 'aphrodite';
 
 import {
-  GREEN, RED, ORANGE, BLACK, DARK_GREY
+  GREEN, DARK_GREEN, RED, DARK_RED, ORANGE, DARK_ORANGE, BLACK, DARK_GREY
 } from "../Common/defaults";
 
 
@@ -12,7 +12,6 @@ const styles = StyleSheet.create({
   toolbar: {
     padding: '0',
   },
-
   filterBox: {
     float: 'left',
     height: '100%',
@@ -20,6 +19,7 @@ const styles = StyleSheet.create({
   buttonsBar: {
     float: 'left',
     height: '100%',
+    lineHeight: '100%',
     color: 'white',
   },
   filterLabel: {
@@ -39,26 +39,26 @@ const styles = StyleSheet.create({
     textDecoration: 'none',
     position: 'relative',
     display: 'inline-block',
-    height: '2.4em',
-    width: '2.4em',
+    height: '2.5em',
+    width: '2.5em',
     cursor: 'pointer',
     color: 'white',
-    padding: '0.7em 0em 0.7em 0em',
+    padding: '0.75em 0em 0.75em 0em',
     transition: 'all 0.3s ease-out 0s',
     ':hover': {
-        color: DARK_GREY
-    }
+        color: DARK_GREY,
+    },
   },
   toolbarInactive: {
     cursor: 'auto',
     color: DARK_GREY,
   },
-  toolbarUnstable: {
-    backgroundColor: ORANGE,
-    color: 'white'
-  },
   toolbarUnknown: {
     backgroundColor: BLACK,
+    color: 'white'
+  },
+  toolbarUnstable: {
+    backgroundColor: ORANGE,
     color: 'white'
   },
   toolbarPassed: {
@@ -67,6 +67,22 @@ const styles = StyleSheet.create({
   },
   toolbarFailed: {
     backgroundColor: RED,
+    color: 'white'
+  },
+  toolbarButtonToggledUnknown: {
+    backgroundColor: 'black',
+    color: 'white'
+  },
+  toolbarButtonToggledUnstable: {
+    backgroundColor: DARK_ORANGE,
+    color: 'white'
+  },
+  toolbarButtonToggledPassed: {
+    backgroundColor: DARK_GREEN,
+    color: 'white'
+  },
+  toolbarButtonToggledFailed: {
+    backgroundColor: DARK_RED,
     color: 'white'
   },
   filterDropdown: {


### PR DESCRIPTION
* If time button is toggled, then display the time information for
  assertions in each testcase, including starting time in UTC and
  execution time (unit in micro second).
* Also works for assertions in nested groups.
* If the buttons in toobar behave like a checkbox, when toggled,
  draw shadow around the icon to let users be clear about the status.