### PR TITLE
Fix 3 issues about runpath

### DIFF
--- a/testplan/common/config/base.py
+++ b/testplan/common/config/base.py
@@ -123,6 +123,19 @@ class Config(object):
             self.__class__.__name__, self._cfg_input or self._options
         )
 
+    def get_local(self, name, default=None):
+        """Returns a local config setting (not from container)"""
+        options = self.__getattribute__("_options")
+
+        # this option is defined in current entity
+        if name in options:
+            # has user specified or valid default value
+            if options[name] is not ABSENT:
+                return options[name]
+
+        else:
+            return default
+
     @property
     def parent(self):
         """Returns the parent configuration."""

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -96,6 +96,7 @@ class TestRunnerIHandler(entity.Entity):
         )
         self._http_handler = self._setup_http_handler()
         self._pool = futures.ThreadPoolExecutor(max_workers=1)
+        self.target.make_runpath_dirs()
 
     def run(self):
         """

--- a/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -10,6 +10,7 @@ from testplan.common.utils.testing import log_propagation_disabled
 from testplan.common.utils.path import fix_home_prefix
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 from testplan.testing.multitest.base import MultiTestConfig
+from testplan.common.utils.strings import slugify
 
 
 @testsuite
@@ -20,7 +21,7 @@ class MySuite(object):
         result.log(env.runpath)
         assert isinstance(env.cfg, MultiTestConfig)
         assert os.path.exists(env.runpath) is True
-        assert env.runpath.endswith(env.cfg.name)
+        assert env.runpath.endswith(slugify(env.cfg.name))
 
 
 def get_mtest(name):
@@ -49,7 +50,7 @@ class SuiteKillingWorker(object):
         result.log(env.runpath)
         assert isinstance(env.cfg, MultiTestConfig)
         assert os.path.exists(env.runpath) is True
-        assert env.runpath.endswith(env.cfg.name)
+        assert env.runpath.endswith(slugify(env.cfg.name))
 
 
 def multitest_kill_one_worker(name, parent_pid, size):

--- a/tests/functional/testplan/runners/pools/test_pool_base.py
+++ b/tests/functional/testplan/runners/pools/test_pool_base.py
@@ -6,6 +6,7 @@ from testplan import Testplan, Task
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 from testplan.testing.multitest.base import MultiTestConfig
 from testplan.runners.pools.base import Pool, Worker
+from testplan.common.utils.strings import slugify
 
 # from testplan.common.utils.testing import log_propagation_disabled
 # from testplan.common.utils.logger import TESTPLAN_LOGGER
@@ -18,7 +19,7 @@ class MySuite(object):
         result.equal(1, 1, "equality description")
         assert isinstance(env.cfg, MultiTestConfig)
         assert os.path.exists(env.runpath)
-        assert env.runpath.endswith(env.cfg.name)
+        assert env.runpath.endswith(slugify(env.cfg.name))
 
 
 def get_mtest():

--- a/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -19,6 +19,7 @@ from testplan.testing.multitest.driver.base import Driver
 from testplan.testing.multitest.driver.tcp import TCPServer, TCPClient
 
 from testplan.common.utils.logger import TESTPLAN_LOGGER
+from testplan.common.utils.strings import slugify
 
 
 @testsuite
@@ -146,7 +147,9 @@ def test_multitest_drivers_in_testplan(runpath):
             assert plan.runpath == runpath
         else:
             assert plan.runpath == default_runpath(plan._runnable)
-        assert mtest.runpath == os.path.join(plan.runpath, mtest.uid())
+        assert mtest.runpath == os.path.join(
+            plan.runpath, slugify(mtest.uid())
+        )
         assert server.runpath == os.path.join(mtest.runpath, server.uid())
         assert client.runpath == os.path.join(mtest.runpath, client.uid())
         assert server.status.tag == ResourceStatus.STOPPED

--- a/tests/unit/testplan/runnable/interactive/test_irunner.py
+++ b/tests/unit/testplan/runnable/interactive/test_irunner.py
@@ -18,6 +18,7 @@ from testplan.testing import multitest
 from testplan.testing import ordering
 from testplan.runnable.interactive import base
 from testplan.testing.multitest import driver
+from testplan.common.utils.path import default_runpath
 
 
 @multitest.testsuite
@@ -46,6 +47,8 @@ def test_startup():
         irunner = base.TestRunnerIHandler(target)
 
         irunner.setup()
+        assert irunner.target.runpath == default_runpath(target)
+
         mock_server.prepare.assert_called_once()
         mock_server.bind_addr = ("hostname", 1234)
         assert irunner.http_handler_info == mock_server.bind_addr


### PR DESCRIPTION
1) custom runpath specified for driver is ignored - make local config setting higher precedence
2) interactive mode runpath is missing the testplan layer - TestRunnerIHandler shall call TestRunner's
make_runpath_dirs()
3) slugify runpath