### PR TITLE
Utilize `custom_name` arg to generate names for given suites

### DIFF
--- a/doc/en/download/Multitest.rst
+++ b/doc/en/download/Multitest.rst
@@ -19,6 +19,19 @@ test_plan.py
 .. literalinclude:: ../../../examples/Multitest/Basic/Initial Context/test_plan.py
 
 
+.. _example_basic_name_customization:
+
+Name Customization
+++++++++++++++++++
+
+Required files:
+  - :download:`test_plan.py <../../../examples/Multitest/Basic/Custom Name/test_plan.py>`
+
+test_plan.py
+````````````
+.. literalinclude:: ../../../examples/Multitest/Basic/Custom Name/test_plan.py
+
+
 .. _example_multitest_listing:
 
 Listing

--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -175,6 +175,25 @@ respect to multiple suites is the following:
     4. Stop each driver in reverse order
 
 
+Name customization
+------------------
+
+Testplan supports customizing test suite name or testcase name, which will be saved
+in test report and displayed on UI. displayed inUse ``name`` argument in @testcase
+or ``custom_name`` argument in @testsuite, while ``custom_name`` can be a normal string
+or a callable. Some examples:
+
+    * ``@testcase(name="Testcase name")``
+    * ``@testsuite(custom_name="Test suite name")``
+    * ``@testsuite(custom_name=lambda self, original_name: "{}_{}".format(original_name , id(self)))``
+
+.. note::
+
+    In one test suite no duplicate testcase names are allowed. Similarly, if multiple
+    objects from the same test suite class are added into a multitest, ``custom_name``
+    is required to make different names for test suites.
+
+
 Listing
 -------
 
@@ -681,7 +700,6 @@ How can I troubleshoot a problem?
 
 
 .. _tagging:
-
 
 Tagging
 -------

--- a/examples/Multitest/Basic/Name Customization/test_plan.py
+++ b/examples/Multitest/Basic/Name Customization/test_plan.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""
+    A Simple example to show how to customize name for test suite and testcase.
+"""
+
+from testplan import test_plan
+from testplan.testing.multitest import testsuite, testcase, MultiTest
+
+
+def _name_func(self, original_name):
+    """Function to return a customized name for test suite"""
+    return original_name + " - " + str(getattr(self, "val", "Default"))
+
+
+@testsuite(custom_name="A simple test suite")
+class SimpleSuite(object):
+    @testcase(name="An empty testcase")
+    def test_example(self, env, result):
+        pass
+
+    @testcase(name="Parametrized testcases", parameters=((1, 2, 3), (1, 0, 1)))
+    def test_equal(self, env, result, a, b, expected):
+        result.equal(a + b, expected, description="Equality test")
+
+
+@testsuite(custom_name=_name_func)
+class ComplicatedSuite(object):
+    def __init__(self, val):
+        self.val = val
+
+    @testcase(name="A testcase with one assertion")
+    def test_less_than(self, env, result):
+        result.less(self.val, 100, description="{} < 100".format(self.val))
+
+
+@test_plan(name="Name customization example")
+def main(plan):
+
+    plan.add(
+        MultiTest(
+            "Name customization example",
+            suites=[SimpleSuite(), ComplicatedSuite(1), ComplicatedSuite(2)],
+        )
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(not main())

--- a/testplan/common/utils/validation.py
+++ b/testplan/common/utils/validation.py
@@ -2,6 +2,9 @@
 This module contains helper validation functions
 to be used with configuration schemas.
 """
+import warnings
+
+import six
 import validators
 
 
@@ -39,4 +42,28 @@ def is_valid_url(url):
 
 
 def is_valid_email(email):
+    """Validator that checks if an email is valid"""
     return bool(validators.email(email))
+
+
+def validate_display_name(name, length, description):
+    """Validator that checks if the name for UI display is valid."""
+    if not isinstance(name, six.string_types):
+        raise ValueError(
+            '{desc} "{name}" must be a string, it is of type:'
+            " {type}".format(name=name, desc=description, type=type(name))
+        )
+
+    if not name or len(name) > length:
+        raise ValueError(
+            '{desc} "{name}" must be a non-empty string with'
+            " length not greater than {length}".format(
+                name=name, desc=description, length=length
+            )
+        )
+
+    if ":" in six.ensure_str(name):
+        warnings.warn(
+            "It is strongly suggested that {desc} contains no colon, but"
+            " Testplan found [{name}]".format(name=name, desc=description)
+        )

