### PR TITLE
close file logger when TestRunner aborts to fix test failure on windows

### DIFF
--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -769,6 +769,7 @@ class TestRunner(Runnable):
         """Stop the web server if it is running."""
         if self._web_server_thread is not None:
             self._web_server_thread.stop()
+        self._close_file_logger()
 
     def _configure_stdout_logger(self):
         """Configure the stdout logger by setting the required level."""

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -106,7 +106,6 @@ class ProcessWorker(Worker):
                 stdout=out,
                 stderr=out,
                 stdin=subprocess.PIPE,
-                close_fds=True,
             )
         self.logger.debug("Started child process - output at %s", self.outfile)
         self._handler.stdin.write(bytes("y\n".encode("utf-8")))


### PR DESCRIPTION
also revert close_fds change