### PR TITLE
Improve the feature of testcase/suite name customization

### DIFF
--- a/doc/en/download/Multitest.rst
+++ b/doc/en/download/Multitest.rst
@@ -29,7 +29,7 @@ Required files:
 
 test_plan.py
 ````````````
-.. literalinclude:: ../../../examples/Multitest/Basic/Custom Name/test_plan.py
+.. literalinclude:: ../../../examples/Multitest/Basic/Name Customization/test_plan.py
 
 
 .. _example_multitest_listing:

--- a/examples/Multitest/Basic/Name Customization/test_plan.py
+++ b/examples/Multitest/Basic/Name Customization/test_plan.py
@@ -1,25 +1,30 @@
 #!/usr/bin/env python
 """
-    A Simple example to show how to customize name for test suite and testcase.
+A Simple example to show how to customize name for testsuite and testcase.
 """
 
 from testplan import test_plan
 from testplan.testing.multitest import testsuite, testcase, MultiTest
 
 
-def suite_name_fn(self, original_name):
-    """Function to return a customized name for test suite"""
-    return "{} - {}".format(original_name, self.val)
+def suite_name_func(cls_name, suite):
+    """Function to return a customized name for testsuite."""
+    return "{} -- {}".format(cls_name, suite.val)
 
 
-def case_name_fn(func_name, kwargs):
-    """Function to return a customized name for parameterized testcase"""
-    return "{} - {}+{}={}".format(
+def case_name_func(func_name, kwargs):
+    """Function to return a customized name for parameterized testcase."""
+    return "{} ({}+{}={})".format(
         func_name, kwargs["a"], kwargs["b"], kwargs["expected"]
     )
 
 
-@testsuite(custom_name="A simple test suite")
+# In @testcase decorator, ``name`` should be a normal string, it can be
+# used with ``name_func`` for parametrized testcases. Refer to examples
+# "../../Parametrization/test_plan.py"
+
+
+@testsuite(name="A Simple Suite")
 class SimpleSuite(object):
     @testcase(name="An empty testcase")
     def test_example(self, env, result):
@@ -28,13 +33,20 @@ class SimpleSuite(object):
     @testcase(
         name="Parametrized testcases",
         parameters=((1, 2, 3), (1, 0, 1)),
-        name_func=case_name_fn,
+        name_func=case_name_func,
     )
     def test_equal(self, env, result, a, b, expected):
         result.equal(a + b, expected, description="Equality test")
 
 
-@testsuite(custom_name=suite_name_fn)
+# In @testsuite decorator, ``name`` can be a normal string or a callable
+# receiving 2 arguments ``cls_name`` and ``suite``, the former is testsuite
+# class name, and the latter is the instance of testsuite class. This can be
+# used when multiple instances from the same testsuite class are added into
+# one Multitest, and their names in the report can be made different.
+
+
+@testsuite(name=suite_name_func)
 class ComplicatedSuite(object):
     def __init__(self, val):
         self.val = val
@@ -42,6 +54,10 @@ class ComplicatedSuite(object):
     @testcase(name="A testcase with one assertion")
     def test_less_than(self, env, result):
         result.less(self.val, 100, description="{} < 100".format(self.val))
+
+
+# A multitest has one testsuite instance from ``SimpleSuite`` and 2 instances
+# from ``ComplicatedSuite``.
 
 
 @test_plan(name="Name customization example")

--- a/examples/Multitest/Ordering/Custom Sorters/test_plan.py
+++ b/examples/Multitest/Ordering/Custom Sorters/test_plan.py
@@ -9,7 +9,6 @@ from testplan.testing.multitest import MultiTest, testsuite, testcase
 
 from testplan import test_plan
 from testplan.report.testing.styles import Style
-from testplan.testing.multitest.suite import get_testsuite_name
 from testplan.testing.ordering import NoopSorter, TypedSorter
 
 
@@ -76,11 +75,13 @@ class ReverseNameLengthSorter(TypedSorter):
         )
 
     def sort_testsuites(self, testsuites):
-        return self.reverse_sort_by_name(testsuites, get_testsuite_name)
+        return self.reverse_sort_by_name(
+            testsuites, operator.attrgetter("name")
+        )
 
     def sort_testcases(self, testcases):
         return self.reverse_sort_by_name(
-            testcases, operator.attrgetter("__name__")
+            testcases, operator.attrgetter("name")
         )
 
 

