### PR TITLE
Add treshold for infinite scroll loading

### DIFF
--- a/testplan/web_ui/testing/src/AssertionPane/InfiniteScroll.js
+++ b/testplan/web_ui/testing/src/AssertionPane/InfiniteScroll.js
@@ -11,12 +11,15 @@ library.add(
   faCaretSquareUp
 );
 
+const BOTTOM_DISTANCE_TRESHOLD = 5;
+
 /**
  * A scrollable container that after rendering an initial amount of items will
  * only render the rest of them (in chunks) if they are required, or in this
  * case, when the user scrolls to the bottom of the container.
  */
-class InfiniteScroll extends Component {
+class InfiniteScroll extends Component {  
+
   constructor(props) {
     super(props);
 
@@ -41,7 +44,9 @@ class InfiniteScroll extends Component {
    * @public
    */
   static isContainerScrolledToTheBottom(el) {
-    return el.getScrollHeight() - el.getScrollTop() === el.getClientHeight();
+    const distanceFromBottom = el.getScrollHeight() - 
+                              (el.getScrollTop() + el.getClientHeight());
+    return  distanceFromBottom < BOTTOM_DISTANCE_TRESHOLD;
   }
 
   /**


### PR DESCRIPTION
- in chrome at 75% zoom the scroll can be a not integer.
- some time it can go to negative as well.

using a treshold in stead of equality this could not happen