### PR TITLE
Clean up indentations from docstrings

### DIFF
--- a/testplan/common/utils/strings.py
+++ b/testplan/common/utils/strings.py
@@ -4,6 +4,7 @@ import sys
 
 import re
 import os
+import inspect
 import unicodedata
 import textwrap
 import six
@@ -219,3 +220,17 @@ def indent(lines_str, indent_size=2):
         "{indent}{line}".format(indent=indent, line=line)
         for line in lines_str.splitlines()
     )
+
+
+def get_docstring(obj):
+    """
+    Get object docstring without leading whitespace.
+    :param obj: Object to be extracted docstring.
+    :type obj: ``object``
+    :return: Docstring of the object.
+    :rtype: ``str`` or ``NoneType``
+    """
+    if hasattr(obj, "__doc__"):
+        if obj.__doc__:
+            return inspect.cleandoc(obj.__doc__)
+    return None

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -23,6 +23,7 @@ from testplan.common.utils import interface
 from testplan.common.utils import validation
 from testplan.common.utils import timing
 from testplan.common.utils import callable as callable_utils
+from testplan.common.utils import strings
 import testplan.report
 from testplan.testing import tagging
 from testplan.testing import filtering
@@ -537,7 +538,7 @@ class MultiTest(testing_base.Test):
         """
         return testplan.report.TestGroupReport(
             name=mtest_suite.get_testsuite_name(testsuite),
-            description=testsuite.__class__.__doc__,
+            description=strings.get_docstring(testsuite.__class__),
             category=testplan.report.ReportCategories.TESTSUITE,
             uid=mtest_suite.get_testsuite_name(testsuite),
             tags=testsuite.__tags__,
@@ -550,7 +551,7 @@ class MultiTest(testing_base.Test):
         """
         return testplan.report.TestCaseReport(
             name=testcase.__name__,
-            description=testcase.__doc__,
+            description=strings.get_docstring(testcase),
             uid=testcase.__name__,
             tags=testcase.__tags__,
         )
@@ -888,7 +889,7 @@ class MultiTest(testing_base.Test):
 
             testcase_report = testplan.report.TestCaseReport(
                 name="{} - {}".format(label, func.__name__),
-                description=func.__doc__,
+                description=strings.get_docstring(func),
             )
 
             num_args = len(callable_utils.getargspec(func).args)


### PR DESCRIPTION
Excessive whitespace is displayed at the top of the report panel docstrings