--- a/examples/Multitest/Parametrization/test_plan.py
+++ b/examples/Multitest/Parametrization/test_plan.py
@@ -77,10 +77,9 @@ class SimpleTest(object):
 # This way we can come up with more readable testcase
 # method names on the test reports.
 
-# If we didn't use a custom name function, we'd end up with method names
-# like `func_raises_error__0`, `func_raises_error__1`
-# But instead the custom function will give
-# us names like `func_raises_error__ValueError`
+# If we didn't use a custom name function, we'd end up with method name
+# like `func_raises_error <func=.., error=...>`, but instead, the custom
+# function will give us names like `func_raises_error__ValueError`.
 
 
 def custom_error_name_func(func_name, kwargs):

--- a/testplan/common/utils/validation.py
+++ b/testplan/common/utils/validation.py
@@ -44,26 +44,3 @@ def is_valid_url(url):
 def is_valid_email(email):
     """Validator that checks if an email is valid"""
     return bool(validators.email(email))
-
-
-def validate_display_name(name, length, description):
-    """Validator that checks if the name for UI display is valid."""
-    if not isinstance(name, six.string_types):
-        raise ValueError(
-            '{desc} "{name}" must be a string, it is of type:'
-            " {type}".format(name=name, desc=description, type=type(name))
-        )
-
-    if not name or len(name) > length:
-        raise ValueError(
-            '{desc} "{name}" must be a non-empty string with'
-            " length not greater than {length}".format(
-                name=name, desc=description, length=length
-            )
-        )
-
-    if ":" in six.ensure_str(name):
-        warnings.warn(
-            "It is strongly suggested that {desc} contains no colon, but"
-            " Testplan found [{name}]".format(name=name, desc=description)
-        )

--- a/testplan/defaults.py
+++ b/testplan/defaults.py
@@ -31,6 +31,4 @@ INTERACTIVE_POOL_SIZE = 4
 
 # Name of multitest/testsuite/testcase (usually used for display) cannot be
 # too long, or the UI will not be pleasant when they end up with long names
-MAX_MULTITEST_NAME_LENGTH = 120
-MAX_TESTSUITE_NAME_LENGTH = 120
-MAX_TESTCASE_NAME_LENGTH = 120
+MAX_TEST_NAME_LENGTH = 255

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -207,10 +207,10 @@ class BaseReportGroup(ReportGroup):
 
     exception_logger = ExceptionLogger
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, name, **kwargs):
         self.meta = kwargs.pop("meta", {})
         self.status_reason = kwargs.pop("status_reason", None)
-        super(BaseReportGroup, self).__init__(*args, **kwargs)
+        super(BaseReportGroup, self).__init__(name=name, **kwargs)
         self.status_override = None
         self.timer = timing.Timer()
 
@@ -443,11 +443,11 @@ class TestReport(BaseReportGroup):
 
     def __init__(
         self,
+        name,
         meta=None,
         attachments=None,
         information=None,
         timeout=None,
-        *args,
         **kwargs
     ):
         self._tags_index = None
@@ -474,7 +474,7 @@ class TestReport(BaseReportGroup):
         self.timeout = timeout
         self.category = ReportCategories.TESTPLAN
 
-        super(TestReport, self).__init__(*args, **kwargs)
+        super(TestReport, self).__init__(name=name, **kwargs)
 
     @property
     def tags_index(self):

--- a/testplan/testing/filtering.py
+++ b/testplan/testing/filtering.py
@@ -7,7 +7,6 @@ import fnmatch
 from enum import Enum, unique
 
 from testplan.testing import tagging
-from testplan.testing.multitest.suite import get_testsuite_name
 
 
 class FilterLevel(Enum):
@@ -292,9 +291,9 @@ class Pattern(Filter):
 
     def filter_suite(self, suite):
         return fnmatch.fnmatch(
-            suite.__class__.__name__
-            if self.match_definition
-            else get_testsuite_name(suite),
+            # Now, Suite has the same name and uid, just like that of Multitest
+            # suite.__class__.__name__ if self.match_definition else suite.name,
+            suite.name,
             self.suite_pattern,
         )
 

--- a/testplan/testing/listing.py
+++ b/testplan/testing/listing.py
@@ -10,7 +10,6 @@ from testplan.common.utils.logger import TESTPLAN_LOGGER
 
 from testplan.testing import tagging
 from testplan.testing.multitest import MultiTest
-from testplan.testing.multitest.suite import get_testsuite_name
 
 INDENT = " "
 MAX_TESTCASES = 25
