### PR TITLE
Remove deprecated argument used in interactive mode

### DIFF
--- a/examples/Interactive/Basic/test_plan_notebook.ipynb
+++ b/examples/Interactive/Basic/test_plan_notebook.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "# Initialize a plan with interactive mode flag set.\n",
     "plan = Testplan(name='MyPlan',\n",
-    "                interactive=True,\n",
+    "                interactive_port=0,\n",
     "                parse_cmdline=False,\n",
     "                logger_level=TEST_INFO)"
    ]

--- a/examples/Interactive/Environments/test_plan.py
+++ b/examples/Interactive/Environments/test_plan.py
@@ -13,7 +13,7 @@ from my_tests.mtest import make_multitest
 # Hard coding interactive mode usage.
 @test_plan(
     name="MyPlan",
-    interactive=True,
+    interactive_port=0,
     stdout_style=Style(
         passing=StyleEnum.ASSERTION_DETAIL, failing=StyleEnum.ASSERTION_DETAIL
     ),

--- a/examples/Interactive/Environments/test_plan_notebook.ipynb
+++ b/examples/Interactive/Environments/test_plan_notebook.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "# Initialize a plan with interactive mode flag set.\n",
     "plan = Testplan(name='MyPlan',\n",
-    "                interactive=True,\n",
+    "                interactive_port=0,\n",
     "                parse_cmdline=False,\n",
     "                logger_level=TEST_INFO)"
    ]

--- a/testplan/base.py
+++ b/testplan/base.py
@@ -84,12 +84,10 @@ class Testplan(entity.RunnableManager):
     :type name: ``str``
     :param description: Description of test plan.
     :type description: ``str``
-    :param parse_cmdline: Parse command lne arguments.
+    :param parse_cmdline: Parse command line arguments.
     :type parse_cmdline: ``bool``
-    :param interactive: Enable interactive execution mode.
-    :type interactive: ``bool``
-    :param port: Port for interactive mode.
-    :type port: ``bool``
+    :param interactive_port: Enable interactive execution mode on a port.
+    :type interactive_port: ``int`` or ``NoneType``
     :param abort_signals: Signals to catch and trigger abort. By default,
         SIGINT and SIGTERM will trigger Testplan to abort.
     :type abort_signals: ``list`` of signals
@@ -325,8 +323,7 @@ class Testplan(entity.RunnableManager):
         name,
         description=None,
         parse_cmdline=True,
-        interactive=False,
-        port=None,
+        interactive_port=None,
         abort_signals=None,
         logger_level=logger.TEST_INFO,
         file_log_level=logger.DEBUG,
@@ -380,8 +377,7 @@ class Testplan(entity.RunnableManager):
                     name=name,
                     description=description,
                     parse_cmdline=parse_cmdline,
-                    interactive=interactive,
-                    port=port,
+                    interactive_port=interactive_port,
                     abort_signals=abort_signals,
                     logger_level=logger_level,
                     file_log_level=file_log_level,

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -634,10 +634,10 @@ class Runnable(Entity):
     :py:class:`~testplan.common.entity.base.Resource` objects
     that can be started/stopped and utilized by the steps defined.
 
-    :param interactive: Enable interactive execution mode.
-    :type interactive: ``bool``
-    :param interactive_no_block: Do not block on run() on interactive mode.
-    :type interactive_no_block: ``bool``
+    :param interactive_port: Enable interactive execution mode on a port.
+    :type interactive_port: ``int`` or ``NoneType``
+    :param interactive_block: Block on run() on interactive mode.
+    :type interactive_block: ``bool``
 
     Also inherits all
     :py:class:`~testplan.common.entity.base.Entity` options.


### PR DESCRIPTION
* Arguments `interactive` and `port` should be totally removed from
  runner class because a single argument `interactive_port` is used.
* Correct document and examples.
* Fix typo.