### PR TITLE
make attachment working in group

### DIFF
--- a/examples/Assertions/Basic/test_plan.py
+++ b/examples/Assertions/Basic/test_plan.py
@@ -9,6 +9,11 @@ import random
 import re
 import sys
 
+import matplotlib
+
+matplotlib.use("agg")
+import matplotlib.pyplot as plot
+
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 
 from testplan import test_plan
@@ -163,6 +168,14 @@ print(os.uname())
         """,
             language="python",
             description="Python codelog example",
+        )
+
+        x = range(0, 10)
+        y = range(0, 10)
+        plot.plot(x, y)
+
+        result.matplot(
+            plot, width=2, height=2, description="Simple matplot example"
         )
 
     @testcase

--- a/examples/Attachments/test_plan.py
+++ b/examples/Attachments/test_plan.py
@@ -47,11 +47,17 @@ class TestSuite(object):
     def test_attach_again(self, env, result):
         """
         Attach the same file to the report again. This is allowed, only
-        one copy of the file will be made under the attachments dir.
+        one copy of the file will be made under the attachments dir. It works
+        even if the result goes to result group
         """
         result.attach(
             self.tmpfile, description="Attaching the same text file again"
         )
+
+        with result.group() as group:
+            group.attach(
+                self.tmpfile, description="Attaching the same text file again"
+            )
 
     @multitest.testcase
     def test_attach_img(self, env, result):

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -1316,6 +1316,7 @@ class Result(object):
                 entries=self.entries, description=self._group_description
             )
         self._parent.entries.append(entry_group)
+        self._parent.attachments.extend(self.attachments)
         return exc_type is None  # re-raise errors if there is any
 
     def get_namespaces(self):
@@ -1384,6 +1385,7 @@ class Result(object):
             _summarize=summarize,
             _num_passing=num_passing,
             _num_failing=num_failing,
+            _scratch=self._scratch,
         )
 
     @property

--- a/testplan/web_ui/testing/src/AssertionPane/Assertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/Assertion.js
@@ -147,6 +147,7 @@ class Assertion extends Component {
             globalIsOpen={this.props.globalIsOpen}
             resetGlobalIsOpen={this.props.resetGlobalIsOpen}
             filter={this.props.filter}
+            reportUid={this.props.reportUid}
           />
         );
         break;


### PR DESCRIPTION
- pass scratch to group result file (needed by some assertions, like matplot)
- merge attachments to parent