### PR TITLE
Change pre_start order in driver start-up logic

### DIFF
--- a/testplan/testing/multitest/driver/base.py
+++ b/testplan/testing/multitest/driver/base.py
@@ -142,18 +142,18 @@ class Driver(Resource):
     def start(self):
         """Start the driver."""
         self.status.change(self.STATUS.STARTING)
+        self.pre_start()
         if self.cfg.pre_start:
             self.cfg.pre_start(self)
-        self.pre_start()
         self.starting()
 
     def stop(self):
         """Stop the driver."""
         self.status.change(self.STATUS.STOPPING)
         if self.active:
+            self.pre_stop()
             if self.cfg.pre_stop:
                 self.cfg.pre_stop(self)
-            self.pre_stop()
             self.stopping()
 
     def pre_start(self):
@@ -189,16 +189,16 @@ class Driver(Resource):
     def _wait_started(self, timeout=None):
         self.started_check(timeout=timeout)
         self.status.change(self.STATUS.STARTED)
-        self.post_start()
         if self.cfg.post_start:
             self.cfg.post_start(self)
+        self.post_start()
 
     def _wait_stopped(self, timeout=None):
         self.stopped_check(timeout=timeout)
         self.status.change(self.STATUS.STOPPED)
-        self.post_stop()
         if self.cfg.post_stop:
             self.cfg.post_stop(self)
+        self.post_stop()
 
     def context_input(self):
         """Driver context information."""

--- a/testplan/testing/multitest/driver/zookeeper.py
+++ b/testplan/testing/multitest/driver/zookeeper.py
@@ -85,7 +85,7 @@ class ZookeeperStandalone(Driver):
         Create mandatory directories and install files from given templates
         using the drivers context before starting zookeeper.
         """
-        self.make_runpath_dirs()
+        super(ZookeeperStandalone, self).pre_start()
         self.zkdata_path = os.path.join(self.runpath, "zkdata")
         self.zklog_path = os.path.join(self.runpath, "zklog")
         self.etc_path = os.path.join(self.runpath, "etc")

--- a/tests/unit/testplan/testing/multitest/driver/test_driver.py
+++ b/tests/unit/testplan/testing/multitest/driver/test_driver.py
@@ -4,6 +4,7 @@ from testplan.testing.multitest.driver import base
 
 
 def pre_start_fn(driver):
+    assert driver.pre_start_called
     driver.pre_start_fn_called = True
 
 
@@ -12,6 +13,7 @@ def post_start_fn(driver):
 
 
 def pre_stop_fn(driver):
+    assert driver.pre_stop_called
     driver.pre_stop_fn_called = True
 
 


### PR DESCRIPTION
* User defined `pre_start` should be called by driver's `pre_start`
  after making runpath.
* Similar changes applied to `post_start`, `pre_stop` and `post_stop`.
* update testcase.
