### PR TITLE
Add a fixture that returns pytest rootdir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial  # required for Python >= 3.7
+dist: bionic
 language: python
 
 env:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,3 +29,11 @@ def repo_root_path():
     # This file is at tests/conftest.py. It should not be moved, since it
     # defines global pytest fixtures for all tests.
     return os.path.join(os.path.dirname(__file__), os.pardir)
+
+
+@pytest.fixture(scope="session")
+def root_directory(pytestconfig):
+    """
+    Return the root directory of pyTest config as a string.
+    """
+    return str(pytestconfig.rootdir)

--- a/tests/unit/testplan/testing/test_pytest.py
+++ b/tests/unit/testplan/testing/test_pytest.py
@@ -13,7 +13,7 @@ from tests.unit.testplan.testing import pytest_expected_data
 
 
 @pytest.fixture
-def pytest_test_inst(repo_root_path):
+def pytest_test_inst(repo_root_path, root_directory):
     """Return a PyTest test instance, with the example tests as its target."""
     # For testing purposes, we want to run the pytest example at
     # examples/PyTest/pytest_tests.py.
@@ -21,7 +21,7 @@ def pytest_test_inst(repo_root_path):
         repo_root_path, "examples", "PyTest", "pytest_tests.py"
     )
 
-    rootdir = os.path.commonprefix([str(pytest.config.rootdir), os.getcwd()])
+    rootdir = os.path.commonprefix([root_directory, os.getcwd()])
 
     # We need to explicitly set the stdout_style in UT, normally it is inherited
     # from the parent object but that doesn't work when testing PyTest in


### PR DESCRIPTION
* As pyTest version updated `pytest.config` object cannot be directly
  accessed, provides a fixture to access the `rootdir` from config.
* Update .travis.yml file to fix build issue.