### PR TITLE
Fix '--browse' argument cannot work

### DIFF
--- a/testplan/exporters/testing/webserver/base.py
+++ b/testplan/exporters/testing/webserver/base.py
@@ -50,6 +50,14 @@ class WebServerExporter(Exporter):
 
     CONFIG = WebServerExporterConfig
 
+    def __init__(self, **options):
+        super(WebServerExporter, self).__init__(**options)
+        self._report_url = None
+
+    @property
+    def report_url(self):
+        return self._report_url
+
     def export(self, source):
         """Serve the web UI locally for our test report."""
         if not len(source):
@@ -102,6 +110,7 @@ class WebServerExporter(Exporter):
         )
 
         (host, port) = self._web_server_thread.server.bind_addr
+        self._report_url = "http://localhost:{}/testplan/local".format(port)
 
         self.logger.exporter_info(
             "View the JSON report in the browser:\n%s",

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -246,8 +246,10 @@ Test filter, runs tests that match ALL of the given tags.
             "--browse",
             action="store_true",
             dest="browse",
-            help="Automatically open report to browse. Must be specifed with "
-            '"--pdf" or "--json --ui" or there will be nothing to open.',
+            help="Automatically open report to browse. Must be specified "
+            'with "--ui" to open it locally, or upload it to a web server '
+            "with a customized exporter which has a `report_url`, or there "
+            "will be nothing to open.",
         )
 
         report_group.add_argument(

--- a/tests/functional/exporters/testing/test_webserver.py
+++ b/tests/functional/exporters/testing/test_webserver.py
@@ -12,7 +12,7 @@ import requests
 from testplan.common.utils.process import kill_process
 
 _TIMEOUT = 60
-_REQUEST_TIMEOUT = 0.1
+_REQUEST_TIMEOUT = 0.5
 _URL_RE = re.compile(r"^\s*Local: (?P<url>[^\s]+)\s*$")
 
 


### PR DESCRIPTION
* When there is a customized exporter and save the web link in
  `report_url` property and `--browse` argument specified for
  testplan, after finishing the test web browser should be able
  to automatically open the link.
* When there are customized exporters with `report_url` property,
  open all of them, but if there's `--ui` argument specified, then 
  open the report locally with prioirty.