### PR TITLE
Fix 2 process pool bugs

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -969,7 +969,7 @@ This is equivalent to declaring each method call explicitly:
     @testsuite
     class SampleTest(object):
 
-      @testcase(parameters={
+      @testcase(parameters=(
           ('Ben', 'Richard', 'Brown'),
           ('Ben', 'Richard', 'van der Heide'),
           ('Ben', 'Richard', "O'Connell"),

--- a/testplan/common/utils/logger.py
+++ b/testplan/common/utils/logger.py
@@ -208,10 +208,23 @@ class Loggable(object):
         # "testplan.<class name>" as the logger name, since class names are
         # mostly unique.
 
-        logger_name = ".".join(("testplan", self.__class__.__name__))
-        self.logger = logging.getLogger(logger_name)
-
+        self._logger = None
         super(Loggable, self).__init__()
+
+    @property
+    def logger(self):
+        """logger object"""
+        # Define logger as a property instead of self.logger directly.
+        # This is to workaround a python2 issue that logger object cannot be
+        # pickled/deepcopied, but we need to do that for task target which
+        # could be a multitest object.
+
+        if self._logger:
+            return self._logger
+
+        logger_name = ".".join(("testplan", self.__class__.__name__))
+        self._logger = logging.getLogger(logger_name)
+        return self._logger
 
     @property
     def _debug_logging_enabled(self):

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -587,7 +587,6 @@ class TestGroupReport(BaseReportGroup):
         category=ReportCategories.TESTGROUP,
         tags=None,
         part=None,
-        extra_attributes=None,
         fix_spec_path=None,
         env_status=None,
         **kwargs
@@ -606,8 +605,6 @@ class TestGroupReport(BaseReportGroup):
         # can be hold back for merging (if necessary)
         self.part = part  # i.e. (m, n), while 0 <= m < n and n > 1
         self.part_report_lookup = {}
-
-        self.extra_attributes = extra_attributes or {}
 
         self.fix_spec_path = fix_spec_path
 

--- a/testplan/report/testing/schemas.py
+++ b/testplan/report/testing/schemas.py
@@ -229,7 +229,6 @@ class TestGroupReportSchema(TestCaseReportSchema):
     source_class = TestGroupReport
     # category = fields.String()
     part = fields.List(fields.Integer, allow_none=True)
-    extra_attributes = fields.Dict(allow_none=True)
     fix_spec_path = fields.String(allow_none=True)
     env_status = fields.String(allow_none=True)
 

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -618,6 +618,8 @@ class TestRunner(Runnable):
                         # a full structured report by dry_run(), thus the order
                         # of testcases can be retained in test report.
                         target = resource_result.task.materialize()
+                        target.parent = self
+                        target.cfg.parent = self.cfg
                         # TODO: Any idea to avoid accessing private members?
                         target.cfg._options["part"] = None
                         target._test_context = None

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -13,7 +13,6 @@ from schema import Or, And, Use
 from testplan.common.config import ConfigOption, validate_func
 from testplan.common import entity
 from testplan.common.utils.thread import interruptible_join
-from testplan.common.utils.strings import Color
 from testplan.common.utils.timing import wait_until_predicate
 from testplan.runners.base import Executor, ExecutorConfig
 from testplan.report import ReportCategories

--- a/testplan/runners/pools/tasks/base.py
+++ b/testplan/runners/pools/tasks/base.py
@@ -9,6 +9,7 @@ import importlib
 from collections import OrderedDict
 
 from six.moves import cPickle
+import copy
 
 
 class TaskMaterializationError(Exception):
@@ -174,7 +175,7 @@ class Task(object):
         """
         Create the actual task target executable/runnable/callable object.
         """
-        target = target or self._target
+        target = target or copy.deepcopy(self._target)
         if not isinstance(target, six.string_types):
             try:
                 run_method = getattr(target, "run")

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -564,7 +564,6 @@ class MultiTest(testing_base.Test):
             category=testplan.report.ReportCategories.TESTSUITE,
             uid=testsuite.name,
             tags=testsuite.__tags__,
-            extra_attributes=testsuite.__extra_attributes__,
         )
 
     def _new_testcase_report(self, testcase):

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -377,24 +377,6 @@ def _testsuite(klass):
         klass.__tags__ = {}  # used for UI
         klass.__tags_index__ = {}  # used for actual filtering
 
-    # Attributes defined in test suite will be saved in test report,
-    # they should be normal objects which can be serialized with json
-    # TODO: Attribute `__extra_attributes__` will be removed later
-    klass.__extra_attributes__ = {
-        attrib: getattr(klass, attrib)
-        for attrib in dir(klass)
-        if not (
-            attrib.startswith("__")
-            or attrib == "name"
-            or callable(getattr(klass, attrib))
-            or isinstance(getattr(klass, attrib), property)
-            or attrib in klass.__testcases__
-            or getattr(
-                getattr(klass, attrib), "__parametrization_template__", False
-            )
-        )
-    }
-
     klass.get_testcases = get_testcase_methods
     testcase_methods = get_testcase_methods(klass)
 

--- a/tests/functional/testplan/runners/pools/test_pool_base.py
+++ b/tests/functional/testplan/runners/pools/test_pool_base.py
@@ -22,8 +22,8 @@ class MySuite(object):
         assert env.runpath.endswith(slugify(env.cfg.name))
 
 
-def get_mtest():
-    return MultiTest(name="MTest3", suites=[MySuite()])
+def get_mtest(name):
+    return MultiTest(name="MTest{}".format(name), suites=[MySuite()])
 
 
 def schedule_tests_to_pool(plan, pool, **pool_cfg):
@@ -38,7 +38,7 @@ def schedule_tests_to_pool(plan, pool, **pool_cfg):
     uid1 = plan.schedule(target=mtest1, resource=pool_name)
     uid2 = plan.schedule(Task(target=mtest2), resource=pool_name)
 
-    task3 = Task(target=get_mtest, path=dirname)
+    task3 = Task(target=get_mtest, path=dirname, kwargs=dict(name=3))
     uid3 = plan.schedule(task=task3, resource=pool_name)
 
     # Task schedule shortcut
@@ -65,14 +65,15 @@ def schedule_tests_to_pool(plan, pool, **pool_cfg):
         Task(target=get_mtest_imported, kwargs=dict(name=6)),
         resource=pool_name,
     )
+    uid7 = plan.schedule(Task(target=get_mtest(name=7)), resource=pool_name,)
 
     # with log_propagation_disabled(TESTPLAN_LOGGER):
     assert plan.run().run is True
 
     assert plan.report.passed is True
-    assert plan.report.counter == {"passed": 6, "total": 6, "failed": 0}
+    assert plan.report.counter == {"passed": 7, "total": 7, "failed": 0}
 
-    names = sorted(["MTest{}".format(x) for x in range(1, 7)])
+    names = sorted(["MTest{}".format(x) for x in range(1, 8)])
     assert sorted([entry.name for entry in plan.report.entries]) == names
 
     assert isinstance(plan.report.serialize(), dict)
@@ -82,6 +83,7 @@ def schedule_tests_to_pool(plan, pool, **pool_cfg):
     assert plan.result.test_results[uid4].report.name == "MTest4"
     assert plan.result.test_results[uid5].report.name == "MTest5"
     assert plan.result.test_results[uid6].report.name == "MTest6"
+    assert plan.result.test_results[uid7].report.name == "MTest7"
 
 
 def test_pool_basic(mockplan):


### PR DESCRIPTION
Process pool execution errors under 2 scenarios:
1) task target is a multitest object
2) testsuite inherit from an abstract class

Fixes:
1) remove extra_attributes from testsuite report
2) deepcopy task target before materializing it, so that in case the target is a Runnable object (multitest
instance) it doesn't get mutated on worker side
3) add task target to local runner before dryrun (for merging part report)