### PR TITLE
Fix an issue of "test_sorter"

### DIFF
--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -342,7 +342,7 @@ that match ALL of the given tags.
             args["test_filter"] = filter_args
 
         # Cmdline supports shuffle ordering only for now
-        if "shuffle" in args:
+        if args.get("shuffle"):
             args["test_sorter"] = ordering.ShuffleSorter(
                 seed=args["shuffle_seed"], shuffle_type=args["shuffle"]
             )


### PR DESCRIPTION
* If no command line arguments "shuffle" is specified, and it is also
  not programmatically defined in source code, then the default
  `test_sorter` of `TestRunner` should be `NoopSorter`, but incorrectly
  `ShuffleSorter` is used, although make no side effect to code logic.