### PR TITLE
Add support to automatically re-run failed task

### DIFF
--- a/doc/en/download/Execution Pools.rst
+++ b/doc/en/download/Execution Pools.rst
@@ -60,6 +60,23 @@ setup_script.ksh
 ++++++++++++++++
 .. literalinclude:: ../../../examples/ExecutionPools/Remote/setup_script.ksh
 
+.. _example_task_rerun:
+
+Task Rerun
+----------
+
+Required files:
+  - :download:`test_plan.py <../../../examples/ExecutionPools/Rerun/test_plan.py>`
+  - :download:`tasks.py <../../../examples/ExecutionPools/Rerun/tasks.py>`
+
+test_plan.py
+++++++++++++
+.. literalinclude:: ../../../examples/ExecutionPools/Rerun/test_plan.py
+
+tasks.py
++++++++++
+.. literalinclude:: ../../../examples/ExecutionPools/Rerun/tasks.py
+
 .. _example_multiTest_parts:
 
 MultiTest parts scheduling

--- a/doc/en/pools.rst
+++ b/doc/en/pools.rst
@@ -76,8 +76,32 @@ and many Test instances can be created from the same target function:
     for idx in range(10):
         task = Task(target='make_multitest',
                     module='tasks',
-                    path=os.path.dirname(os.path.abspath(__file__)),  # same dir
+                    path=os.path.dirname(os.path.abspath(__file__)),
                     args=(idx,))  # or kwargs={'index': idx}
+
+With argument `rerun` testplan can rerun the task up to user specified times
+unless it passes:
+
+.. code-block:: python
+
+    # ./test_plan.py
+
+    task = Task(target='make_multitest',
+                module='tasks',
+                path=os.path.dirname(os.path.abspath(__file__)),
+                rerun=3)  # default value 0 means no rerun
+
+A custom funtion can be used to determine if the task needs to run again, the
+default implementation is to check that task has been executed and the status
+of report is PASS.
+
+.. code-block:: python
+
+    # ./test_plan.py
+
+    pool = ThreadPool(name="MyPool", should_rerun=custom_func)
+    # can also set the custom func later
+    pool.set_rerun_check(custom_func)
 
 TaskResult
 ++++++++++

--- a/examples/ExecutionPools/Rerun/tasks.py
+++ b/examples/ExecutionPools/Rerun/tasks.py
@@ -1,0 +1,61 @@
+"""An unstable tests to be executed until pass."""
+
+import os
+
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+from testplan.common.utils.path import makedirs
+
+
+@testsuite
+class Unstablesuite(object):
+    """
+    A test suite which has an unstable testcase.
+    The multitest containing this suite has to re-run twice
+    (3 times in total) in order to get passed.
+    """
+
+    def __init__(self, tmp_file):
+        self._iteration = None
+        self._max_rerun = 2
+        self._tmp_file = tmp_file
+
+    def setup(self, env, result):
+        """
+        Create a tmp text file which record how many times the suite
+        has been executed, should remove it after the last rerun.
+        """
+        makedirs(os.path.dirname(self._tmp_file))
+        if not os.path.exists(self._tmp_file):
+            self._iteration = 0
+        else:
+            with open(self._tmp_file, "r") as fp:
+                self._iteration = int(fp.read())
+
+        if self._iteration == self._max_rerun:
+            os.remove(self._tmp_file)
+        else:
+            with open(self._tmp_file, "w") as fp:
+                fp.write(str(self._iteration + 1))
+
+        result.log("Suite setup in iteration {}".format(self._iteration))
+
+    @testcase
+    def unstable_testcase(self, env, result):
+        """
+        An unstable testcase which can only pass at 3rd run (2nd rerun).
+        """
+        if self._iteration == 2:
+            result.log("Test passes")
+        else:
+            result.fail("Test fails")
+
+
+def make_multitest(tmp_file):
+    """
+    Creates a new MultiTest that runs unstable tests.
+    """
+    return MultiTest(
+        name="UnstableMultiTest",
+        suites=[Unstablesuite(tmp_file=tmp_file)],
+        environment=[],
+    )