@@ -64,7 +63,7 @@ class ExpandedNameLister(BaseLister):
         if isinstance(suite, six.string_types):
             return suite
         else:
-            return get_testsuite_name(suite)
+            return suite.name
 
     def format_testcase(self, instance, suite, testcase):
         if isinstance(testcase, six.string_types):
@@ -138,7 +137,7 @@ class ExpandedPatternLister(ExpandedNameLister):
         if not isinstance(instance, MultiTest):
             return "{}::{}".format(instance.name, suite)
 
-        pattern = "{}::{}".format(instance.name, get_testsuite_name(suite))
+        pattern = "{}::{}".format(instance.name, suite.name)
         return self.apply_tag_label(pattern, suite)
 
     def format_testcase(self, instance, suite, testcase):
@@ -147,7 +146,7 @@ class ExpandedPatternLister(ExpandedNameLister):
             return "{}::{}::{}".format(instance.name, suite, testcase)
 
         pattern = "{}::{}::{}".format(
-            instance.name, get_testsuite_name(suite), testcase.name,
+            instance.name, suite.name, testcase.name,
         )
         return self.apply_tag_label(pattern, testcase)
 

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -9,10 +9,12 @@ from builtins import str
 from future import standard_library
 
 standard_library.install_aliases()
+
 import os
 import collections
 import functools
 import itertools
+import warnings
 
 import concurrent
 
@@ -39,21 +41,21 @@ def iterable_suites(obj):
     """Create an iterable suites object."""
     suites = [obj] if not isinstance(obj, collections.Iterable) else obj
 
-    # No duplicate names of test suites are allowed, if there is any, user
-    # should use `custom_name` argument of @testsuite for customization
-    suite_names = [mtest_suite.get_testsuite_name(suite) for suite in suites]
-    for name in suite_names:
-        validation.validate_display_name(
-            name, defaults.MAX_TESTSUITE_NAME_LENGTH, "Test suite name"
-        )
-
-    suite_name_counts = collections.Counter(suite_names)
-    dupe_names = {k for k, v in suite_name_counts.items() if v > 1}
+    # If multiple objects from one test suite class are added into a Multitest,
+    # it's better provide naming function to avoid duplicate test suite names.
+    name_counts = collections.Counter(
+        # After calling `get_testsuite_name` each test suite object has
+        # an attribute `name` of string type (value has been verified)
+        mtest_suite.get_testsuite_name(suite)
+        for suite in suites
+    )
+    dupe_names = {k for k, v in name_counts.items() if v > 1}
 
     if len(dupe_names) > 0:
         raise ValueError(
-            "Duplicate test suite name found: {}. Consider using `custom_name`"
-            " argument in @testsuite decorator.".format(", ".join(dupe_names))
+            'Duplicate test suite name found: "{}".'
+            " Consider customizing test suite names with argument `name`"
+            " in @testsuite decorator.".format(", ".join(dupe_names))
         )
 
     for suite in suites:
@@ -557,10 +559,10 @@ class MultiTest(testing_base.Test):
         :return: A new and empty report for a testsuite.
         """
         return testplan.report.TestGroupReport(
-            name=mtest_suite.get_testsuite_name(testsuite),
+            name=testsuite.name,
             description=strings.get_docstring(testsuite.__class__),
             category=testplan.report.ReportCategories.TESTSUITE,
-            uid=testsuite.__name__,
+            uid=testsuite.name,
             tags=testsuite.__tags__,
             extra_attributes=testsuite.__extra_attributes__,
         )
@@ -688,7 +690,7 @@ class MultiTest(testing_base.Test):
                 if self.cfg.stop_on_error:
                     self.logger.debug(
                         'Stopping exeucution of testsuite "%s" due to error',
-                        mtest_suite.get_testsuite_name(testsuite),
+                        testsuite.name,
                     )
                     break
 
@@ -949,7 +951,7 @@ class MultiTest(testing_base.Test):
         """Runs a testsuite object and returns its report."""
         _check_testcases(testcases)
         setup_report = self._setup_testsuite(testsuite)
-        testsuite_uid = mtest_suite.get_testsuite_name(testsuite)
+        testsuite_uid = testsuite.name
 
         if setup_report is not None:
             yield setup_report, [self.name, testsuite_uid]
@@ -975,7 +977,7 @@ class MultiTest(testing_base.Test):
         """
         pre_testcase = getattr(testsuite, "pre_testcase", None)
         post_testcase = getattr(testsuite, "post_testcase", None)
