### PR TITLE
Support custom testcase/testsuite name

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -214,9 +214,9 @@ without any trimming the output.
 
     $ test_plan.py --info pattern
     Primary
-    Primary:AlphaSuite
-      Primary:AlphaSuite:testcase_a
-      Primary:AlphaSuite:testcase_b
+    Primary::AlphaSuite
+      Primary::AlphaSuite::testcase_a
+      Primary::AlphaSuite::testcase_b
       ...
 
 

--- a/examples/Multitest/Listing/Basic Listing/test_plan_command_line.py
+++ b/examples/Multitest/Listing/Basic Listing/test_plan_command_line.py
@@ -80,9 +80,9 @@ class Gamma(object):
 # Sample output:
 
 # Primary
-# ..Primary:Alpha
-# ....Primary:Alpha:test_a
-# ....Primary:Alpha:test_b  --tags server
+# ..Primary::Alpha
+# ....Primary::Alpha::test_a
+# ....Primary::Alpha::test_b  --tags server
 # ...
 
 # Pattern listing (without any testcase trimming):

--- a/examples/Multitest/Parametrization/test_plan.py
+++ b/examples/Multitest/Parametrization/test_plan.py
@@ -101,9 +101,8 @@ class ErrorTest(object):
     @testcase(
         parameters=(
             # tuple notation, using default error value (TypeError)
-            ((lambda: "foo" + 5),),
-            # dict notation, using default error value (TypeError)
-            {"func": lambda: "foo" * "foo"},
+            (lambda: "foo" + 5,),
+            (lambda: object().b, AttributeError),
             (lambda: {"a": 5}["b"], KeyError),
             (lambda: int("a"), ValueError),
             (lambda: 10 / 0, ZeroDivisionError),

--- a/testplan/base.py
+++ b/testplan/base.py
@@ -453,5 +453,6 @@ class TestplanMock(Testplan):
         kwargs.setdefault("abort_signals", [])
         kwargs.setdefault("runpath", default_runpath_mock)
         kwargs.setdefault("parse_cmdline", False)
+        kwargs.setdefault("reset_report_uid", False)
 
         super(TestplanMock, self).__init__(*args, **kwargs)

--- a/testplan/common/report/base.py
+++ b/testplan/common/report/base.py
@@ -53,7 +53,7 @@ class Report(object):
         self.name = name
         self.description = description
 
-        self.uid = uuid.uuid4() if uid is None else uid
+        self.uid = uid or uuid.uuid4()
         self.entries = entries or []
 
         self.logs = []

--- a/testplan/common/utils/process.py
+++ b/testplan/common/utils/process.py
@@ -101,7 +101,10 @@ def kill_process_psutil(proc, timeout=5, signal_=None, output=None):
     """
     _log = functools.partial(_log_proc, output=output)
 
-    all_procs = proc.children(recursive=True) + [proc]
+    try:
+        all_procs = proc.children(recursive=True) + [proc]
+    except psutil.NoSuchProcess:
+        return []
 
     try:
         if signal_ is not None:

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -54,8 +54,6 @@ import traceback
 
 from collections import Counter
 
-from marshmallow import exceptions
-
 from testplan.common.report import (
     ExceptionLogger as ExceptionLoggerBase,
     Report,

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -156,6 +156,7 @@ class TestRunnerConfig(RunnableConfig):
             ConfigOption(
                 "interactive_handler", default=TestRunnerIHandler
             ): object,
+            ConfigOption("reset_report_uid", default=True): bool,
             ConfigOption("extra_deps", default=[]): list,
         }
 
@@ -637,9 +638,10 @@ class TestRunner(Runnable):
         if test_rep_lookup:
             step_result = self._merge_reports(test_rep_lookup) and step_result
 
-        # The uids of a test report and all of its children
-        # should be comply with standard UUID form
-        test_report.reset_uid()
+        # The uids of a test report and all of its children can be made
+        # complied with standard UUID form
+        if self.cfg.reset_report_uid:
+            test_report.reset_uid()
 
         return step_result
 

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -6,9 +6,9 @@ import sys
 import time
 import signal
 import subprocess
-from schema import Or
-import psutil
 import tempfile
+
+from schema import Or
 
 import testplan
 from testplan.common.utils.logger import TESTPLAN_LOGGER

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -4,6 +4,7 @@ import sys
 import subprocess
 import six
 import tempfile
+import warnings
 
 from lxml import objectify
 from schema import Or, Use, And
@@ -28,7 +29,6 @@ from testplan.report import (
     test_styles,
     TestGroupReport,
     TestCaseReport,
-    Status,
     ReportCategories,
     RuntimeStatus,
 )
@@ -128,6 +128,12 @@ class Test(Runnable):
     filter_levels = [filtering.FilterLevel.TEST]
 
     def __init__(self, **options):
+        if ":" in options.get("name", ""):
+            warnings.warn(
+                "It is strongly suggested not using colon in name of {} - "
+                "[{}]".format(self.__class__.__name__, options.get("name"))
+            )
+
         super(Test, self).__init__(**options)
 
         for resource in self.cfg.environment:

--- a/testplan/testing/listing.py
+++ b/testplan/testing/listing.py
@@ -7,9 +7,10 @@ import six
 
 from testplan.common.utils.parser import ArgMixin
 from testplan.common.utils.logger import TESTPLAN_LOGGER
-from .multitest import MultiTest
-from .multitest.suite import get_testsuite_name
+
 from testplan.testing import tagging
+from testplan.testing.multitest import MultiTest
+from testplan.testing.multitest.suite import get_testsuite_name
 
 INDENT = " "
 MAX_TESTCASES = 25
@@ -69,7 +70,7 @@ class ExpandedNameLister(BaseLister):
         if isinstance(testcase, six.string_types):
             return testcase
         else:
-            return testcase.__name__
+            return testcase.name
 
     def get_testcase_outputs(self, instance, suite, testcases):
         result = ""
@@ -135,18 +136,18 @@ class ExpandedPatternLister(ExpandedNameLister):
 
     def format_suite(self, instance, suite):
         if not isinstance(instance, MultiTest):
-            return "{}:{}".format(instance.name, suite)
+            return "{}::{}".format(instance.name, suite)
 
-        pattern = "{}:{}".format(instance.name, get_testsuite_name(suite))
+        pattern = "{}::{}".format(instance.name, get_testsuite_name(suite))
         return self.apply_tag_label(pattern, suite)
 
     def format_testcase(self, instance, suite, testcase):
 
         if not isinstance(instance, MultiTest):
-            return "{}:{}:{}".format(instance.name, suite, testcase)
+            return "{}::{}::{}".format(instance.name, suite, testcase)
 
-        pattern = "{}:{}:{}".format(
-            instance.name, get_testsuite_name(suite), testcase.__name__
+        pattern = "{}::{}::{}".format(
+            instance.name, get_testsuite_name(suite), testcase.name,
         )
         return self.apply_tag_label(pattern, testcase)
 

--- a/testplan/testing/multitest/driver/base.py
+++ b/testplan/testing/multitest/driver/base.py
@@ -167,7 +167,7 @@ class Driver(Resource):
         """Driver started status condition check."""
         wait(
             lambda: self.extract_values(),
-            self.cfg.timeout,
+            timeout or self.cfg.timeout,
             raise_on_timeout=True,
         )
 

--- a/testplan/testing/ordering.py
+++ b/testplan/testing/ordering.py
@@ -164,4 +164,4 @@ class AlphanumericSorter(TypedSorter):
         return sorted(testsuites, key=get_testsuite_name)
 
     def sort_testcases(self, testcases):
-        return sorted(testcases, key=operator.attrgetter("__name__"))
+        return sorted(testcases, key=operator.attrgetter("name"))

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -6,8 +6,8 @@ import re
 import traceback
 
 import pytest
-import schema
 import six
+from schema import Or
 
 from testplan.testing import base as testing
 from testplan.common.config import ConfigOption
@@ -42,9 +42,9 @@ class PyTestConfig(testing.TestConfig):
     @classmethod
     def get_options(cls):
         return {
-            "target": schema.Or(str, [str]),
+            "target": Or(str, [str]),
             ConfigOption("select", default=""): str,
-            ConfigOption("extra_args", default=None): schema.Or([str], None),
+            ConfigOption("extra_args", default=None): Or([str], None),
             ConfigOption(
                 "result", default=MultiTestResult
             ): validation.is_subclass(MultiTestResult),

--- a/tests/functional/testplan/report/testing/test_merge.py
+++ b/tests/functional/testplan/report/testing/test_merge.py
@@ -44,7 +44,7 @@ from testplan.report import TestCaseReport, TestGroupReport
 expected_report = TestGroupReport(
     name="MyMultiTest",
     category="multitest",
-    uid=0,
+    uid=1,
     tags={"color": {"green"}},
     entries=[
         TestGroupReport(
@@ -132,7 +132,7 @@ expected_report = TestGroupReport(
 mt_report_alpha = TestGroupReport(
     name="MyMultiTest",
     category="multitest",
-    uid=0,
+    uid=1,
     tags={"color": {"green"}},
     entries=[
         TestGroupReport(
@@ -157,7 +157,7 @@ mt_report_alpha = TestGroupReport(
 mt_report_beta_1 = TestGroupReport(
     name="MyMultiTest",
     category="multitest",
-    uid=0,
+    uid=1,
     tags={"color": {"green"}},
     entries=[
         TestGroupReport(
@@ -181,7 +181,7 @@ mt_report_beta_1 = TestGroupReport(
 mt_report_beta_2 = TestGroupReport(
     name="MyMultiTest",
     category="multitest",
-    uid=0,
+    uid=1,
     tags={"color": {"green"}},
     entries=[
         TestGroupReport(
@@ -219,7 +219,7 @@ mt_report_beta_2 = TestGroupReport(
 mt_report_gamma = TestGroupReport(
     name="MyMultiTest",
     category="multitest",
-    uid=0,
+    uid=1,
     tags={"color": {"green"}},
     entries=[
         TestGroupReport(
@@ -250,7 +250,7 @@ def test_merge():
     mt_report = TestGroupReport(
         name="MyMultiTest",
         category="multitest",
-        uid=0,
+        uid=1,
         tags={"color": {"green"}},
     )
 

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -394,7 +394,7 @@ EXPECTED_INITIAL_GET = [
                 "description": "Parametrized testcase.",
                 "entries": [],
                 "logs": [],
-                "name": "test_parametrized__val_1",
+                "name": "test_parametrized <val=1>",
                 "parent_uids": [
                     "InteractiveAPITest",
                     "ExampleMTest",
@@ -416,7 +416,7 @@ EXPECTED_INITIAL_GET = [
                 "description": "Parametrized testcase.",
                 "entries": [],
                 "logs": [],
-                "name": "test_parametrized__val_2",
+                "name": "test_parametrized <val=2>",
                 "parent_uids": [
                     "InteractiveAPITest",
                     "ExampleMTest",
@@ -438,7 +438,7 @@ EXPECTED_INITIAL_GET = [
                 "description": "Parametrized testcase.",
                 "entries": [],
                 "logs": [],
-                "name": "test_parametrized__val_3",
+                "name": "test_parametrized <val=3>",
                 "parent_uids": [
                     "InteractiveAPITest",
                     "ExampleMTest",
@@ -465,7 +465,7 @@ EXPECTED_INITIAL_GET = [
             "description": "Parametrized testcase.",
             "entries": [],
             "logs": [],
-            "name": "test_parametrized__val_1",
+            "name": "test_parametrized <val=1>",
             "parent_uids": [
                 "InteractiveAPITest",
                 "ExampleMTest",

--- a/tests/functional/testplan/testing/multitest/test_stop_on_error.py
+++ b/tests/functional/testplan/testing/multitest/test_stop_on_error.py
@@ -146,7 +146,7 @@ def test_execution_order(mockplan):
                                 category=ReportCategories.PARAMETRIZATION,
                                 entries=[
                                     TestCaseReport(
-                                        name="test_case_divide_by_arg",
+                                        name="test_case_divide_by_arg <arg=-1>",
                                         entries=[
                                             {
                                                 "type": "Equal",
@@ -156,11 +156,11 @@ def test_execution_order(mockplan):
                                         ],
                                     ),
                                     _create_testcase_report(
-                                        name="test_case_divide_by_arg__arg_0",
+                                        name="test_case_divide_by_arg <arg=0>",
                                         status_override=Status.ERROR,
                                     ),
                                     TestCaseReport(
-                                        name="test_case_divide_by_arg__arg_1",
+                                        name="test_case_divide_by_arg <arg=1>",
                                         entries=[
                                             {
                                                 "type": "Equal",
@@ -176,7 +176,7 @@ def test_execution_order(mockplan):
                                 category=ReportCategories.PARAMETRIZATION,
                                 entries=[
                                     TestCaseReport(
-                                        name="test_case_divide_by_one",
+                                        name="test_case_divide_by_one <arg=-1>",
                                         entries=[
                                             {
                                                 "type": "Equal",
@@ -186,7 +186,7 @@ def test_execution_order(mockplan):
                                         ],
                                     ),
                                     TestCaseReport(
-                                        name="test_case_divide_by_one__arg_0",
+                                        name="test_case_divide_by_one <arg=0>",
                                         entries=[
                                             {
                                                 "type": "Equal",
@@ -196,7 +196,7 @@ def test_execution_order(mockplan):
                                         ],
                                     ),
                                     TestCaseReport(
-                                        name="test_case_divide_by_one__arg_1",
+                                        name="test_case_divide_by_one <arg=1>",
                                         entries=[
                                             {
                                                 "type": "Equal",
@@ -256,7 +256,7 @@ def test_execution_order(mockplan):
                                 category=ReportCategories.PARAMETRIZATION,
                                 entries=[
                                     TestCaseReport(
-                                        name="test_case_divide_by_arg",
+                                        name="test_case_divide_by_arg <arg=-1>",
                                         entries=[
                                             {
                                                 "type": "Equal",
@@ -266,7 +266,7 @@ def test_execution_order(mockplan):
                                         ],
                                     ),
                                     _create_testcase_report(
-                                        name="test_case_divide_by_arg__arg_0",
+                                        name="test_case_divide_by_arg <arg=0>",
                                         status_override=Status.ERROR,
                                     ),
                                 ],

--- a/tests/functional/testplan/testing/multitest/test_timeout_on_testcases.py
+++ b/tests/functional/testplan/testing/multitest/test_timeout_on_testcases.py
@@ -42,7 +42,7 @@ class Suite2(object):
         result.log("Testcase will sleep for {} seconds".format(val))
         time.sleep(val)
 
-    @testcase(parameters=(1, 2, 5), execution_group="second", timeout=3)
+    @testcase(parameters=(1, 2, 8), execution_group="second", timeout=3)
     def test_timeout_2(self, env, result, val):
         result.log("Testcase will sleep for {} seconds".format(val))
         time.sleep(val)
@@ -117,7 +117,7 @@ def test_timeout_on_testcases(mockplan):
                                 category=ReportCategories.PARAMETRIZATION,
                                 entries=[
                                     TestCaseReport(
-                                        name="test_timeout_1__val_1",
+                                        name="test_timeout_1 <val=1>",
                                         entries=[
                                             {
                                                 "type": "Log",
@@ -126,7 +126,7 @@ def test_timeout_on_testcases(mockplan):
                                         ],
                                     ),
                                     TestCaseReport(
-                                        name="test_timeout_1__val_2",
+                                        name="test_timeout_1 <val=2>",
                                         entries=[
                                             {
                                                 "type": "Log",
@@ -135,7 +135,7 @@ def test_timeout_on_testcases(mockplan):
                                         ],
                                     ),
                                     TestCaseReport(
-                                        name="test_timeout_1__val_3",
+                                        name="test_timeout_1 <val=3>",
                                         entries=[
                                             {
                                                 "type": "Log",
@@ -150,7 +150,7 @@ def test_timeout_on_testcases(mockplan):
                                 category=ReportCategories.PARAMETRIZATION,
                                 entries=[
                                     TestCaseReport(
-                                        name="test_timeout_2__val_1",
+                                        name="test_timeout_2 <val=1>",
                                         entries=[
                                             {
                                                 "type": "Log",
@@ -159,7 +159,7 @@ def test_timeout_on_testcases(mockplan):
                                         ],
                                     ),
                                     TestCaseReport(
-                                        name="test_timeout_2__val_2",
+                                        name="test_timeout_2 <val=2>",
                                         entries=[
                                             {
                                                 "type": "Log",
@@ -168,12 +168,12 @@ def test_timeout_on_testcases(mockplan):
                                         ],
                                     ),
                                     _create_testcase_report(
-                                        name="test_timeout_2__val_5",
+                                        name="test_timeout_2 <val=8>",
                                         status_override=Status.ERROR,
                                         entries=[
                                             {
                                                 "type": "Log",
-                                                "message": "Testcase will sleep for 5 seconds",
+                                                "message": "Testcase will sleep for 8 seconds",
                                             }
                                         ],
                                     ),

--- a/tests/functional/testplan/testing/test_listing.py
+++ b/tests/functional/testplan/testing/test_listing.py
@@ -60,19 +60,19 @@ class Gamma(object):
 
 DEFAULT_PATTERN_OUTPUT = to_stdout(
     "Primary",
-    "  Primary:Beta  --tags color=yellow",
-    "    Primary:Beta:test_c",
-    "    Primary:Beta:test_b  --tags foo",
-    "    Primary:Beta:test_a  --tags color=red",
-    "  Primary:Alpha",
-    "    Primary:Alpha:test_c",
-    "    Primary:Alpha:test_b  --tags bar foo",
-    "    Primary:Alpha:test_a  --tags color=green",
+    "  Primary::Beta  --tags color=yellow",
+    "    Primary::Beta::test_c",
+    "    Primary::Beta::test_b  --tags foo",
+    "    Primary::Beta::test_a  --tags color=red",
+    "  Primary::Alpha",
+    "    Primary::Alpha::test_c",
+    "    Primary::Alpha::test_b  --tags bar foo",
+    "    Primary::Alpha::test_a  --tags color=green",
     "Secondary",
-    "  Secondary:Gamma",
-    "    Secondary:Gamma:test_c",
-    "    Secondary:Gamma:test_b  --tags bar",
-    "    Secondary:Gamma:test_a  --tags color=blue",
+    "  Secondary::Gamma",
+    "    Secondary::Gamma::test_c",
+    "    Secondary::Gamma::test_b  --tags bar",
+    "    Secondary::Gamma::test_a  --tags color=blue",
 )
 
 
@@ -244,7 +244,7 @@ class ParametrizedSuite(object):
             to_stdout(
                 *["Primary", "  ParametrizedSuite"]
                 + [
-                    "    test_method__val_{}".format(idx)
+                    "    test_method <val={}>".format(idx)
                     for idx in range(NUM_TESTS)
                 ]
             ),
@@ -255,7 +255,7 @@ class ParametrizedSuite(object):
             to_stdout(
                 *["Primary", "  ParametrizedSuite"]
                 + [
-                    "    test_method__val_{}".format(idx)
+                    "    test_method <val={}>".format(idx)
                     for idx in range(listing.MAX_TESTCASES)
                 ]
                 + [
@@ -269,10 +269,10 @@ class ParametrizedSuite(object):
         (
             listing.PatternLister(),
             to_stdout(
-                *["Primary", "  Primary:ParametrizedSuite"]
+                *["Primary", "  Primary::ParametrizedSuite"]
                 + [
-                    "    Primary:ParametrizedSuite"
-                    ":test_method__val_{}".format(idx)
+                    "    Primary::ParametrizedSuite"
+                    "::test_method <val={}>".format(idx)
                     for idx in range(listing.MAX_TESTCASES)
                 ]
                 + [

--- a/tests/functional/testplan/testing/test_tagging.py
+++ b/tests/functional/testplan/testing/test_tagging.py
@@ -98,11 +98,11 @@ report_for_multitest_without_tags = TestGroupReport(
                     tags={"speed": {"slow"}},
                     entries=[
                         TestCaseReport(
-                            name="test_param__value_AAA",
+                            name="test_param <value='AAA'>",
                             tags={"symbol": {"aaa"}},
                         ),
                         TestCaseReport(
-                            name="test_param__value_BBB",
+                            name="test_param <value='BBB'>",
                             tags={"symbol": {"bbb"}},
                         ),
                     ],
@@ -112,8 +112,8 @@ report_for_multitest_without_tags = TestGroupReport(
                     category="parametrization",
                     tags={"speed": {"fast"}},
                     entries=[
-                        TestCaseReport(name="test_param_2__value_XXX"),
-                        TestCaseReport(name="test_param_2__value_YYY"),
+                        TestCaseReport(name="test_param_2 <value='XXX'>"),
+                        TestCaseReport(name="test_param_2 <value='YYY'>"),
                     ],
                 ),
             ],
@@ -162,11 +162,11 @@ report_for_multitest_with_tags = TestGroupReport(
                     tags={"speed": {"slow"}},
                     entries=[
                         TestCaseReport(
-                            name="test_param__value_AAA",
+                            name="test_param <value='AAA'>",
                             tags={"symbol": {"aaa"}},
                         ),
                         TestCaseReport(
-                            name="test_param__value_BBB",
+                            name="test_param <value='BBB'>",
                             tags={"symbol": {"bbb"}},
                         ),
                     ],
@@ -176,8 +176,8 @@ report_for_multitest_with_tags = TestGroupReport(
                     category="parametrization",
                     tags={"speed": {"fast"}},
                     entries=[
-                        TestCaseReport(name="test_param_2__value_XXX"),
-                        TestCaseReport(name="test_param_2__value_YYY"),
+                        TestCaseReport(name="test_param_2 <value='XXX'>"),
+                        TestCaseReport(name="test_param_2 <value='YYY'>"),
                     ],
                 ),
             ],

--- a/tests/unit/testplan/common/report/test_base.py
+++ b/tests/unit/testplan/common/report/test_base.py
@@ -217,16 +217,16 @@ class TestReportGroup(object):
 
     def test_merge_children(self):
         """Should merge each children separately."""
-        child_clone_1 = DummyReport(uid=1)
-        child_clone_2 = DummyReport(uid=2)
+        child_clone_1 = DummyReport(uid=10)
+        child_clone_2 = DummyReport(uid=20)
         parent_clone = DummyReportGroup(
-            uid=0, entries=[child_clone_1, child_clone_2]
+            uid=1, entries=[child_clone_1, child_clone_2]
         )
 
-        child_orig_1 = DummyReport(uid=1)
-        child_orig_2 = DummyReport(uid=2)
+        child_orig_1 = DummyReport(uid=10)
+        child_orig_2 = DummyReport(uid=20)
         parent_orig = DummyReportGroup(
-            uid=0, entries=[child_orig_1, child_orig_2]
+            uid=1, entries=[child_orig_1, child_orig_2]
         )
 
         with mock.patch.object(child_orig_1, "merge"):
@@ -242,14 +242,14 @@ class TestReportGroup(object):
 
     def test_merge_children_fail(self):
         """Should raise `MergeError` if child `uid`s do not match."""
-        child_clone_1 = DummyReport(uid=1)
-        child_clone_2 = DummyReport(uid=2)
+        child_clone_1 = DummyReport(uid=10)
+        child_clone_2 = DummyReport(uid=20)
         parent_clone = DummyReportGroup(
-            uid=0, entries=[child_clone_1, child_clone_2]
+            uid=1, entries=[child_clone_1, child_clone_2]
         )
 
         child_orig_1 = DummyReport(uid=1)
-        parent_orig = DummyReportGroup(uid=0, entries=[child_orig_1])
+        parent_orig = DummyReportGroup(uid=10, entries=[child_orig_1])
 
         with pytest.raises(report.MergeError):
             parent_orig.merge(parent_clone)

--- a/tests/unit/testplan/report/test_testing.py
+++ b/tests/unit/testplan/report/test_testing.py
@@ -132,8 +132,8 @@ class TestBaseReportGroup(object):
         Should merge children and set `status_override`
         using `report.status_override` precedence.
         """
-        report_orig = DummyReportGroup(uid=0)
-        report_clone = DummyReportGroup(uid=0)
+        report_orig = DummyReportGroup(uid=1)
+        report_clone = DummyReportGroup(uid=1)
 
         assert report_orig.status_override is None
 
@@ -151,17 +151,16 @@ class TestBaseReportGroup(object):
           Not strict merge should append child entries and update
           the index if they do not exist in the parent.
         """
-        child_clone_1 = DummyReport(uid=1)
-        child_clone_2 = DummyReport(uid=2)
+        child_clone_1 = DummyReport(uid=10)
+        child_clone_2 = DummyReport(uid=20)
         parent_clone = DummyReportGroup(
-            uid=0, entries=[child_clone_1, child_clone_2]
+            uid=1, entries=[child_clone_1, child_clone_2]
         )
 
-        child_orig_1 = DummyReport(uid=1)
-        parent_orig = DummyReportGroup(uid=0, entries=[child_orig_1])
+        child_orig_1 = DummyReport(uid=10)
+        parent_orig = DummyReportGroup(uid=1, entries=[child_orig_1])
 
         parent_orig.merge(parent_clone, strict=False)
-
         assert parent_orig.entries == [child_orig_1, child_clone_2]
 
         # Merging a second time should give us the same results

--- a/tests/unit/testplan/testing/multitest/test_multitest.py
+++ b/tests/unit/testplan/testing/multitest/test_multitest.py
@@ -2,14 +2,16 @@
 
 import os
 
+
+from testplan.common import entity
 from testplan.common.utils import path
+from testplan.common.utils import testing
 from testplan.testing import multitest
-from testplan.testing.multitest import base
 from testplan.testing import filtering
 from testplan.testing import ordering
 from testplan import defaults
 from testplan import report
-from testplan.common import entity
+
 
 # TODO: shouldn't need to specify these...
 MTEST_DEFAULT_PARAMS = {
@@ -141,19 +143,19 @@ EXPECTED_REPORT_SKELETON = report.TestGroupReport(
                     parent_uids=["MTest", "Suite"],
                     entries=[
                         report.TestCaseReport(
-                            name="parametrized__val_1",
+                            name="parametrized <val=1>",
                             description="Parametrized testcase.",
                             uid="parametrized__val_1",
                             parent_uids=["MTest", "Suite", "parametrized"],
                         ),
                         report.TestCaseReport(
-                            name="parametrized__val_2",
+                            name="parametrized <val=2>",
                             description="Parametrized testcase.",
                             uid="parametrized__val_2",
                             parent_uids=["MTest", "Suite", "parametrized"],
                         ),
                         report.TestCaseReport(
-                            name="parametrized__val_3",
+                            name="parametrized <val=3>",
                             description="Parametrized testcase.",
                             uid="parametrized__val_3",
                             parent_uids=["MTest", "Suite", "parametrized"],
@@ -174,9 +176,10 @@ def test_dry_run():
     result = mtest.dry_run()
     report_skeleton = result.report
 
-    # Comparing the serialized reports makes it much easier to spot any
-    # inconsistencies.
-    assert report_skeleton.serialize() == EXPECTED_REPORT_SKELETON.serialize()
+    # Comparing the reports to spot any inconsistencies.
+    testing.check_report(
+        expected=EXPECTED_REPORT_SKELETON, actual=report_skeleton
+    )
 
 
 def test_run_all_tests():
@@ -285,7 +288,7 @@ def _check_parallel_param(param_report):
     assert len(param_report.entries) == 3  # Three parametrized testcases.
 
     for i, testcase_report in enumerate(param_report.entries):
-        assert testcase_report.name == "parametrized__val_{}".format(i + 1)
+        assert testcase_report.name == "parametrized <val={}>".format(i + 1)
         assert testcase_report.category == report.ReportCategories.TESTCASE
         assert len(testcase_report.entries) == 1  # One assertion
 
@@ -318,7 +321,7 @@ def _check_param_testcase_report(testcase_report, i):
     "parametrized" testcase from the "Suite" testsuite.
     """
     assert testcase_report.passed
-    assert testcase_report.name == "parametrized__val_{}".format(i + 1)
+    assert testcase_report.name == "parametrized <val={}>".format(i + 1)
     assert testcase_report.category == report.ReportCategories.TESTCASE
     assert len(testcase_report.entries) == 1  # One assertion
 

--- a/tests/unit/testplan/testing/test_filtering.py
+++ b/tests/unit/testplan/testing/test_filtering.py
@@ -275,14 +275,17 @@ class TestPattern(object):
         assert len(testcases) == 3  # Expect 3 testcases to be generated.
 
         testcase = testcases[0]
-        for pattern in ["*:Delta:parametrized", "*:Delta:parametrized__val_1"]:
+        for pattern in [
+            "*:Delta:parametrized",
+            "*:Delta:parametrized <val=1>",
+        ]:
             filter_obj = filtering.Pattern(pattern=pattern)
             assert filter_obj.filter_case(testcase)
 
     def test_filter_initialization_error(self):
         """
-            Pattern filter should raise error if
-            pattern depth exceeds MAX_LEVEL
+        Symbol ":" or "::" can be used as delimiter and MAX_LEVEL parts
+        can be generated for matching.
         """
         with pytest.raises(ValueError):
             filtering.Pattern("foo:bar:baz:bat")


### PR DESCRIPTION
* User can define the names of testcase/testsuite in @testcase and
  @testsuite decorator which are human readable. Instead of class
  name or function name, these strings will be displayed on UI or
  exported PDF. Also they are used for pattern matching while
  filtering testcases, and set as parent uids for a report entity.
* No testcases having the same function name can be defined in one
  test suite, Testplan will check it and raise. User defined names
  should also be unique. If the function name of generated testcase
  conflict with others, Testplan could altomatically solve it.
* No duplicate test suite name allowed, otherwise at the step of
  "generating report" exception will be raised.
* User can define a naming function for parametrized testcases, or
  the default one is used, generating a function name like this:
  "<original_name> {arg_name:value, ...}". Raise if testcase names
  are not valid (e.g. name too long), then users have to pass their
  own `name_func`.
* "::" is the delimiter for listed cases to conform to a more generic
  format, e.g. "Multitest::Suite::TestCase". To list test with
  "--tests" argument, both ":" and "::" can be used as delimiter.
* CFG option `reset_report_uid` is added to `TestRunner` so that
  it is not necessary to make UUID as unique identifier for test
  report, without UUID set, the original class name or function name
  can be used as unique id for test report.
* Aoid creating test report twice while executing Multitest instance.
* All false value including "None", empty string, number 0 can not be
  set as uid of test report, otherwise will be replaced by uuid4(),
  change the testcase where number 0 is passed to report constructor
  as uid.
* Update related testcases.