### PR TITLE
Fix Newly created worker may raise when pool is exiting

### DIFF
--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -664,7 +664,7 @@ class Pool(Executor):
             worker.status.STOPPING,
             worker.status.STOPPED,
         ):
-            return "inactive", "Worker in stop/abort status"
+            return "inactive", "Worker {} in stop/abort status"
 
         if worker.status.tag in (worker.status.NONE, worker.status.STARTING):
             return "initializing", None
@@ -700,9 +700,13 @@ class Pool(Executor):
     def _handle_inactive(self, worker, reason):
         """
         Handle an inactive worker.
+
         :param worker: worker object
+        :type worker: :py:class:`~testplan.runners.pool.base.Worker`
         :param reason: why worker is considered inactive
+        :type reason: ``str``
         :return: True if worker restarted, else False
+        :rtype: ``bool``
         """
         if worker.status.tag != worker.status.STARTED:
             return False

--- a/testplan/runners/pools/connection.py
+++ b/testplan/runners/pools/connection.py
@@ -56,8 +56,8 @@ class Client(logger.Loggable):
         :param message: Message sent.
         :type message:
             :py:class:`~testplan.runners.pools.communication.Message`
-        :param expect: Assert message received command is the expected.
-        :type expect: ``NoneType`` or
+        :param expect: Expected command of message received.
+        :type expect: ``NoneType`` or ``tuple`` or ``list`` or
             :py:class:`~testplan.runners.pools.communication.Message`
         :return: Message received.
         :rtype: ``object``
@@ -82,7 +82,10 @@ class Client(logger.Loggable):
                 raise RuntimeError(
                     "Received None when {} was expected.".format(expect)
                 )
-            assert received.cmd == expect
+            if isinstance(expect, (tuple, list)):
+                assert received.cmd in expect
+            else:
+                assert received.cmd == expect
         return received
 
 


### PR DESCRIPTION
* A worker communicates with its parent, sending a message and get the
  response. When a worker is created, e.g. unexpectedly abort and then
  re-created, it should receive a `ConfigSending` message, but if at
  this point all task is finished then an `Stop` message arrives, there
  will be stack information of error logged, which might lead to
  misunderstanding.
* Fix a log message which is not correctly formatted during handling
  inactive workers.