-        testsuite_uid = mtest_suite.get_testsuite_name(testsuite)
+        testsuite_uid = testsuite.name
 
         for testcase in testcases:
             if not self.active:

--- a/testplan/testing/ordering.py
+++ b/testplan/testing/ordering.py
@@ -10,7 +10,6 @@ import six
 from enum import Enum
 
 from testplan.common.utils.convert import make_tuple
-from testplan.testing.multitest.suite import get_testsuite_name
 
 
 class SortType(Enum):
@@ -161,7 +160,7 @@ class AlphanumericSorter(TypedSorter):
         return sorted(instances, key=operator.attrgetter("name"))
 
     def sort_testsuites(self, testsuites):
-        return sorted(testsuites, key=get_testsuite_name)
+        return sorted(testsuites, key=operator.attrgetter("name"))
 
     def sort_testcases(self, testcases):
         return sorted(testcases, key=operator.attrgetter("name"))

--- a/testplan/web_ui/testing/src/Common/sampleReports.js
+++ b/testplan/web_ui/testing/src/Common/sampleReports.js
@@ -355,7 +355,7 @@ const ERROR_REPORT = {
   "entries": [],
   "logs": [
     {
-      "message": "While starting resource [client]\nTraceback (most recent call last):\n  File \"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/common/entity/base.py\", line 143, in start\n    resource.start()\n  File \"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/testing/multitest/driver/base.py\", line 148, in start\n    self.starting()\n  File \"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/testing/multitest/driver/tcp/client.py\", line 161, in starting\n    1/0\nZeroDivisionError: integer division or modulo by zero\n",
+      "message": "While starting resource [client]\nTraceback (most recent call last):\n  File \"/tmp/myworkspace/testplan/common/entity/base.py\", line 143, in start\n    resource.start()\n  File \"/tmp/myworkspace/testplan/testing/multitest/driver/base.py\", line 148, in start\n    self.starting()\n  File \"/tmp/myworkspace/testplan/testing/multitest/driver/tcp/client.py\", line 161, in starting\n    1/0\nZeroDivisionError: integer division or modulo by zero\n",
       "created": "2018-10-15T14:30:12.971680+00:00",
       "levelno": 40,
       "levelname": "ERROR",

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
@@ -2533,11 +2533,11 @@ exports[`BatchReport shallow renders the correct HTML structure when report with
               "lineno": 387,
               "message": "While starting resource [client]
 Traceback (most recent call last):
-  File \\"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/common/entity/base.py\\", line 143, in start
+  File \\"/tmp/myworkspace/testplan/common/entity/base.py\\", line 143, in start
     resource.start()
-  File \\"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/testing/multitest/driver/base.py\\", line 148, in start
+  File \\"/tmp/myworkspace/testplan/testing/multitest/driver/base.py\\", line 148, in start
     self.starting()
-  File \\"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/testing/multitest/driver/tcp/client.py\\", line 161, in starting
+  File \\"/tmp/myworkspace/testplan/testing/multitest/driver/tcp/client.py\\", line 161, in starting
     1/0
 ZeroDivisionError: integer division or modulo by zero
 ",
@@ -3386,11 +3386,11 @@ ZeroDivisionError: integer division or modulo by zero
               "lineno": 387,
               "message": "While starting resource [client]
 Traceback (most recent call last):
-  File \\"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/common/entity/base.py\\", line 143, in start
+  File \\"/tmp/myworkspace/testplan/common/entity/base.py\\", line 143, in start
     resource.start()
-  File \\"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/testing/multitest/driver/base.py\\", line 148, in start
+  File \\"/tmp/myworkspace/testplan/testing/multitest/driver/base.py\\", line 148, in start
     self.starting()
-  File \\"/d/d1/shared/yitaor/ets.testplan.2/ets/testplan/ets.testplan/src/oss/testplan/testing/multitest/driver/tcp/client.py\\", line 161, in starting
+  File \\"/tmp/myworkspace/testplan/testing/multitest/driver/tcp/client.py\\", line 161, in starting
     1/0
 ZeroDivisionError: integer division or modulo by zero
 ",

--- a/tests/functional/testplan/runnable/interactive/test_interactive.py
+++ b/tests/functional/testplan/runnable/interactive/test_interactive.py
@@ -74,9 +74,7 @@ class BasicSuite(object):
         result.equal(1, 1, description="Passing assertion")
 
 
-@testsuite(
-    custom_name=lambda self, original_name: "Custom_{}".format(self.arg)
-)
+@testsuite(name=lambda cls_name, suite: "Custom_{}".format(suite.arg))
 class TCPSuite(object):
     def __init__(self, arg):
         self.arg = arg

--- a/tests/functional/testplan/testing/multitest/test_suite_decorators.py
+++ b/tests/functional/testplan/testing/multitest/test_suite_decorators.py
@@ -1,9 +1,10 @@
 """TODO."""
 
 import pytest
+import mock
 from schema import SchemaError
 
-from testplan.defaults import MAX_TESTSUITE_NAME_LENGTH
+from testplan.defaults import MAX_TEST_NAME_LENGTH
 from testplan.testing.multitest import MultiTest
 
 from testplan.common.utils.testing import log_propagation_disabled
@@ -45,7 +46,7 @@ def post2(name, self, env, result, a=None, b=None):
 
 @pre_testcase(pre1)
 @post_testcase(post1)
-@testsuite(custom_name="Test Suite - One")
+@testsuite(name="Test Suite")
 class Suite1(object):
     def setup(self, env, result):
         result.equal(2, 2)
@@ -69,11 +70,7 @@ class Suite1(object):
 
 @pre_testcase(pre2)
 @post_testcase(post2)
-@testsuite(
-    custom_name=lambda self, original_name: "Test Suite - Another {}".format(
-        self.val
-    )
-)
+@testsuite(name=lambda cls_name, suite: "{}__{}".format(cls_name, suite.val))
 class Suite2(object):
     def __init__(self, val):
         self.val = val
@@ -99,8 +96,8 @@ class Suite2(object):
 
 
 def test_basic_multitest(mockplan):
-
-    mtest = MultiTest(name="MTest", suites=[Suite1(), Suite2(1), Suite2(2)])
+    """Basic test for suite decorator."""
+    mtest = MultiTest(name="MTest", suites=[Suite1(), Suite2(0), Suite2(1)])
     mockplan.add(mtest)
 
     with log_propagation_disabled(TESTPLAN_LOGGER):
@@ -115,12 +112,12 @@ def test_basic_multitest(mockplan):
     mt_entry = mockplan.report.entries[0]
     assert isinstance(mt_entry, TestGroupReport)
     assert len(mt_entry.entries) == 3  # 2 Suites
-    assert mt_entry.entries[0].name == "Test Suite - One"
-    assert mt_entry.entries[0].uid == "Test Suite - One"
-    assert mt_entry.entries[1].name == "Test Suite - Another 1"
-    assert mt_entry.entries[1].uid == "Test Suite - Another 1"
-    assert mt_entry.entries[2].name == "Test Suite - Another 2"
-    assert mt_entry.entries[2].uid == "Test Suite - Another 2"
+    assert mt_entry.entries[0].name == "Test Suite"
+    assert mt_entry.entries[0].uid == "Test Suite"
+    assert mt_entry.entries[1].name == "Suite2__0"
+    assert mt_entry.entries[1].uid == "Suite2__0"
+    assert mt_entry.entries[2].name == "Suite2__1"
+    assert mt_entry.entries[2].uid == "Suite2__1"
 
     for st_entry in mt_entry.entries:
         assert isinstance(st_entry, TestGroupReport)
@@ -135,14 +132,20 @@ def test_basic_multitest(mockplan):
                 assert isinstance(tc_entry, TestCaseReport)
 
 
-def test_invalid_long_testsuite_name(mockplan):
-    """Custom naming function should return a valid non-empty string."""
-    with pytest.raises(SchemaError):
+@pytest.mark.parametrize(
+    "suite_name", ("s" * (MAX_TEST_NAME_LENGTH + 1), "My::Suite")
+)
+def test_unwanted_testsuite_name(mockplan, suite_name):
+    """
+    Warning for inappropriate custom suite name.
+    1. Suite name too long
+    2. Colon in suite name
+    """
+    with mock.patch("warnings.warn", return_value=None) as mock_warn:
 
-        long_string = "a" * (MAX_TESTSUITE_NAME_LENGTH + 1)
-
-        @testsuite(custom_name=long_string)
+        @testsuite(name=suite_name)
         class MySuite(object):
+            @testcase
             def sample_test(self, env, result):
                 pass
 
@@ -152,22 +155,77 @@ def test_invalid_long_testsuite_name(mockplan):
         with log_propagation_disabled(TESTPLAN_LOGGER):
             mockplan.run()
 
-        pytest.fail("Should fail if custom_name returns a very long string.")
+    mock_warn.assert_called_once()
 
 
 def test_duplicate_testsuite_names(mockplan):
-    """Custom naming function should return a valid non-empty string."""
+    """Raises when duplicate suite names found."""
     with pytest.raises(SchemaError):
 
         @testsuite
         class MySuite(object):
+            def __init__(self, val):
+                self.val = val
+
+            @testcase
             def sample_test(self, env, result):
                 pass
 
-        multitest = MultiTest(name="MTest", suites=[MySuite(), MySuite()])
+        multitest = MultiTest(name="MTest", suites=[MySuite(0), MySuite(1)])
         mockplan.add(multitest)
 
         with log_propagation_disabled(TESTPLAN_LOGGER):
             mockplan.run()
 
-        pytest.fail("Should fail if 2 Multitests have the same name.")
+        pytest.fail("Duplicate test suite name found in a Multitest.")
+
+
+@pytest.mark.parametrize(
+    "deco, attr_name", ((testsuite, 123), (testsuite(name=123), "My Suite"))
+)
+def test_invalid_name_attribute_in_suite_class(mockplan, deco, attr_name):
+    """
+    User should not define invalid attribute `name` in a test suite object.
+    Note: This only happens when @testsuite is used but not @testsuite()
+    """
+    with pytest.raises(TypeError):
+
+        class MySuite(object):
+            name = attr_name
+
+            @testcase
+            def sample_test(self, env, result):
+                pass
+
+        MySuite = deco(MySuite)
+        multitest = MultiTest(name="MyMultitest", suites=[MySuite()])
+        mockplan.add(multitest)
+
+        with log_propagation_disabled(TESTPLAN_LOGGER):
+            mockplan.run()
+
+        pytest.fail("Attribute `name` defined in test suite class is invalid.")
+
+
+def test_unexpected_name_attribute_in_suite_object(mockplan):
+    """
+    User cannot define attribute `name` in a test suite object because
+    it is reserved by Testplan.
+    """
+    with pytest.raises(SchemaError):  # `AttributeError` caught by Schema
+
+        @testsuite
+        class MySuite(object):
+            @testcase
+            def sample_test(self, env, result):
+                pass
+
+        suite = MySuite()
+        suite.name = lambda cls_name, suite: cls_name
+        multitest = MultiTest(name="MyMultitest", suites=[suite])
+        mockplan.add(multitest)
+
+        with log_propagation_disabled(TESTPLAN_LOGGER):
+            mockplan.run()
+
+        pytest.fail("Attribute `name` of test suite object is invalid.")

--- a/tests/unit/testplan/testing/test_filtering.py
+++ b/tests/unit/testplan/testing/test_filtering.py
@@ -22,8 +22,7 @@ class Alpha(object):
 
 
 @testsuite(
-    tags="bar",
-    custom_name=lambda self, original_name: original_name + " - Custom",
+    tags="bar", name=lambda cls_name, suite: cls_name + " -- Custom",
 )
 class Beta(object):
     @testcase
@@ -238,13 +237,15 @@ class TestPattern(object):
             ("*:Alpha:foo", Alpha(), True),
             ("*:Al*:foo", Alpha(), True),
             ("*:B*:*", Alpha(), False),
-            # custom_name func overrides the original class name
+            # Argument ``name`` overrides the original class name
             ("*:Beta:*", Beta(), False),
-            ("*:Beta - Custom:*", Beta(), True),
+            ("*:Beta -- Custom:*", Beta(), True),
         ),
     )
     def test_filter_suite(self, pattern, testsuite_obj, expected):
         filter_obj = filtering.Pattern(pattern=pattern)
+        # Test suite object gets its `name` after added into a Multitest
+        MultiTest(name="MTest", suites=testsuite_obj)
         assert bool(filter_obj.filter_suite(testsuite_obj)) == expected
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
* Allow user to give testsuite & testcase a custom name
  - @testcase(name=<str>, name_func=<callable>)
  - @testsuite(name=<str or callable>)
* Consisten testcase/testsuite name func signature:
  - def case_name_fn(func_name, kwargs)
  - def suite_name_fn(cls_name, suite)
* If user explicitly makes "name_func=None" instead of the default one,
  parameterized testcases will get renamed with integer suffix appended
  at the end (no argument showed).
* If name of test suite or testcase is too long (e.g >255 char),
  give a soft warning.
* No duplicate test suite names are allowed for now.
* Fix documentation errors.