### PR TITLE
Modify the config object by accessing internal dict

### DIFF
--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -236,9 +236,10 @@ class App(Driver):
         cwd = self.cfg.working_dir or self.runpath
         try:
             self.logger.debug(
-                "%(driver)s driver command: %(cmd)s,\n"
-                "\trunpath: %(runpath)s\n"
-                "\tout/err files %(out)s - %(err)s",
+                "%(driver)s driver command: %(cmd)s\n"
+                "\tRunpath: %(runpath)s\n"
+                "\tOut file: %(out)s\n"
+                "\tErr file: %(err)s\n",
                 {
                     "driver": self.uid(),
                     "cmd": cmd,
@@ -307,12 +308,12 @@ class App(Driver):
         else:
             self._rename_std_and_log()
 
-        path_cleanup = self.cfg.path_cleanup
-        self.cfg.path_cleanup = False
         # we don't want to cleanup runpath during restart
+        path_cleanup = self.cfg.path_cleanup
+        self.cfg._options["path_cleanup"] = False
         self.start()
         self.wait(self.status.STARTED)
-        self.cfg.path_cleanup = path_cleanup
+        self.cfg._options["path_cleanup"] = path_cleanup
 
     def _move_app_path(self):
         """

--- a/testplan/testing/multitest/driver/fix/client.py
+++ b/testplan/testing/multitest/driver/fix/client.py
@@ -90,7 +90,7 @@ class FixClient(Driver):
     :type logoff_timeout: ``int`` or ``float``
 
     Also inherits all
-    :py:class:`~testplan.testing.multitest.driver.base.Driver`` options.
+    :py:class:`~testplan.testing.multitest.driver.base.Driver` options.
     """
 
     CONFIG = FixClientConfig

--- a/testplan/testing/multitest/driver/fix/server.py
+++ b/testplan/testing/multitest/driver/fix/server.py
@@ -66,7 +66,7 @@ class FixServer(Driver):
     :type version: ``str``
 
     Also inherits all
-    :py:class:`~testplan.testing.multitest.driver.base.Driver`` options.
+    :py:class:`~testplan.testing.multitest.driver.base.Driver` options.
     """
 
     CONFIG = FixServerConfig

--- a/testplan/testing/multitest/driver/tcp/client.py
+++ b/testplan/testing/multitest/driver/tcp/client.py
@@ -55,7 +55,7 @@ class TCPClient(Driver):
     :type connect_at_start: ``bool``
 
     Also inherits all
-    :py:class:`~testplan.testing.multitest.driver.base.Driver`` options.
+    :py:class:`~testplan.testing.multitest.driver.base.Driver` options.
     """
 
     CONFIG = TCPClientConfig

--- a/testplan/testing/multitest/driver/tcp/server.py
+++ b/testplan/testing/multitest/driver/tcp/server.py
@@ -47,7 +47,7 @@ class TCPServer(Driver):
     :type port: ``int``
 
     Also inherits all
-    :py:class:`~testplan.testing.multitest.driver.base.Driver`` options.
+    :py:class:`~testplan.testing.multitest.driver.base.Driver` options.
     """
 
     CONFIG = TCPServerConfig


### PR DESCRIPTION
* It's better not modify the cfg object by setting "self.cfg.attr=val"
  in our internal implemetation, by directly modify the dictionary
  inside the cfg object, e.g. "self.cfg._options['attr']=val".
* Fix some dostring typo of drivers.