### PR TITLE
Remove duplicated description on assertion pane

### DIFF
--- a/testplan/web_ui/testing/src/AssertionPane/AssertionPane.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionPane.js
@@ -82,15 +82,33 @@ class AssertionPane extends Component {
       position: 'absolute',
       left: this.props.left,
       paddingLeft: '20px',
-      top: '5em',
-      height: `calc(100% - 5em)`,
+      top: '5.5em',
+      height: `calc(100% - 5.5em)`,
       width: `calc(100% - ${this.props.left})`,
     };
 
-    if (this.props.assertions.length !== 0 || this.props.logs.length !== 0) {
+    if (
+      this.props.assertions.length !== 0 || this.props.logs.length !== 0
+      || this.props.descriptionEntries.length !== 0
+    ) {
       return (
         <div style={assertionPaneStyle}>
-          <div className={css(styles.buttonsDiv)}>
+          <div className={css(styles.infiniteScrollDiv)}>
+            {/*
+            The key is passed to force InfiniteScroll to update when only the
+            props of AssertionPane are changed. Normally when just props change
+            and not state the child component is not updated. Giving the
+            InfiniteScroll component a key tells react to update it. Unsure if
+            it updates it or creates a new instance, need to check.
+            */}
+            <InfiniteScroll
+              key={this.props.testcaseUid}
+              items={this.props.assertions}
+            >
+              <DescriptionPane
+                descriptionEntries={this.props.descriptionEntries}
+              />
+           <div className={css(styles.buttonsDiv)}>
             <FontAwesomeIcon
               size='1x'
               key='faPlusCircle'
@@ -108,21 +126,6 @@ class AssertionPane extends Component {
               className={css(styles.icon)}
             />
           </div>
-          <div className={css(styles.infiniteScrollDiv)}>
-            {/*
-            The key is passed to force InfiniteScroll to update when only the
-            props of AssertionPane are changed. Normally when just props change
-            and not state the child component is not updated. Giving the
-            InfiniteScroll component a key tells react to update it. Unsure if
-            it updates it or creates a new instance, need to check.
-            */}
-            <InfiniteScroll
-              key={this.props.testcaseUid}
-              items={this.props.assertions}
-            >
-              <DescriptionPane
-                descriptionEntries={this.props.descriptionEntries}
-              />
               <AssertionGroup
                 entries={[]}
                 globalIsOpen={this.state.globalIsOpen}
@@ -165,13 +168,16 @@ const styles = StyleSheet.create({
     cursor: 'pointer',
   },
 
-  buttonsDiv: {
-    textAlign: 'right',
+  infiniteScrollDiv: {
+    height: 'calc(100% - 1.5em)',
   },
 
-  infiniteScrollDiv: {
-    height: 'calc(100% - 35px)',
-  }
+  buttonsDiv: {
+    position: 'absolute',
+    top: '0em',
+    width: '100%',
+    textAlign: 'right',
+  },
 });
 
 export default AssertionPane;

--- a/testplan/web_ui/testing/src/AssertionPane/InfiniteScroll.js
+++ b/testplan/web_ui/testing/src/AssertionPane/InfiniteScroll.js
@@ -104,7 +104,7 @@ class InfiniteScroll extends Component {
 
     return (
       <Scrollbars autoHide onScroll={this.onScroll} ref={this.scrollbars}>
-        <div style={{paddingRight: '2rem'}}>
+        <div style={{paddingRight: '4rem'}}>
           {children}
           {isLoading && <div>Loading...</div>}
         </div>

--- a/testplan/web_ui/testing/src/AssertionPane/__tests__/__snapshots__/AssertionPane.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/__tests__/__snapshots__/AssertionPane.test.js.snap
@@ -4,61 +4,17 @@ exports[`AssertionPane shallow renders the correct HTML structure 1`] = `
 <div
   style={
     Object {
-      "height": "calc(100% - 5em)",
+      "height": "calc(100% - 5.5em)",
       "left": "19.5em",
       "paddingLeft": "20px",
       "position": "absolute",
-      "top": "5em",
+      "top": "5.5em",
       "width": "calc(100% - 19.5em)",
     }
   }
 >
   <div
-    className="buttonsDiv_140n9qh"
-  >
-    <FontAwesomeIcon
-      border={false}
-      className="icon_1rr1rr0"
-      fixedWidth={false}
-      flip={null}
-      icon="plus-circle"
-      inverse={false}
-      key="faPlusCircle"
-      listItem={false}
-      mask={null}
-      onClick={[Function]}
-      pull={null}
-      pulse={false}
-      rotation={null}
-      size="1x"
-      spin={false}
-      symbol={false}
-      title="Expand all"
-      transform={null}
-    />
-    <FontAwesomeIcon
-      border={false}
-      className="icon_1rr1rr0"
-      fixedWidth={false}
-      flip={null}
-      icon="minus-circle"
-      inverse={false}
-      key="faMinusCircle"
-      listItem={false}
-      mask={null}
-      onClick={[Function]}
-      pull={null}
-      pulse={false}
-      rotation={null}
-      size="1x"
-      spin={false}
-      symbol={false}
-      title="Collapse all"
-      transform={null}
-    />
-  </div>
-  <div
-    className="infiniteScrollDiv_4z6319"
+    className="infiniteScrollDiv_gt1n5"
   >
     <InfiniteScroll
       items={
@@ -81,6 +37,50 @@ exports[`AssertionPane shallow renders the correct HTML structure 1`] = `
       key="22758cc5-8a89-472b-bf67-b64dbc2c0b40"
     >
       <DescriptionPane />
+      <div
+        className="buttonsDiv_16w4ads"
+      >
+        <FontAwesomeIcon
+          border={false}
+          className="icon_1rr1rr0"
+          fixedWidth={false}
+          flip={null}
+          icon="plus-circle"
+          inverse={false}
+          key="faPlusCircle"
+          listItem={false}
+          mask={null}
+          onClick={[Function]}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size="1x"
+          spin={false}
+          symbol={false}
+          title="Expand all"
+          transform={null}
+        />
+        <FontAwesomeIcon
+          border={false}
+          className="icon_1rr1rr0"
+          fixedWidth={false}
+          flip={null}
+          icon="minus-circle"
+          inverse={false}
+          key="faMinusCircle"
+          listItem={false}
+          mask={null}
+          onClick={[Function]}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size="1x"
+          spin={false}
+          symbol={false}
+          title="Collapse all"
+          transform={null}
+        />
+      </div>
       <AssertionGroup
         entries={Array []}
         resetGlobalIsOpen={[Function]}

--- a/testplan/web_ui/testing/src/AssertionPane/__tests__/__snapshots__/InfiniteScroll.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/__tests__/__snapshots__/InfiniteScroll.test.js.snap
@@ -22,7 +22,7 @@ exports[`InfiniteScroll shallow renders the correct HTML structure 1`] = `
   <div
     style={
       Object {
-        "paddingRight": "2rem",
+        "paddingRight": "4rem",
       }
     }
   />

--- a/testplan/web_ui/testing/src/Common/sampleReports.js
+++ b/testplan/web_ui/testing/src/Common/sampleReports.js
@@ -374,14 +374,14 @@ const FakeInteractiveReport = {
   entries: [{
     counter: {passed: 0, failed: 0},
     category: "multitest",
-    description: null,
+    description: "Interactive MTest Desc",
     entries: [{
       counter: {passed: 0, failed: 0},
       category: "testsuite",
-      description: null,
+      description: "Interactive Suite Desc",
       entries: [{
         counter: {passed: 0, failed: 0},
-        description: null,
+        description: "Interactive Testcase Desc",
         entries: [],
         logs: [],
         name: "test_interactive",

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
@@ -48,7 +48,7 @@ const InteractiveNavEntry = (props) => {
         className={
           css(styles.entryName, styles[STATUS_CATEGORY[props.status]])
         }
-        title={props.name}
+        title={props.description || props.name}
       >
         {props.name}
       </div>
@@ -180,6 +180,8 @@ const getEnvStatusIcon = (envStatus, envCtrlCallback) => {
 InteractiveNavEntry.propTypes = {
   /** Entry name */
   name: PropTypes.string,
+  /** Entry description */
+  description: PropTypes.string,
   /** Entry status */
   status: PropTypes.oneOf(STATUS),
   runtime_status: PropTypes.oneOf(RUNTIME_STATUS),

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
@@ -15,6 +15,7 @@ const InteractiveNavList = (props) => {
     (entry) => (
       <InteractiveNavEntry
         name={entry.name}
+        description={entry.description}
         status={entry.status}
         runtime_status={entry.runtime_status}
         envStatus={entry.env_status}
@@ -41,6 +42,7 @@ InteractiveNavList.propTypes = {
   entries: PropTypes.arrayOf(PropTypes.shape({
     uid: PropTypes.string,
     name: PropTypes.string,
+    description: PropTypes.string,
     status: PropTypes.oneOf(STATUS),
     runtime_status: PropTypes.oneOf(RUNTIME_STATUS),
     counter: PropTypes.shape({

--- a/testplan/web_ui/testing/src/Nav/NavBreadcrumbs.js
+++ b/testplan/web_ui/testing/src/Nav/NavBreadcrumbs.js
@@ -34,6 +34,7 @@ return (
     <div className={css(styles.breadcrumbEntry, CommonStyles.unselectable)}>
       <NavEntry
         name={entry.name}
+        description={entry.description}
         status={entry.status}
         type={entry.category}
         caseCountPassed={entry.counter.passed}
@@ -51,6 +52,7 @@ NavBreadcrumbs.propTypes = {
   entries: PropTypes.arrayOf(PropTypes.shape({
     uid: PropTypes.string,
     name: PropTypes.string,
+    description: PropTypes.string,
     status: PropTypes.oneOf(STATUS),
     runtime_status: PropTypes.oneOf(RUNTIME_STATUS),
     counter: PropTypes.shape({

--- a/testplan/web_ui/testing/src/Nav/NavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/NavEntry.js
@@ -38,7 +38,7 @@ const NavEntry = (props) => {
     >
       <div
         className={css(styles.entryName, styles[STATUS_CATEGORY[props.status]])}
-        title={props.name}
+        title={props.description || props.name}
       >
         {props.name}
       </div>
@@ -63,6 +63,8 @@ const NavEntry = (props) => {
 NavEntry.propTypes = {
   /** Entry name */
   name: PropTypes.string,
+  /** Entry description */
+  description: PropTypes.string,
   /** Entry status */
   status: PropTypes.oneOf(STATUS),
   /** Entry type */

--- a/testplan/web_ui/testing/src/Nav/NavList.js
+++ b/testplan/web_ui/testing/src/Nav/NavList.js
@@ -19,6 +19,7 @@ const NavList = (props) => {
       return (
         <NavEntry
           name={entry.name}
+          description={entry.description}
           status={entry.status}
           type={entry.category}
           caseCountPassed={entry.counter.passed}
@@ -39,6 +40,7 @@ NavList.propTypes = {
   entries: PropTypes.arrayOf(PropTypes.shape({
     uid: PropTypes.string,
     name: PropTypes.string,
+    description: PropTypes.string,
     status: PropTypes.oneOf(STATUS),
     counter: PropTypes.shape({
       passed: PropTypes.number,

--- a/testplan/web_ui/testing/src/Nav/__tests__/InteractiveNavEntry.test.js
+++ b/testplan/web_ui/testing/src/Nav/__tests__/InteractiveNavEntry.test.js
@@ -22,6 +22,7 @@ describe('InteractiveNavEntry', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
+        description={'TestCaseDesc'}
         status={'unknown'}
         runtime_status={'ready'}
         envStatus={null}
@@ -39,6 +40,7 @@ describe('InteractiveNavEntry', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
+        description={'TestCaseDesc'}
         status={'unknown'}
         runtime_status={'running'}
         envStatus={null}
@@ -56,6 +58,7 @@ describe('InteractiveNavEntry', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
+        description={'TestCaseDesc'}
         status={'passed'}
         runtime_status={'finished'}
         envStatus={null}
@@ -73,6 +76,7 @@ describe('InteractiveNavEntry', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
+        description={'TestCaseDesc'}
         status={'failed'}
         runtime_status={'finished'}
         envStatus={null}
@@ -91,6 +95,7 @@ describe('InteractiveNavEntry', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
+        description={'TestCaseDesc'}
         status={'unknown'}
         runtime_status={'ready'}
         envStatus={null}
@@ -111,6 +116,7 @@ describe('InteractiveNavEntry', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
+        description={'TestCaseDesc'}
         status={'failed'}
         runtime_status={'finished'}
         envStatus={null}
@@ -130,6 +136,7 @@ describe('InteractiveNavEntry', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
+        description={'TestCaseDesc'}
         status={'unknown'}
         runtime_status={'ready'}
         envStatus={'STOPPED'}
@@ -147,6 +154,7 @@ describe('InteractiveNavEntry', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
+        description={'TestCaseDesc'}
         status={'unknown'}
         runtime_status={'ready'}
         envStatus={'STARTING'}
@@ -164,6 +172,7 @@ describe('InteractiveNavEntry', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
+        description={'TestCaseDesc'}
         status={'unknown'}
         runtime_status={'ready'}
         envStatus={'STARTED'}
@@ -181,6 +190,7 @@ describe('InteractiveNavEntry', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
+        description={'TestCaseDesc'}
         status={'unknown'}
         runtime_status={'ready'}
         envStatus={'STOPPING'}
@@ -199,6 +209,7 @@ describe('InteractiveNavEntry', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
+        description={'TestCaseDesc'}
         status={'unknown'}
         runtime_status={'ready'}
         envStatus={'STOPPED'}
@@ -230,6 +241,7 @@ describe('InteractiveNavEntry', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
+        description={'TestCaseDesc'}
         status={'unknown'}
         runtime_status={'ready'}
         envStatus={'STARTED'}

--- a/testplan/web_ui/testing/src/Nav/__tests__/NavBreadcrumbs.test.js
+++ b/testplan/web_ui/testing/src/Nav/__tests__/NavBreadcrumbs.test.js
@@ -8,6 +8,7 @@ function defaultProps() {
   const entry = {
     uid: '123',
     name: 'test',
+    description: 'desc',
     status: 'passed',
     category: 'testplan',
     counter: {

--- a/testplan/web_ui/testing/src/Nav/__tests__/NavEntry.test.js
+++ b/testplan/web_ui/testing/src/Nav/__tests__/NavEntry.test.js
@@ -8,6 +8,7 @@ import NavEntry from '../NavEntry';
 function defaultProps() {
   return {
     name: 'entry name',
+    description: 'entry description',
     status: 'passed',
     type: 'testplan',
     caseCountPassed: 0,

--- a/testplan/web_ui/testing/src/Nav/__tests__/NavList.test.js
+++ b/testplan/web_ui/testing/src/Nav/__tests__/NavList.test.js
@@ -9,6 +9,7 @@ function defaultProps() {
   const entry = {
     uid: '123',
     name: 'test',
+    description: 'desc',
     status: 'passed',
     type: 'testplan',
     counter: {

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNav.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNav.test.js.snap
@@ -17,7 +17,7 @@ exports[`InteractiveNav shallow renders and matches snapshot 1`] = `
                 "failed": 0,
                 "passed": 0,
               },
-              "description": null,
+              "description": "Interactive MTest Desc",
               "entries": Array [
                 Object {
                   "category": "testsuite",
@@ -25,14 +25,14 @@ exports[`InteractiveNav shallow renders and matches snapshot 1`] = `
                     "failed": 0,
                     "passed": 0,
                   },
-                  "description": null,
+                  "description": "Interactive Suite Desc",
                   "entries": Array [
                     Object {
                       "counter": Object {
                         "failed": 0,
                         "passed": 0,
                       },
-                      "description": null,
+                      "description": "Interactive Testcase Desc",
                       "entries": Array [],
                       "logs": Array [],
                       "name": "test_interactive",
@@ -104,7 +104,7 @@ exports[`InteractiveNav shallow renders and matches snapshot 1`] = `
             "failed": 0,
             "passed": 0,
           },
-          "description": null,
+          "description": "Interactive MTest Desc",
           "entries": Array [
             Object {
               "category": "testsuite",
@@ -112,14 +112,14 @@ exports[`InteractiveNav shallow renders and matches snapshot 1`] = `
                 "failed": 0,
                 "passed": 0,
               },
-              "description": null,
+              "description": "Interactive Suite Desc",
               "entries": Array [
                 Object {
                   "counter": Object {
                     "failed": 0,
                     "passed": 0,
                   },
-                  "description": null,
+                  "description": "Interactive Testcase Desc",
                   "entries": Array [],
                   "logs": Array [],
                   "name": "test_interactive",

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
@@ -11,7 +11,7 @@ exports[`InteractiveNavEntry renders a testcase in "failed" state 1`] = `
 >
   <div
     className="entryName_1dd7qci-o_O-failed_11es5k7"
-    title="FakeTestcase"
+    title="TestCaseDesc"
   >
     FakeTestcase
   </div>
@@ -89,7 +89,7 @@ exports[`InteractiveNavEntry renders a testcase in "passed" state 1`] = `
 >
   <div
     className="entryName_1dd7qci-o_O-passed_1kh4m98"
-    title="FakeTestcase"
+    title="TestCaseDesc"
   >
     FakeTestcase
   </div>
@@ -167,7 +167,7 @@ exports[`InteractiveNavEntry renders a testcase in "ready" state 1`] = `
 >
   <div
     className="entryName_1dd7qci"
-    title="FakeTestcase"
+    title="TestCaseDesc"
   >
     FakeTestcase
   </div>
@@ -245,7 +245,7 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
 >
   <div
     className="entryName_1dd7qci"
-    title="FakeTestcase"
+    title="TestCaseDesc"
   >
     FakeTestcase
   </div>
@@ -322,7 +322,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTED 1`
 >
   <div
     className="entryName_1dd7qci"
-    title="FakeTestcase"
+    title="TestCaseDesc"
   >
     FakeTestcase
   </div>
@@ -431,7 +431,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTING 1
 >
   <div
     className="entryName_1dd7qci"
-    title="FakeTestcase"
+    title="TestCaseDesc"
   >
     FakeTestcase
   </div>
@@ -539,7 +539,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPED 1`
 >
   <div
     className="entryName_1dd7qci"
-    title="FakeTestcase"
+    title="TestCaseDesc"
   >
     FakeTestcase
   </div>
@@ -648,7 +648,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPING 1
 >
   <div
     className="entryName_1dd7qci"
-    title="FakeTestcase"
+    title="TestCaseDesc"
   >
     FakeTestcase
   </div>

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavList.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavList.test.js.snap
@@ -18,6 +18,7 @@ exports[`InteractiveNavList shallow renders and matches snapshot 1`] = `
       <InteractiveNavEntry
         caseCountFailed={0}
         caseCountPassed={0}
+        description="Interactive MTest Desc"
         envCtrlCallback={[Function]}
         handlePlayClick={[Function]}
         name="Interactive MTest"

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavBreadcrumbs.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavBreadcrumbs.test.js.snap
@@ -17,6 +17,7 @@ exports[`NavBreadcrumbs shallow renders the correct HTML structure 1`] = `
         <NavEntry
           caseCountFailed={0}
           caseCountPassed={0}
+          description="desc"
           displayTime={false}
           executionTime={null}
           name="test"

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavEntry.test.js.snap
@@ -11,7 +11,7 @@ exports[`NavEntry shallow renders the correct HTML structure 1`] = `
 >
   <div
     className="entryName_1dd7qci-o_O-passed_1kh4m98"
-    title="entry name"
+    title="entry description"
   >
     entry name
   </div>
@@ -58,7 +58,7 @@ exports[`NavEntry when prop status="failed" name div and Badge have correct styl
 >
   <div
     className="entryName_1dd7qci-o_O-failed_11es5k7"
-    title="entry name"
+    title="entry description"
   >
     entry name
   </div>
@@ -105,7 +105,7 @@ exports[`NavEntry when prop status="xfail" name div and Badge have correct style
 >
   <div
     className="entryName_1dd7qci-o_O-unstable_eujaab"
-    title="entry name"
+    title="entry description"
   >
     entry name
   </div>

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavList.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavList.test.js.snap
@@ -18,6 +18,7 @@ exports[`NavList shallow renders and matches snapshot 1`] = `
       <NavEntry
         caseCountFailed={0}
         caseCountPassed={1}
+        description="desc"
         displayTime={false}
         executionTime={null}
         name="test"

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -216,7 +216,7 @@ const GetCenterPane = (
   selectedEntries
 ) => {
   const logs = state.logs || [];
-  const selectedDescription = selectedEntries.map((element) => {
+  const selectedDescription = selectedEntries.slice(-1).map((element) => {
     return element.description;
   }).filter((element) => {
     return element; // filter empty description
@@ -230,7 +230,10 @@ const GetCenterPane = (
         left={state.navWidth}
       />
     );
-  } else if (assertions.length > 0 || logs.length > 0) {
+  } else if (
+      assertions.length > 0 || logs.length > 0
+      || selectedDescription.length > 0
+    ) {
     return (
       <AssertionPane
         assertions={assertions}


### PR DESCRIPTION
* Only display the description of the current report on assertion pane
  but ignore the descriptions of the parent reports.
* For each NavEntry display the report description as tooltip rather
  than the report name.
* UI layout adjustment.
* update testcases.