### PR TITLE
Json report can be split into smaller ones

### DIFF
--- a/examples/Test Output/Console Output/Basic Configuration/test_plan.py
+++ b/examples/Test Output/Console Output/Basic Configuration/test_plan.py
@@ -111,11 +111,7 @@ style_4_b = Style(passing=StyleEnum.TEST, failing=StyleEnum.TESTSUITE)
 
 
 # Replace the `stdout_style` argument with the styles defined
-#  above to see how they change console output.
-
-# If you want to test out command line configuration for console output
-# please remove `stdout_style` argument completely as programmatic
-# declaration overrides the command line.
+# above to see how they change console output.
 
 
 @test_plan(

--- a/examples/Test Output/Exporters/JSON/json_to_pdf.py
+++ b/examples/Test Output/Exporters/JSON/json_to_pdf.py
@@ -15,8 +15,10 @@ def main(source, target):
 
     with open(source) as source_file:
         data = json.loads(source_file.read())
-        report_obj = TestReport.deserialize(data)
+        if data.get("split"):
+            raise RuntimeError("Cannot process JSON report that was split")
 
+        report_obj = TestReport.deserialize(data)
         print("Loaded report: {}".format(report_obj.name))
 
         # We can initialize an exporter object directly, without relying on

--- a/examples/Test Output/Exporters/JSON/test_plan.py
+++ b/examples/Test Output/Exporters/JSON/test_plan.py
@@ -66,9 +66,9 @@ class BetaSuite(object):
 
 # <report-path> should be valid system file path.
 
-# If you want to test out command line configuration for JSON generation please
-# remove `json_path` arguments from below as
-# programmatic declaration overrides command line arguments.
+# If you want to test out command line configuration for JSON generation
+# please directly use --json argument because command line arguments can
+# override programmatic declaration.
 
 # After running this example, you can see how a JSON can be converted back
 # into a report object via `json_to_pdf.py` script.

--- a/examples/Test Output/Exporters/PDF/Basic PDF Report/test_plan.py
+++ b/examples/Test Output/Exporters/PDF/Basic PDF Report/test_plan.py
@@ -73,9 +73,9 @@ class BetaSuite(object):
 # <report-path> should be valid system file path and <report-style> should be
 # one of: `result-only`, `summary`, `extended-summary`, `detailed`.
 
-# If you want to test out command line configuration for PDF generation please
-# remove `pdf_path` and `pdf_style` arguments from below as
-# programmatic declaration overrides command line arguments.
+# If you want to test out command line configuration for PDF generation
+# please directly use --pdf argument because command line arguments can
+# override programmatic declaration.
 
 
 @test_plan(

--- a/examples/Test Output/Exporters/PDF/Tag Filtered PDF Report/test_plan.py
+++ b/examples/Test Output/Exporters/PDF/Tag Filtered PDF Report/test_plan.py
@@ -70,10 +70,10 @@ class BetaSuite(object):
 # You can use `pdf_style` argument to apply common styling to all
 # generated PDF reports.
 
-# If you want to test out command line configuration for PDF generation please
-# remove `report_tags`, `report_tags_all`, `report_dir` and `pdf_style`
-# arguments from below as programmatic declaration overrides
-# command line arguments.
+# If you want to test out command line configuration for PDF generation
+# please directly use --report-tags, --report-tags-all, --report-dir and
+# --pdf-style arguments because command line arguments can override
+# programmatic declaration.
 
 # An example command line call for tag filtered PDFs would be:
 # ./test_plan --report-dir . --report-tags server color=red,blue

--- a/examples/Test Output/Exporters/XML/test_plan.py
+++ b/examples/Test Output/Exporters/XML/test_plan.py
@@ -44,6 +44,10 @@ class BetaSuite(object):
 # <xml-directory> should be a valid system directory, if this directory already
 # exists it will be removed and recreated.
 
+# If you want to test out command line configuration for XML generation
+# please directly use --xml argument because command line arguments can
+# override programmatic declaration.
+
 
 @test_plan(
     name="Basic XML Report Example",

--- a/testplan/exporters/testing/base.py
+++ b/testplan/exporters/testing/base.py
@@ -1,7 +1,7 @@
 import os
 from shutil import copyfile
 
-from schema import Schema, Use, Or
+from schema import Use
 
 from testplan.common.config import ConfigOption
 from testplan.common.exporters import BaseExporter, ExporterConfig

--- a/testplan/exporters/testing/http/__init__.py
+++ b/testplan/exporters/testing/http/__init__.py
@@ -63,7 +63,7 @@ class HTTPExporter(Exporter):
         response = None
         errmsg = ""
 
-        if data and data["entries"]:
+        if data and (data.get("entries") or data.get("split")):
             headers = {"Content-Type": "application/json"}
             try:
                 response = requests.post(

--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -6,14 +6,17 @@ from __future__ import absolute_import
 
 import os
 import json
+import copy
+import hashlib
 
 from testplan import defaults
 
 from testplan.common.config import ConfigOption
 from testplan.common.exporters import ExporterConfig
+from testplan.common.utils.path import makedirs
 
+from testplan.report import ReportCategories
 from testplan.report.testing.schemas import TestReportSchema
-
 
 from ..base import Exporter, save_attachments
 
@@ -27,7 +30,13 @@ class JSONExporterConfig(ExporterConfig):
 
     @classmethod
     def get_options(cls):
-        return {ConfigOption("json_path"): str}
+        return {
+            ConfigOption("json_path"): str,
+            # By default a single JSON file should be exported, with cfg option
+            # `split_json_report` enabled it generates a main JSON file with 2
+            # attachments, this is useful when there's some limit on file size.
+            ConfigOption("split_json_report", default=False): bool,
+        }
 
 
 class JSONExporter(Exporter):
@@ -36,6 +45,8 @@ class JSONExporter(Exporter):
 
     :param json_path: File path for saving json report.
     :type json_path: ``str``
+    :param split_json_report: Split a single json report into several parts.
+    :type split_json_report: ``bool``
 
     Also inherits all
     :py:class:`~testplan.exporters.testing.base.Exporter` options.
@@ -50,16 +61,46 @@ class JSONExporter(Exporter):
         if len(source):
             test_plan_schema = TestReportSchema(strict=True)
             data = test_plan_schema.dump(source).data
-
-            # Save the Testplan report.
-            with open(json_path, "w") as json_file:
-                json.dump(data, json_file)
-
-            # Save any attachments.
             attachments_dir = os.path.join(
                 os.path.dirname(json_path), defaults.ATTACHMENTS
             )
-            save_attachments(report=source, directory=attachments_dir)
+
+            # Save the Testplan report.
+            if self.cfg.split_json_report:
+                basename, _ = os.path.splitext(os.path.basename(json_path))
+                digest = hashlib.md5(
+                    os.path.realpath(json_path).encode("utf-8")
+                ).hexdigest()
+
+                attachment_1 = "{}-structure-{}.json".format(basename, digest)
+                attachment_2 = "{}-assertions-{}.json".format(basename, digest)
+                attachment_filepath_1 = os.path.join(
+                    attachments_dir, attachment_1
+                )
+                attachment_filepath_2 = os.path.join(
+                    attachments_dir, attachment_2
+                )
+
+                meta, structure, assertions = self.split_json_report(data)
+                makedirs(attachments_dir)
+
+                with open(attachment_filepath_1, "w") as json_file:
+                    json.dump(structure, json_file)
+                with open(attachment_filepath_2, "w") as json_file:
+                    json.dump(assertions, json_file)
+
+                save_attachments(report=source, directory=attachments_dir)
+                # Modify json data may change the original `TestReport` object
+                meta["attachments"] = copy.deepcopy(meta["attachments"])
+                meta["attachments"][attachment_1] = attachment_filepath_1
+                meta["attachments"][attachment_2] = attachment_filepath_2
+
+                with open(json_path, "w") as json_file:
+                    json.dump(meta, json_file)
+            else:
+                save_attachments(report=source, directory=attachments_dir)
+                with open(json_path, "w") as json_file:
+                    json.dump(data, json_file)
 
             self.logger.exporter_info(
                 "JSON generated at %s", os.path.abspath(json_path)
@@ -68,3 +109,52 @@ class JSONExporter(Exporter):
             self.logger.exporter_info(
                 "Skipping JSON creation for empty report: %s", source.name
             )
+
+    @staticmethod
+    def split_json_report(data):
+        """Split a single Json into several parts."""
+
+        def split_assertions(entries, assertions):
+            """Remove assertions from report and place them in a dictionary."""
+            for entry in entries:
+                if entry.get("category") == ReportCategories.TESTCASE:
+                    assertions[entry["name"]] = entry["entries"]
+                    entry["entries"] = []
+                elif "entries" in entry:
+                    assertions.setdefault(entry["name"], {})
+                    split_assertions(
+                        entry["entries"], assertions[entry["name"]]
+                    )
+
+        meta, structure, assertions = data, data["entries"], {data["name"]: {}}
+        meta["split"] = True
+        meta["entries"] = []
+        split_assertions(structure, assertions[meta["name"]])
+        return meta, structure, assertions
+
+    @staticmethod
+    def merge_json_report(meta, structure, assertions, strict=True):
+        """Merge parts of json report into a single one."""
+
+        def merge_assertions(entries, assertions, strict=True):
+            """Fill assertions into report by the unique id."""
+            for entry in entries:
+                if entry.get("category") == ReportCategories.TESTCASE:
+                    try:
+                        dictionary = assertions
+                        for key in entry["parent_uids"]:
+                            dictionary = dictionary[key]
+                        entry["entries"] = dictionary[entry["name"]]
+                    except KeyError as err:
+                        if strict:
+                            raise RuntimeError(
+                                "Assertion key not found: {}".format(str(err))
+                            )
+                elif "entries" in entry:
+                    merge_assertions(entry["entries"], assertions, strict)
+
+        merge_assertions(structure, assertions, strict)
+        meta["entries"] = structure
+        if "split" in meta:
+            del meta["split"]
+        return meta

--- a/testplan/exporters/testing/xml/__init__.py
+++ b/testplan/exporters/testing/xml/__init__.py
@@ -1,9 +1,10 @@
 """
     XML Export logic for test reports.
 """
-import socket
 import os
+import socket
 import shutil
+from collections import Counter
 
 from lxml import etree
 from lxml.builder import E  # pylint: disable=no-name-in-module
@@ -22,7 +23,6 @@ from testplan.report import (
 )
 
 from ..base import Exporter
-from collections import Counter
 
 
 class BaseRenderer(object):

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -236,24 +236,18 @@ Test filter, runs tests that match ALL of the given tags.
             "-v",
             "--verbose",
             action="store_true",
-            dest="verbose",
             help="Enable verbose mode that will also set the stdout-style "
             'option to "detailed".',
         )
 
         report_group.add_argument(
-            "-d",
-            "--debug",
-            action="store_true",
-            dest="debug",
-            help="Enable debug mode.",
+            "-d", "--debug", action="store_true", help="Enable debug mode.",
         )
 
         report_group.add_argument(
             "-b",
             "--browse",
             action="store_true",
-            dest="browse",
             help="Automatically open report to browse. Must be specified "
             'with "--ui" to open it locally, or upload it to a web server '
             "with a customized exporter which has a `report_url`, or there "
@@ -343,9 +337,9 @@ that match ALL of the given tags.
                 seed=args["shuffle_seed"], shuffle_type=args["shuffle"]
             )
 
-        # We can set arguments in @test_plan decorator or by comman line, for
-        # arguments in boolean type if in one place it set tp True, then the
-        # final result is True
+        # We can set arguments in @test_plan decorator or by command line, for
+        # arguments in boolean type if in one place it is set to True, then
+        # the final result is True
         args["browse"] = args["browse"] or self._default_options["browse"]
         args["verbose"] = args["verbose"] or self._default_options["verbose"]
         args["debug"] = args["debug"] or self._default_options["debug"]

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -170,6 +170,8 @@ class ReportCategories(object):
     CPPUNIT_SUITE = "cppunit-suite"
     BOOST_TEST = "boost-test"
     BOOST_SUITE = "boost-suite"
+    PYTEST = "pytest"
+    PYUNIT = "pyunit"
     UNITTEST = "unittest"
     QUNIT = "qunit"
     ERROR = "error"

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -317,7 +317,8 @@ class TestRunner(Runnable):
     def get_default_exporters(self):
         """
         Instantiate certain exporters if related cmdline argument (e.g. --pdf)
-        is passed but there aren't any exporter declarations.
+        or programmatic arguments (e.g. pdf_path) is passed but there are not
+        any exporter declarations.
         """
         exporters = []
         if self.cfg.pdf_path:

--- a/tests/functional/exporters/testing/test_http.py
+++ b/tests/functional/exporters/testing/test_http.py
@@ -80,7 +80,7 @@ def test_http_exporter(http_server):
     plan = Testplan(
         name="plan",
         parse_cmdline=False,
-        exporters=HTTPExporter(http_url=http_url),
+        exporters=[HTTPExporter(http_url=http_url)],
     )
     multitest_1 = multitest.MultiTest(name="Primary", suites=[Alpha()])
     multitest_2 = multitest.MultiTest(name="Secondary", suites=[Beta()])

--- a/tests/functional/exporters/testing/test_json.py
+++ b/tests/functional/exporters/testing/test_json.py
@@ -1,6 +1,7 @@
 """Test the JSON exporter."""
 import json
 import os
+import hashlib
 import tempfile
 
 from testplan.testing import multitest
@@ -34,7 +35,7 @@ class Beta(object):
     @multitest.testcase
     def test_failure(self, env, result):
         result.equal(1, 2, "failing assertion")
-        result.equal(5, 10)
+        result.not_equal(5, 5)
 
     @multitest.testcase
     def test_error(self, env, result):
@@ -50,7 +51,7 @@ def test_json_exporter(tmpdir):
     plan = Testplan(
         name="plan",
         parse_cmdline=False,
-        exporters=JSONExporter(json_path=json_path),
+        exporters=[JSONExporter(json_path=json_path)],
     )
     multitest_1 = multitest.MultiTest(name="Primary", suites=[Alpha()])
     multitest_2 = multitest.MultiTest(name="Secondary", suites=[Beta()])
@@ -69,12 +70,103 @@ def test_json_exporter(tmpdir):
     attachments_dir = os.path.join(os.path.dirname(json_path), "_attachments")
     assert os.path.isdir(attachments_dir)
     assert len(report["attachments"]) == 1
+
     dst_path = list(report["attachments"].keys())[0]
     attachment_filepath = os.path.join(attachments_dir, dst_path)
     assert os.path.isfile(attachment_filepath)
+
     with open(attachment_filepath) as f:
         attachment_file_contents = f.read()
     assert attachment_file_contents == "testplan\n" * 100
+
+
+def test_json_exporter_split_report(tmpdir):
+    """
+    JSON Exporter should generate a json report at the given `json_path`.
+    """
+    tmp_dir = tmpdir.mkdir("reports")
+    json_path = tmp_dir.join("report.json").strpath
+
+    plan = Testplan(
+        name="plan",
+        parse_cmdline=False,
+        exporters=[JSONExporter(json_path=json_path, split_json_report=True)],
+    )
+    multitest_1 = multitest.MultiTest(name="Primary", suites=[Alpha()])
+    multitest_2 = multitest.MultiTest(name="Secondary", suites=[Beta()])
+    plan.add(multitest_1)
+    plan.add(multitest_2)
+    plan.run()
+
+    assert os.path.exists(json_path)
+    assert os.stat(json_path).st_size > 0
+
+    # Load the JSON file to validate it contains valid JSON.
+    with open(json_path) as json_file:
+        report = json.load(json_file)
+    assert report["split"] == True
+
+    # Check that the expected text file is attached correctly.
+    attachments_dir = os.path.join(os.path.dirname(json_path), "_attachments")
+    assert os.path.isdir(attachments_dir)
+    assert len(report["entries"]) == 0
+    assert len(report["attachments"]) == 3
+
+    digest = hashlib.md5(json_path.encode("utf-8")).hexdigest()
+    attachment_1 = "report-structure-{}.json".format(digest)
+    attachment_2 = "report-assertions-{}.json".format(digest)
+    assert attachment_1 in report["attachments"]
+    assert attachment_2 in report["attachments"]
+
+    attachment_filepath_1 = os.path.join(attachments_dir, attachment_1)
+    attachment_filepath_2 = os.path.join(attachments_dir, attachment_2)
+    assert os.path.isfile(attachment_filepath_1)
+    assert os.path.isfile(attachment_filepath_2)
+
+    with open(attachment_filepath_1) as f1, open(attachment_filepath_2) as f2:
+        structure = json.loads(f1.read())
+        assertions = json.loads(f2.read())
+
+    assert len(structure) == 2  # 2 multitests
+    assert structure[0]["name"] == "Primary"  # 1st multitest name
+    assert len(structure[0]["entries"]) == 1  # one suite in 1st multitest
+    assert structure[0]["entries"][0]["name"] == "Alpha"  # 1st suite name
+    assert len(structure[0]["entries"][0]["entries"]) == 3  # 3 testcases
+    assert structure[1]["name"] == "Secondary"  # 2nd multitest name
+    assert len(structure[1]["entries"]) == 1  # one suite in 2nd multitest
+    assert structure[1]["entries"][0]["name"] == "Beta"  # 1st suite name
+    assert len(structure[1]["entries"][0]["entries"]) == 2  # 2 testcases
+
+    assert len(assertions["plan"]) == 2
+    assert len(assertions["plan"]["Primary"]) == 1
+    assert len(assertions["plan"]["Primary"]["Alpha"]) == 3
+    assert len(assertions["plan"]["Secondary"]) == 1
+    assert len(assertions["plan"]["Secondary"]["Beta"]) == 2
+
+    # only one assertion in each testcase in suite `Alpha`
+    assert (
+        assertions["plan"]["Primary"]["Alpha"]["test_comparison"][0]["type"]
+        == "Equal"
+    )
+    assert (
+        assertions["plan"]["Primary"]["Alpha"]["test_membership"][0]["type"]
+        == "Contain"
+    )
+    assert (
+        assertions["plan"]["Primary"]["Alpha"]["test_attach"][0]["type"]
+        == "Attachment"
+    )
+    # 2 assertions in testcase `test_failure`
+    assert (
+        assertions["plan"]["Secondary"]["Beta"]["test_failure"][0]["type"]
+        == "Equal"
+    )
+    assert (
+        assertions["plan"]["Secondary"]["Beta"]["test_failure"][1]["type"]
+        == "NotEqual"
+    )
+    # no assertion in testcase `test_error`
+    assert len(assertions["plan"]["Secondary"]["Beta"]["test_error"]) == 0
 
 
 def test_implicit_exporter_initialization(tmpdir):

--- a/tests/functional/exporters/testing/test_xml.py
+++ b/tests/functional/exporters/testing/test_xml.py
@@ -49,7 +49,7 @@ def test_xml_exporter(tmpdir):
     plan = Testplan(
         name="plan",
         parse_cmdline=False,
-        exporters=XMLExporter(xml_dir=xml_dir.strpath),
+        exporters=[XMLExporter(xml_dir=xml_dir.strpath)],
     )
     multitest_1 = multitest.MultiTest(name="Primary", suites=[Alpha()])
     multitest_2 = multitest.MultiTest(name="Secondary", suites=[Beta()])

--- a/tests/unit/testplan/report/test_testing.py
+++ b/tests/unit/testplan/report/test_testing.py
@@ -23,7 +23,6 @@ from testplan.report.testing.schemas import TestReportSchema, EntriesField
 from testplan.common import report, entity
 from testplan.common.utils.testing import check_report
 from testplan.testing.multitest.result import Result
-from testplan.common import entity
 
 DummyReport = functools.partial(TestCaseReport, name="dummy")
 DummyReportGroup = functools.partial(BaseReportGroup, name="dummy")


### PR DESCRIPTION
* The Json report can become very large. Add an optional argument
  `split_json_report` for `JSONExporter` so that the generated json
  report is only a small file containing meta info, the test structure
  and assertions are stored in separate attached files. In the future
  the assertion file can be split into shards further more.
* Update document and testcase.