### PR TITLE
Close fds while driver starts a subprocess

### DIFF
--- a/testplan/common/utils/process.py
+++ b/testplan/common/utils/process.py
@@ -135,7 +135,7 @@ DEFAULT_CLOSE_FDS = platform.system() != "Windows"
 
 def subprocess_popen(
     args,
-    bufsize=0,
+    bufsize=0,  # unbuffered (`io.DEFAULT_BUFFER_SIZE` for Python 3 by default)
     executable=None,
     stdin=None,
     stdout=None,

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -15,7 +15,7 @@ from past.builtins import basestring
 from testplan.common.config import ConfigOption
 from testplan.common.utils.path import StdFiles, makedirs
 from testplan.common.utils.context import is_context, expand
-from testplan.common.utils.process import kill_process
+from testplan.common.utils.process import subprocess_popen, kill_process
 
 from .base import Driver, DriverConfig
 
@@ -248,7 +248,7 @@ class App(Driver):
                     "err": self.std.err_path,
                 },
             )
-            self.proc = subprocess.Popen(
+            self.proc = subprocess_popen(
                 cmd,
                 shell=self.cfg.shell,
                 stdin=subprocess.PIPE,


### PR DESCRIPTION
* When a driver starts a subprocess with `Popen` the argument
  `close_fds` should be set `True` on Linux to avoid some unexpected
  issue. by default this value is `False` while working with Python2.