### PR TITLE
Names of split json report are recorded directly in main report

### DIFF
--- a/examples/Test Output/Exporters/JSON/json_to_pdf.py
+++ b/examples/Test Output/Exporters/JSON/json_to_pdf.py
@@ -15,8 +15,17 @@ def main(source, target):
 
     with open(source) as source_file:
         data = json.loads(source_file.read())
-        if data.get("split"):
-            raise RuntimeError("Cannot process JSON report that was split")
+        if (
+            data.get("version", 1) >= 2
+            or data.get("structure_file")
+            or data.get("assertions_file")
+        ):
+            raise RuntimeError(
+                "This utility can only process a single all-in-one JSON"
+                " report, you can set `split_json_report` to False in"
+                " `JSONExporter` while running Testplan script to get a"
+                " single JSON report."
+            )
 
         report_obj = TestReport.deserialize(data)
         print("Loaded report: {}".format(report_obj.name))

--- a/testplan/exporters/testing/http/__init__.py
+++ b/testplan/exporters/testing/http/__init__.py
@@ -63,7 +63,7 @@ class HTTPExporter(Exporter):
         response = None
         errmsg = ""
 
-        if data and (data.get("entries") or data.get("split")):
+        if data and (data.get("entries") or data.get("attachments")):
             headers = {"Content-Type": "application/json"}
             try:
                 response = requests.post(

--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -90,15 +90,20 @@ class JSONExporter(Exporter):
                     json.dump(assertions, json_file)
 
                 save_attachments(report=source, directory=attachments_dir)
-                # Modify json data may change the original `TestReport` object
+                meta["version"] = 2
+                # Modify dict ref may change the original `TestReport` object
                 meta["attachments"] = copy.deepcopy(meta["attachments"])
                 meta["attachments"][attachment_1] = attachment_filepath_1
                 meta["attachments"][attachment_2] = attachment_filepath_2
+                meta["structure_file"] = attachment_1
+                meta["assertions_file"] = attachment_2
 
                 with open(json_path, "w") as json_file:
                     json.dump(meta, json_file)
             else:
                 save_attachments(report=source, directory=attachments_dir)
+                data["version"] = 1
+
                 with open(json_path, "w") as json_file:
                     json.dump(data, json_file)
 
@@ -127,7 +132,6 @@ class JSONExporter(Exporter):
                     )
 
         meta, structure, assertions = data, data["entries"], {data["name"]: {}}
-        meta["split"] = True
         meta["entries"] = []
         split_assertions(structure, assertions[meta["name"]])
         return meta, structure, assertions
@@ -155,6 +159,4 @@ class JSONExporter(Exporter):
 
         merge_assertions(structure, assertions, strict)
         meta["entries"] = structure
-        if "split" in meta:
-            del meta["split"]
         return meta

--- a/tests/functional/exporters/testing/test_json.py
+++ b/tests/functional/exporters/testing/test_json.py
@@ -102,7 +102,7 @@ def test_json_exporter_split_report(runpath):
     # Load the JSON file to validate it contains valid JSON.
     with open(json_path) as json_file:
         report = json.load(json_file)
-    assert report["split"] == True
+    assert "structure_file" in report and "assertions_file" in report
 
     # Check that the expected text file is attached correctly.
     attachments_dir = os.path.join(os.path.dirname(json_path), "_attachments")
@@ -115,6 +115,8 @@ def test_json_exporter_split_report(runpath):
     attachment_2 = "report-assertions-{}.json".format(digest)
     assert attachment_1 in report["attachments"]
     assert attachment_2 in report["attachments"]
+    assert report["structure_file"] == attachment_1
+    assert report["assertions_file"] == attachment_2
 
     attachment_filepath_1 = os.path.join(attachments_dir, attachment_1)
     attachment_filepath_2 = os.path.join(attachments_dir, attachment_2)


### PR DESCRIPTION
* In main report 2 fields `structure_file` and `assertions_file` are
  added so there's no need to search them in `attachments`.
* version info added.