--- a/testplan/defaults.py
+++ b/testplan/defaults.py
@@ -28,3 +28,9 @@ WEB_SERVER_TIMEOUT = 10
 
 # Default to using 4 threads for interactive pool.
 INTERACTIVE_POOL_SIZE = 4
+
+# Name of multitest/testsuite/testcase (usually used for display) cannot be
+# too long, or the UI will not be pleasant when they end up with long names
+MAX_MULTITEST_NAME_LENGTH = 120
+MAX_TESTSUITE_NAME_LENGTH = 120
+MAX_TESTCASE_NAME_LENGTH = 120

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -9,6 +9,7 @@ import warnings
 from lxml import objectify
 from schema import Or, Use, And
 
+from testplan.defaults import MAX_MULTITEST_NAME_LENGTH
 from testplan.common.config import ConfigOption, validate_func
 
 from testplan.testing import filtering, ordering, tagging
@@ -24,6 +25,7 @@ from testplan.common.utils.process import subprocess_popen
 from testplan.common.utils.timing import parse_duration, format_duration
 from testplan.common.utils.process import enforce_timeout, kill_process
 from testplan.common.utils.strings import slugify
+from testplan.common.utils.validation import validate_display_name
 
 from testplan.report import (
     test_styles,
@@ -53,8 +55,7 @@ class TestConfig(RunnableConfig):
         )
 
         return {
-            # 'name': And(str, lambda s: s.count(' ') == 0),
-            "name": str,
+            "name": str,  # And(str, lambda s: s.count(' ') == 0),
             ConfigOption("description", default=None): Or(str, None),
             ConfigOption("environment", default=[]): [Resource],
             ConfigOption("before_start", default=None): start_stop_signature,
@@ -128,11 +129,9 @@ class Test(Runnable):
     filter_levels = [filtering.FilterLevel.TEST]
 
     def __init__(self, **options):
-        if ":" in options.get("name", ""):
-            warnings.warn(
-                "It is strongly suggested not using colon in name of {} - "
-                "[{}]".format(self.__class__.__name__, options.get("name"))
-            )
+        validate_display_name(
+            options.get("name"), MAX_MULTITEST_NAME_LENGTH, "MultiTest name"
+        )
 
         super(Test, self).__init__(**options)
 

--- a/testplan/testing/multitest/parametrization.py
+++ b/testplan/testing/multitest/parametrization.py
@@ -20,10 +20,6 @@ PYTHON_VARIABLE_REGEX = re.compile(PYTHON_VARIABLE_PATTERN)
 
 # Python attribute names can be of unlimited length but we set a limit here
 MAX_METHOD_NAME_LENGTH = 255
-# Name of testcase (usually used for display) cannot be too long,
-# Because the UI will not be pleasant when we end up with really long names
-MAX_TESTSUITE_NAME_LENGTH = 80
-MAX_TESTCASE_NAME_LENGTH = 80
 
 
 class ParametrizationError(ValueError):
@@ -444,19 +440,12 @@ def generate_functions(
         for kwargs in kwarg_list
     ]
 
-    for func, kwargs in zip(functions, kwarg_list):
-        func.name = func.name or func.__name__
+    for func in functions:
         func.summarize = summarize
         func.summarize_num_passing = num_passing
         func.summarize_num_failing = num_failing
         func.summarize_key_combs_limit = key_combs_limit
         func.execution_group = execution_group
         func.timeout = timeout
-
-        if ":" in func.name:
-            warnings.warn(
-                "It is strongly suggested not using colon in"
-                " name of testcase - [{}]".format(func.name)
-            )
 
     return functions

--- a/testplan/web_ui/testing/src/Common/sampleReports.js
+++ b/testplan/web_ui/testing/src/Common/sampleReports.js
@@ -436,5 +436,6 @@ const FakeInteractiveReport = {
 export {
   TESTPLAN_REPORT,
   SIMPLE_REPORT,
+  ERROR_REPORT,
   FakeInteractiveReport,
 }

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
@@ -2513,14 +2513,52 @@ exports[`BatchReport shallow renders the correct HTML structure when report with
       extraButtons={
         Array [
           <TimeButton
-            status={null}
+            status="error"
             updateTimeDisplayCbk={[Function]}
           />,
         ]
       }
       filterBoxWidth="22em"
       handleNavFilter={[Function]}
-      status={null}
+      report={
+        Object {
+          "category": "testplan",
+          "entries": Array [],
+          "logs": Array [
+            Object {
+              "created": "2018-10-15T14:30:12.971680+00:00",
+              "funcName": "post_step_call",
+              "levelname": "ERROR",
+              "levelno": 40,
+              "lineno": 387,
+              "message": "While starting resource [client]
+Traceback (most recent call last):
+  File \\"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/common/entity/base.py\\", line 143, in start
+    resource.start()
+  File \\"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/testing/multitest/driver/base.py\\", line 148, in start
+    self.starting()
+  File \\"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/testing/multitest/driver/tcp/client.py\\", line 161, in starting
+    1/0
+ZeroDivisionError: integer division or modulo by zero
+",
+              "uid": "dbc47190-505b-4153-ab3e-fec460eac78d",
+            },
+          ],
+          "meta": Object {},
+          "name": "Testplan with errors",
+          "status": "error",
+          "status_override": null,
+          "tags_index": Object {},
+          "timer": Object {
+            "run": Object {
+              "end": "2018-10-15T14:30:11.296158+00:00",
+              "start": "2018-10-15T14:30:10.998071+00:00",
+            },
+          },
+          "uid": "520a92e4-325e-4077-93e6-55d7091a3f83",
+        }
+      }
+      status="error"
       updateEmptyDisplayFunc={[Function]}
       updateFilterFunc={[Function]}
       updateTagsDisplayFunc={[Function]}
@@ -2561,7 +2599,7 @@ exports[`BatchReport shallow renders the correct HTML structure when report with
             </div>
             <Collapse
               appear={false}
-              className="toolbar_l6n5rs-o_O-toolbarUnknown_1mqui2p"
+              className="toolbar_l6n5rs-o_O-toolbarFailed_1v5i7tx"
               enter={true}
               exit={true}
               in={false}
@@ -2594,7 +2632,7 @@ exports[`BatchReport shallow renders the correct HTML structure when report with
                 unmountOnExit={false}
               >
                 <div
-                  className="toolbar_l6n5rs-o_O-toolbarUnknown_1mqui2p collapse navbar-collapse"
+                  className="toolbar_l6n5rs-o_O-toolbarFailed_1v5i7tx collapse navbar-collapse"
                   style={Object {}}
                 >
                   <Nav
@@ -2608,7 +2646,7 @@ exports[`BatchReport shallow renders the correct HTML structure when report with
                     >
                       <TimeButton
                         key="time-button"
-                        status={null}
+                        status="error"
                         updateTimeDisplayCbk={[Function]}
                       >
                         <NavItem
@@ -2764,14 +2802,14 @@ exports[`BatchReport shallow renders the correct HTML structure when report with
                               >
                                 <DropdownToggle
                                   aria-haspopup={true}
-                                  className="toolbar_l6n5rs-o_O-toolbarUnknown_1mqui2p"
+                                  className="toolbar_l6n5rs-o_O-toolbarFailed_1v5i7tx"
                                   color="secondary"
                                   nav={true}
                                 >
                                   <a
                                     aria-expanded={false}
                                     aria-haspopup={true}
-                                    className="toolbar_l6n5rs-o_O-toolbarUnknown_1mqui2p nav-link"
+                                    className="toolbar_l6n5rs-o_O-toolbarFailed_1v5i7tx nav-link"
                                     href="#"
                                     onClick={[Function]}
                                   >
@@ -3335,6 +3373,44 @@ exports[`BatchReport shallow renders the correct HTML structure when report with
       handleColumnResizing={[Function]}
       handleNavClick={[Function]}
       navListWidth="22em"
+      report={
+        Object {
+          "category": "testplan",
+          "entries": Array [],
+          "logs": Array [
+            Object {
+              "created": "2018-10-15T14:30:12.971680+00:00",
+              "funcName": "post_step_call",
+              "levelname": "ERROR",
+              "levelno": 40,
+              "lineno": 387,
+              "message": "While starting resource [client]
+Traceback (most recent call last):
+  File \\"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/common/entity/base.py\\", line 143, in start
+    resource.start()
+  File \\"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/testing/multitest/driver/base.py\\", line 148, in start
+    self.starting()
+  File \\"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/testing/multitest/driver/tcp/client.py\\", line 161, in starting
+    1/0
+ZeroDivisionError: integer division or modulo by zero
+",
+              "uid": "dbc47190-505b-4153-ab3e-fec460eac78d",
+            },
+          ],
+          "meta": Object {},
+          "name": "Testplan with errors",
+          "status": "error",
+          "status_override": null,
+          "tags_index": Object {},
+          "timer": Object {
+            "run": Object {
+              "end": "2018-10-15T14:30:11.296158+00:00",
+              "start": "2018-10-15T14:30:10.998071+00:00",
+            },
+          },
+          "uid": "520a92e4-325e-4077-93e6-55d7091a3f83",
+        }
+      }
       selected={Array []}
     >
       <NavBreadcrumbs
@@ -3401,7 +3477,7 @@ exports[`BatchReport shallow renders the correct HTML structure when report with
     </Nav>
     <Message
       left="22em"
-      message="Fetching Testplan report..."
+      message="Please select an entry."
     >
       <div
         style={
@@ -3414,7 +3490,7 @@ exports[`BatchReport shallow renders the correct HTML structure when report with
         <h1
           className="message_110xrpz"
         >
-          Fetching Testplan report...
+          Please select an entry.
         </h1>
       </div>
     </Message>

--- a/tests/functional/testplan/runnable/interactive/test_interactive.py
+++ b/tests/functional/testplan/runnable/interactive/test_interactive.py
@@ -74,13 +74,12 @@ class BasicSuite(object):
         result.equal(1, 1, description="Passing assertion")
 
 
-@testsuite
+@testsuite(
+    custom_name=lambda self, original_name: "Custom_{}".format(self.arg)
+)
 class TCPSuite(object):
     def __init__(self, arg):
         self.arg = arg
-
-    def suite_name(self):
-        return "Custom_{}".format(self.arg)
 
     @testcase
     def send_and_receive_msg(self, env, result):

--- a/tests/functional/testplan/testing/multitest/test_parametrization.py
+++ b/tests/functional/testplan/testing/multitest/test_parametrization.py
@@ -3,26 +3,24 @@ import logging
 from contextlib import contextmanager
 
 import pytest
-from schema import SchemaError
 from six.moves import reload_module
 
+from testplan.defaults import MAX_TESTCASE_NAME_LENGTH
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 from testplan.testing.multitest.parametrization import (
-    ParametrizationError,
     MAX_METHOD_NAME_LENGTH,
-    MAX_TESTCASE_NAME_LENGTH,
-)
-
-from testplan.common.utils.testing import (
-    check_report,
-    warnings_suppressed,
-    log_propagation_disabled,
+    ParametrizationError,
 )
 from testplan.report import (
     TestReport,
     TestGroupReport,
     TestCaseReport,
     ReportCategories,
+)
+from testplan.common.utils.testing import (
+    check_report,
+    warnings_suppressed,
+    log_propagation_disabled,
 )
 from testplan.common.utils.logger import TESTPLAN_LOGGER
 
@@ -445,7 +443,7 @@ def test_invalid_name_func(name_func, msg):
 
 def test_invalid_long_testcase_name(mockplan):
     """Custom naming function should return a valid non-empty string."""
-    with pytest.raises(SchemaError):
+    with pytest.raises(ValueError):
 
         long_string = "a" * (MAX_TESTCASE_NAME_LENGTH + 1)
 

--- a/tests/functional/testplan/testing/multitest/test_suite_decorators.py
+++ b/tests/functional/testplan/testing/multitest/test_suite_decorators.py
@@ -1,5 +1,9 @@
 """TODO."""
 
+import pytest
+from schema import SchemaError
+
+from testplan.defaults import MAX_TESTSUITE_NAME_LENGTH
 from testplan.testing.multitest import MultiTest
 
 from testplan.common.utils.testing import log_propagation_disabled
@@ -41,7 +45,7 @@ def post2(name, self, env, result, a=None, b=None):
 
 @pre_testcase(pre1)
 @post_testcase(post1)
-@testsuite(name="Test Suite - One")
+@testsuite(custom_name="Test Suite - One")
 class Suite1(object):
     def setup(self, env, result):
         result.equal(2, 2)
@@ -65,13 +69,17 @@ class Suite1(object):
 
 @pre_testcase(pre2)
 @post_testcase(post2)
-@testsuite(name="Test Suite")
+@testsuite(
+    custom_name=lambda self, original_name: "Test Suite - Another {}".format(
+        self.val
+    )
+)
 class Suite2(object):
+    def __init__(self, val):
+        self.val = val
+
     def setup(self, env):
         pass
-
-    def suite_name(self):
-        return "Another"
 
     @testcase(parameters=(("aa", "bb"), ("aaa", "bbb")))
     def case4(self, env, result, a, b):
@@ -92,29 +100,31 @@ class Suite2(object):
 
 def test_basic_multitest(mockplan):
 
-    mtest = MultiTest(name="Name1", suites=[Suite1(), Suite2()])
+    mtest = MultiTest(name="MTest", suites=[Suite1(), Suite2(1), Suite2(2)])
     mockplan.add(mtest)
 
     with log_propagation_disabled(TESTPLAN_LOGGER):
         res = mockplan.run()
 
     assert res.run is True
-    assert isinstance(res.test_results["Name1"].report, TestGroupReport)
-    assert len(res.test_results["Name1"].report.entries) == 2
+    assert isinstance(res.test_results["MTest"].report, TestGroupReport)
+    assert len(res.test_results["MTest"].report.entries) == 3
     assert isinstance(mockplan.report, TestReport)
     assert len(mockplan.report.entries) == 1  # 1 Multitest
 
     mt_entry = mockplan.report.entries[0]
     assert isinstance(mt_entry, TestGroupReport)
-    assert len(mt_entry.entries) == 2  # 2 Suites
+    assert len(mt_entry.entries) == 3  # 2 Suites
     assert mt_entry.entries[0].name == "Test Suite - One"
-    assert mt_entry.entries[0].uid == "Suite1"
-    assert mt_entry.entries[1].name == "Test Suite - Another"
-    assert mt_entry.entries[1].uid == "Suite2"
+    assert mt_entry.entries[0].uid == "Test Suite - One"
+    assert mt_entry.entries[1].name == "Test Suite - Another 1"
+    assert mt_entry.entries[1].uid == "Test Suite - Another 1"
+    assert mt_entry.entries[2].name == "Test Suite - Another 2"
+    assert mt_entry.entries[2].uid == "Test Suite - Another 2"
 
     for st_entry in mt_entry.entries:
         assert isinstance(st_entry, TestGroupReport)
-        assert len(st_entry.entries) == 4  # 4 Testcases
+        assert len(st_entry.entries) == 4  # 4 entries in each suites
 
         for tc_entry in st_entry.entries:
             if tc_entry.name == "case4":
@@ -123,3 +133,41 @@ def test_basic_multitest(mockplan):
                 assert len(tc_entry.entries) == 2  # 2 generated testcases
             else:
                 assert isinstance(tc_entry, TestCaseReport)
+
+
+def test_invalid_long_testsuite_name(mockplan):
+    """Custom naming function should return a valid non-empty string."""
+    with pytest.raises(SchemaError):
+
+        long_string = "a" * (MAX_TESTSUITE_NAME_LENGTH + 1)
+
+        @testsuite(custom_name=long_string)
+        class MySuite(object):
+            def sample_test(self, env, result):
+                pass
+
+        multitest = MultiTest(name="MTest", suites=[MySuite()])
+        mockplan.add(multitest)
+
+        with log_propagation_disabled(TESTPLAN_LOGGER):
+            mockplan.run()
+
+        pytest.fail("Should fail if custom_name returns a very long string.")
+
+
+def test_duplicate_testsuite_names(mockplan):
+    """Custom naming function should return a valid non-empty string."""
+    with pytest.raises(SchemaError):
+
+        @testsuite
+        class MySuite(object):
+            def sample_test(self, env, result):
+                pass
+
+        multitest = MultiTest(name="MTest", suites=[MySuite(), MySuite()])
+        mockplan.add(multitest)
+
+        with log_propagation_disabled(TESTPLAN_LOGGER):
+            mockplan.run()
+
+        pytest.fail("Should fail if 2 Multitests have the same name.")

--- a/tests/unit/testplan/testing/test_filtering.py
+++ b/tests/unit/testplan/testing/test_filtering.py
@@ -21,11 +21,11 @@ class Alpha(object):
         pass
 
 
-@testsuite(tags="bar")
+@testsuite(
+    tags="bar",
+    custom_name=lambda self, original_name: original_name + " - Custom",
+)
 class Beta(object):
-    def suite_name(self):
-        return "Custom"
-
     @testcase
     def test_one(self, env, result):
         pass
@@ -238,7 +238,7 @@ class TestPattern(object):
             ("*:Alpha:foo", Alpha(), True),
             ("*:Al*:foo", Alpha(), True),
             ("*:B*:*", Alpha(), False),
-            # suite_name func overrides class name
+            # custom_name func overrides the original class name
             ("*:Beta:*", Beta(), False),
             ("*:Beta - Custom:*", Beta(), True),
         ),


### PR DESCRIPTION
* if a test suite class is initialized twice and the instances
  are added into a multitest then there is name conflict on both
  test suite names and test suite unique ID. we usa=ually have a
  method `suite_name` which can be override and then the return
  value is made as a postfix of test suite name, but this is really
  confusing. Now an argument `custom_name` is added to @testsuite
  and it can be a normal string or a function takes 2 args and
  return a string.