--- a/examples/ExecutionPools/Rerun/test_plan.py
+++ b/examples/ExecutionPools/Rerun/test_plan.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""
+This example is to demonstrate task level rerun feature in a pool.
+"""
+
+import os
+import sys
+import uuid
+import getpass
+import tempfile
+
+from testplan import test_plan, Task
+from testplan.runners.pools import ThreadPool
+
+from testplan.parser import TestplanParser
+from testplan.report.testing.styles import Style, StyleEnum
+
+OUTPUT_STYLE = Style(StyleEnum.ASSERTION_DETAIL, StyleEnum.ASSERTION_DETAIL)
+
+
+class CustomParser(TestplanParser):
+    """Inheriting base parser."""
+
+    def add_arguments(self, parser):
+        """Defining custom arguments for this Testplan."""
+        parser.add_argument("--pool-size", action="store", type=int, default=4)
+
+
+# Using a custom parser to support `--tasks-num` and `--pool-size` command
+# line arguments so that users can experiment with process pool test execution.
+
+# Hard-coding `pdf_path`, 'stdout_style' and 'pdf_style' so that the
+# downloadable example gives meaningful and presentable output.
+# NOTE: this programmatic arguments passing approach will cause Testplan
+# to ignore any command line arguments related to that functionality.
+@test_plan(
+    name="PoolExecutionAndTaskRerun",
+    parser=CustomParser,
+    pdf_path="report.pdf",
+    stdout_style=OUTPUT_STYLE,
+    pdf_style=OUTPUT_STYLE,
+)
+def main(plan):
+    """
+    Testplan decorated main function to add and execute MultiTests.
+
+    :return: Testplan result object.
+    :rtype:  ``testplan.base.TestplanResult``
+    """
+    # Add a thread pool test execution resource to the plan of given size.
+    # Can also use a process pool instead.
+    pool = ThreadPool(name="MyPool", size=plan.args.pool_size)
+    plan.add_resource(pool)
+
+    # Add a task with `rerun` argument to the thread pool
+    tmp_file = os.path.join(
+        tempfile.gettempdir(), getpass.getuser(), "{}.tmp".format(uuid.uuid4())
+    )
+    task = Task(
+        target="make_multitest", module="tasks", args=(tmp_file,), rerun=2
+    )
+    plan.schedule(task, resource="MyPool")
+
+
+if __name__ == "__main__":
+    res = main()
+    print("Exiting code: {}".format(res.exit_code))
+    sys.exit(res.exit_code)

--- a/testplan/common/utils/interface.py
+++ b/testplan/common/utils/interface.py
@@ -166,8 +166,8 @@ def check_signature(func, args_list):
     :param args_list: list of arg names to match as signature
     :type args_list: ``list`` of ``str``
 
-    :return: ``None``
-    :rtype: ``NoneType``
+    :return: ``None`` or ``True``
+    :rtype: ``NoneType`` or ``bool``
     """
     refsig = MethodSignature(func.__name__, args_list)
     actualsig = MethodSignature.from_callable(func)

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -160,6 +160,7 @@ class ReportCategories(object):
     TESTPLAN = "testplan"
     TESTGROUP = "testgroup"  # test group of unspecific type?
     MULTITEST = "multitest"
+    TASK_RERUN = "task_rerun"
     TESTSUITE = "testsuite"
     TESTCASE = "testcase"
     PARAMETRIZATION = "parametrization"
@@ -348,6 +349,8 @@ class BaseReportGroup(ReportGroup):
         for child in self:
             if child.category == ReportCategories.ERROR:
                 counter.update({Status.ERROR: 1, "total": 1})
+            elif child.category == ReportCategories.TASK_RERUN:
+                pass
             else:
                 counter.update(child.counter)
 

--- a/testplan/runners/base.py
+++ b/testplan/runners/base.py
@@ -62,6 +62,8 @@ class Executor(Resource):
         """
         if self.active:
             self._input[uid] = item
+            # `NoRunpathPool` adds item after calling `_prepopulate_runnables`
+            # so the following step is still needed
             self.ongoing.append(uid)
 
     def get(self, uid):

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -87,6 +87,7 @@ class ChildLoop(object):
             worker_type=self._worker_type,
             size=self._pool_size,
             runpath=self.runpath,
+            should_rerun=lambda pool, task_result: False,  # always return False
         )
         self._pool.parent = self
         self._pool.cfg.parent = self._pool_cfg

--- a/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -112,6 +112,7 @@ def schedule_tests_to_pool(name, pool, schedule_path=None, **pool_cfg):
         name = "MTest{}".format(idx)
         assert plan.result.test_results[uids[idx - 1]].report.name == name
 
-    # All tasks scheduled once
-    for uid in pool.task_assign_cnt:
-        assert pool.task_assign_cnt[uid] == 1
+    # All tasks assigned once
+    for uid in pool._task_retries_cnt:
+        assert pool._task_retries_cnt[uid] == 0
+        assert pool.added_item(uid).reassign_cnt == 0

--- a/tests/functional/testplan/runners/pools/test_pool_base.py
+++ b/tests/functional/testplan/runners/pools/test_pool_base.py
@@ -2,13 +2,13 @@
 
 import os
 
-from testplan.common.utils.testing import log_propagation_disabled
-
 from testplan import Testplan, Task
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 from testplan.testing.multitest.base import MultiTestConfig
 from testplan.runners.pools.base import Pool, Worker
-from testplan.common.utils.logger import TESTPLAN_LOGGER
+
+# from testplan.common.utils.testing import log_propagation_disabled
+# from testplan.common.utils.logger import TESTPLAN_LOGGER
 
 
 @testsuite

--- a/tests/functional/testplan/runners/pools/test_pool_remote.py
+++ b/tests/functional/testplan/runners/pools/test_pool_remote.py
@@ -1,4 +1,4 @@
-"""Remote worker pool unit tests."""
+"""Remote worker pool functional tests."""
 
 import os
 import pytest

--- a/tests/functional/testplan/runners/pools/test_task_rerun.py
+++ b/tests/functional/testplan/runners/pools/test_task_rerun.py
@@ -1,0 +1,303 @@
+"""
+Task rerun feature functional tests.
+
+The task with `rerun` attribute set can be re-assign to pool if fails,
+re-assign count cannot exceed the value of `rerun`, all of the results
+should be saved.
+"""
+
+import os
+import tempfile
+import getpass
+import uuid
+
+from testplan import Testplan, Task
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+from testplan.testing.multitest.driver.base import Driver, DriverConfig
+from testplan.runners.pools import ThreadPool, ProcessPool
+from testplan.common.config import ConfigOption as Optional
+from testplan.common.utils.path import makedirs
+from testplan.report import ReportCategories
+
+
+class MockDriverConfig(DriverConfig):
+    @classmethod
+    def get_options(cls):
+        return {
+            Optional("start_raises", default=False): bool,
+            Optional("stop_raises", default=False): bool,
+        }
+
+
+class MockDriver(Driver):
+    """
+    A mock driver used to check that the environment is correctly
+    started and stopped.
+    """
+
+    CONFIG = MockDriverConfig
+
+    def __init__(self, start_raises=False, stop_raises=False, **options):
+        options.update(self.filter_locals(locals()))
+        super(MockDriver, self).__init__(**options)
+        self._start_done = False
+        self._stop_done = False
+        self._start_raises = start_raises
+        self._stop_raises = stop_raises
+
+    def starting(self):
+        super(MockDriver, self).starting()
+        if self._start_raises:
+            raise RuntimeError("MockDriver fails to start")
+        self._start_done = True
+
+    def stopping(self):
+        super(MockDriver, self).stopping()
+        if self._stop_raises:
+            raise RuntimeError("MockDriver fails to stop")
+        self._stop_done = True
+
+
+class UnstableSuiteBase(object):
+    """
+    In this test suite a temporary file is created
+    to record how many times does it run.
+    """
+
+    def __init__(self, tmp_file, max_retries):
+        self._iteration = -1
+        self._max_retries = max_retries
+        self._tmp_file = tmp_file
+
+    def setup(self, env, result):
+        makedirs(os.path.dirname(self._tmp_file))
+        if not os.path.exists(self._tmp_file):
+            self._iteration = 0
+        else:
+            with open(self._tmp_file, "r") as fp:
+                try:
+                    self._iteration = int(fp.read())
+                except Exception:
+                    self._iteration = 0
+
+        if self._iteration == self._max_retries:  # iter starts from zero
+            os.remove(self._tmp_file)
+        else:
+            with open(self._tmp_file, "w") as fp:
+                fp.write(str(self._iteration + 1))
+
+        result.log("Suite setup in iteration {}".format(self._iteration))
+
+
+@testsuite
+class UnstableSuite1(UnstableSuiteBase):
+    @testcase
+    def unstable_case(self, env, result):
+        if self._iteration == 0:
+            result.fail("Testcase fails in this iteration")
+        else:
+            result.log("Testcase passes in this iteration")
+
+    @testcase
+    def unstable_driver(self, env, result):
+        if self._iteration == 1:
+            env.mock_driver._stop_raises = True
+        else:
+            result.log("MockDriver does not raise in this iteration")
+
+
+@testsuite
+class UnstableSuite2(UnstableSuiteBase):
+    @testcase
+    def unstable_worker(self, env, result):
+        if self._iteration == 0:
+            result.log("Kill the runner")
+            os._exit(1)
+        result.log("Do not kill the runner in this iteration")
+
+
+@testsuite
+class UnstableSuite3(UnstableSuiteBase):
+    @testcase
+    def unstable_case(self, env, result):
+        if self._iteration > 2:
+            result.log("Testcase passes after retry 3 times")
+        else:
+            result.fail("Testcase fails in this iteration")
+
+
+def make_multitest_1(tmp_file):
+    return MultiTest(
+        name="Unstable MTest1",
+        description="MultiTest that fails in iteration 0 & 1, and passes on 2",
+        suites=[UnstableSuite1(tmp_file=tmp_file, max_retries=2)],
+        environment=[MockDriver(name="mock_driver")],
+    )
+
+
+def make_multitest_2(tmp_file):
+    return MultiTest(
+        name="Unstable MTest2",
+        description="MultiTest that fails in iteration 0, and passes on 1",
+        suites=[UnstableSuite2(tmp_file=tmp_file, max_retries=1)],
+        environment=[],
+    )
+
+
+def make_multitest_3(tmp_file):
+    return MultiTest(
+        name="Unstable MTest3",
+        description="MultiTest that passes until iteration 4",
+        suites=[UnstableSuite3(tmp_file=tmp_file, max_retries=4)],
+        environment=[],
+    )
+
+
+def _remove_existing_tmp_file(tmp_file):
+    """Make sure the temporary file is removed."""
+    if os.path.isfile(tmp_file):
+        os.remove(tmp_file)
+
+
+def test_task_rerun_in_thread_pool():
+    """
+    Test procedure:
+      - 1st run: `unstable_case` fails.
+      - 1st rerun: `mock_driver` raises during stop.
+      - 2nd rerun: all pass.
+    """
+    pool_name = ThreadPool.__name__
+    plan = Testplan(name="Plan", parse_cmdline=False)
+    pool = ThreadPool(name=pool_name, size=2)
+    plan.add_resource(pool)
+
+    directory = os.path.dirname(os.path.abspath(__file__))
+    tmp_file = os.path.join(
+        tempfile.gettempdir(), getpass.getuser(), "{}.tmp".format(uuid.uuid4())
+    )
+    task = Task(
+        target=make_multitest_1, path=directory, args=(tmp_file,), rerun=2
+    )
+    uid = plan.schedule(task=task, resource=pool_name)
+
+    assert plan.run().run is True
+    assert plan.report.passed is True
+    assert plan.report.counter == {"passed": 3, "total": 3, "failed": 0}
+
+    assert isinstance(plan.report.serialize(), dict)
+    assert plan.result.test_results[uid].report.name == "Unstable MTest1"
+    assert len(plan.report.entries) == 3
+    assert plan.report.entries[-1].category == ReportCategories.TASK_RERUN
+    assert plan.report.entries[-2].category == ReportCategories.TASK_RERUN
+
+    assert task.reassign_cnt == 2
+    _remove_existing_tmp_file(tmp_file)
+
+
+def test_task_rerun_in_process_pool():
+    """
+    Test 1 procedure:
+      - 1st run: `unstable_case` fails.
+      - 1st rerun: `mock_driver` raises during stop.
+      - 2nd rerun: all pass.
+    Test 2 procedure:
+      - 1st run: `unstable_worker` makes child process exit.
+      - monitor detects inactive worker, decommission the task from worker,
+        then re-assign it and it passes (no rerun is needed).
+    """
+    pool_name = ProcessPool.__name__
+    plan = Testplan(name="Plan", parse_cmdline=False)
+    pool = ProcessPool(name=pool_name, size=2)
+    plan.add_resource(pool)
+
+    directory = os.path.dirname(os.path.abspath(__file__))
+    tmp_file_1 = os.path.join(
+        tempfile.gettempdir(), getpass.getuser(), "{}.tmp".format(uuid.uuid4())
+    )
+    tmp_file_2 = os.path.join(
+        tempfile.gettempdir(), getpass.getuser(), "{}.tmp".format(uuid.uuid4())
+    )
+    task1 = Task(
+        target=make_multitest_1, path=directory, args=(tmp_file_1,), rerun=2
+    )
+    task2 = Task(
+        target=make_multitest_2, path=directory, args=(tmp_file_2,), rerun=0
+    )
+    uid1 = plan.schedule(task=task1, resource=pool_name)
+    uid2 = plan.schedule(task=task2, resource=pool_name)
+
+    assert plan.run().run is True
+    assert plan.report.passed is True
+    assert plan.report.counter == {"passed": 5, "total": 5, "failed": 0}
+
+    assert isinstance(plan.report.serialize(), dict)
+    assert plan.result.test_results[uid1].report.name == "Unstable MTest1"
+    assert plan.result.test_results[uid2].report.name == "Unstable MTest2"
+    assert len(plan.report.entries) == 4
+    assert plan.report.entries[-1].category == ReportCategories.TASK_RERUN
+    assert plan.report.entries[-2].category == ReportCategories.TASK_RERUN
+
+    assert task1.reassign_cnt == 2
+    assert task2.reassign_cnt == 0  # 1st run: assigned but not executed
+    assert pool._task_retries_cnt[uid2] == 1
+    _remove_existing_tmp_file(tmp_file_1)
+    _remove_existing_tmp_file(tmp_file_2)
+
+
+def test_task_rerun_with_more_times():
+    """
+    Test procedure 1:
+      (set `task_rerun_limit` to 2, a task can be scheduled 3 times in total)
+      - 1st run: `unstable_case` fails.
+      - 1st rerun: `unstable_case` fails.
+      - 2nd rerun: `unstable_case` fails.
+
+    Test procedure 2:
+      (set `task_rerun_limit` to 4, a task can be scheduled 5 times in total)
+      - 1st run: `unstable_case` fails.
+      - 1st rerun: `unstable_case` fails.
+      - 2nd rerun: `unstable_case` fails.
+      - 3rd rerun: all pass.
+    """
+    pool_name = ThreadPool.__name__
+    plan = Testplan(name="Plan", parse_cmdline=False)
+    pool = ThreadPool(name=pool_name, size=1)
+    plan.add_resource(pool)
+
+    directory = os.path.dirname(os.path.abspath(__file__))
+    tmp_file = os.path.join(
+        tempfile.gettempdir(), getpass.getuser(), "{}.tmp".format(uuid.uuid4())
+    )
+    task = Task(
+        target=make_multitest_3, path=directory, args=(tmp_file,), rerun=2
+    )
+    uid = plan.schedule(task=task, resource=pool_name)
+
+    assert plan.run().run is True
+    assert plan.report.passed is False
+    assert plan.report.counter == {"passed": 1, "total": 2, "failed": 1}
+    assert plan.result.test_results[uid].report.name == "Unstable MTest3"
+
+    assert task.reassign_cnt == 2
+    # test fails, should manually remove it
+    _remove_existing_tmp_file(tmp_file)
+
+    plan = Testplan(name="Plan", parse_cmdline=False)
+    pool = ThreadPool(name=pool_name, size=1)
+    plan.add_resource(pool)
+
+    tmp_file = os.path.join(
+        tempfile.gettempdir(), getpass.getuser(), "{}.tmp".format(uuid.uuid4())
+    )
+    task = Task(
+        target=make_multitest_3, path=directory, args=(tmp_file,), rerun=3
+    )
+    uid = plan.schedule(task=task, resource=pool_name)
+
+    assert plan.run().run is True
+    assert plan.report.passed is True
+    assert plan.report.counter == {"passed": 2, "total": 2, "failed": 0}
+    assert plan.result.test_results[uid].report.name == "Unstable MTest3"
+
+    assert task.reassign_cnt == 3
+    _remove_existing_tmp_file(tmp_file)

--- a/tests/unit/testplan/runners/pools/test_pool_base.py
+++ b/tests/unit/testplan/runners/pools/test_pool_base.py
@@ -156,7 +156,7 @@ class TestPoolIsolated:
             worker._is_alive = False
             assert pool._query_worker_status(worker) == (
                 "inactive",
-                "Deco {}, handler no longer alive".format(worker),
+                "Decommission {}, handler no longer alive".format(worker),
             )
 
             assert pool._handle_inactive(worker, "test restart") == True


### PR DESCRIPTION
* Implement task rerun feature, it has default implementation (check
  if test pass) but can also be decided by end users.
* Add a `rerun` argument to `Task`, when a task running in `Pool`
  fails, testplan will automatically re-assign it to a worker.
* Intermediate task report should be appended to the end.
* Pool has a member `_task_retries_limit`, it is used to restrict
  the total times a task is re-assigned due to some error (e.g. worker
  died), while property `rerun` of a task is used to restrict the total
  it can reassigned and run if `should_rerun` returns True.
* Some simple interfaces for derived Pool classes in the future.
* New testcase for rerun feature.
* Update document and examples.