### PR TITLE
Json report is split by `UID` of report object instead of `name`

### DIFF
--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -138,17 +138,14 @@ class JSONExporter(Exporter):
             """Remove assertions from report and place them in a dictionary."""
             for entry in entries:
                 if entry.get("category") == ReportCategories.TESTCASE:
-                    assertions[entry["name"]] = entry["entries"]
+                    assertions[entry["uid"]] = entry["entries"]
                     entry["entries"] = []
                 elif "entries" in entry:
-                    assertions.setdefault(entry["name"], {})
-                    split_assertions(
-                        entry["entries"], assertions[entry["name"]]
-                    )
+                    split_assertions(entry["entries"], assertions)
 
-        meta, structure, assertions = data, data["entries"], {data["name"]: {}}
+        meta, structure, assertions = data, data["entries"], {}
         meta["entries"] = []
-        split_assertions(structure, assertions[meta["name"]])
+        split_assertions(structure, assertions)
         return meta, structure, assertions
 
     @staticmethod
@@ -159,16 +156,14 @@ class JSONExporter(Exporter):
             """Fill assertions into report by the unique id."""
             for entry in entries:
                 if entry.get("category") == ReportCategories.TESTCASE:
-                    try:
-                        dictionary = assertions
-                        for key in entry["parent_uids"]:
-                            dictionary = dictionary[key]
-                        entry["entries"] = dictionary[entry["name"]]
-                    except KeyError as err:
-                        if strict:
-                            raise RuntimeError(
-                                "Assertion key not found: {}".format(str(err))
+                    if entry["uid"] in assertions:
+                        entry["entries"] = assertions[entry["uid"]]
+                    elif strict:
+                        raise RuntimeError(
+                            "Testcase report uid missing: {}".format(
+                                entry["uid"]
                             )
+                        )
                 elif "entries" in entry:
                     merge_assertions(entry["entries"], assertions, strict)
 

--- a/testplan/web_ui/testing/src/Report/__tests__/reportUtils.test.js
+++ b/testplan/web_ui/testing/src/Report/__tests__/reportUtils.test.js
@@ -130,55 +130,54 @@ describe('Report/reportUtils', () => {
       "status": "failed",
       "entries": [],
       "name": "Multiply",
+      "uid": "Multiply",
       "project": "testplan",
       "timeout": 14400
     };
 
     const assertions = {
-      "Multiply": {
-        "MultiplyTest": {
-          "BasicSuite": {
-            "basic_multiply": {
-              "basic_multiply__p1_aaaa__p2_11111": [
-                {"name": "test assertion1"},
-              ], 
-              "basic_multiply__p1_bbbb__p2_2222": [
-                {"name": "test assertion2"},
-              ]
-            }
-          }
-        }
-      }
+      "basic_multiply__p1_aaaa__p2_11111": [
+        {"name": "test assertion1", "uid": "test_assertion1"},
+      ],
+      "basic_multiply__p1_bbbb__p2_22222": [
+        {"name": "test assertion2", "uid": "test_assertion2"},
+      ]
     };
+
     const structure = [
       {
         "category": "multitest",
         "parent_uids": ["Multiply"],
         "name": "MultiplyTest",
+        "uid": "MultiplyTest",
         "entries": [
           {
             "category": "testsuite",
             "parent_uids": ["Multiply", "MultiplyTest"],
             "name": "BasicSuite",
+            "uid": "BasicSuite",
             "entries": [
               {
                 "category": "parametrization",
                 "parent_uids": ["Multiply", "MultiplyTest", "BasicSuite"],
-                "name": "basic_multiply",
+                "name": "Basic Multiply",
+                "uid": "basic_multiply",
                 "entries": [
                   {
                     "entries": [],
                     "type": "TestCaseReport",
                     "category": "testcase",
                     "parent_uids": ["Multiply", "MultiplyTest", "BasicSuite", "basic_multiply"],
-                    "name": "basic_multiply__p1_aaaa__p2_11111",
+                    "name": "basic multiply <p1='aaaa', p2=11111>",
+                    "uid": "basic_multiply__p1_aaaa__p2_11111",
                   },
                   {
                     "entries": [],
                     "type": "TestCaseReport",
                     "category": "testcase",
                     "parent_uids": ["Multiply", "MultiplyTest", "BasicSuite", "basic_multiply"],
-                    "name": "basic_multiply__p1_bbbb__p2_2222",
+                    "name": "basic multiply <p1='bbbb', p2=22222>",
+                    "uid": "basic_multiply__p1_bbbb__p2_22222",
                   }
                 ],
                 "type": "TestGroupReport"
@@ -202,34 +201,39 @@ describe('Report/reportUtils', () => {
           "category": "multitest",
           "parent_uids": ["Multiply"],
           "name": "MultiplyTest",
+          "uid": "MultiplyTest",
           "entries": [
             {
               "category": "testsuite",
               "parent_uids": ["Multiply", "MultiplyTest"],
               "name": "BasicSuite",
+              "uid": "BasicSuite",
               "entries": [
                 {
                   "category": "parametrization",
                   "parent_uids": ["Multiply", "MultiplyTest", "BasicSuite"],
-                  "name": "basic_multiply",
+                  "name": "Basic Multiply",
+                  "uid": "basic_multiply",
                   "entries": [
                     {
                       "entries": [
-                        {"name": "test assertion1"},
+                        {"name": "test assertion1", "uid": "test_assertion1"},
                       ],
                       "type": "TestCaseReport",
                       "category": "testcase",
                       "parent_uids": ["Multiply", "MultiplyTest", "BasicSuite", "basic_multiply"],
-                      "name": "basic_multiply__p1_aaaa__p2_11111",
+                      "name": "basic multiply <p1='aaaa', p2=11111>",
+                      "uid": "basic_multiply__p1_aaaa__p2_11111",
                     },
                     {
                       "entries": [
-                        {"name": "test assertion2"}
+                        {"name": "test assertion2", "uid": "test_assertion2"}
                       ],
                       "type": "TestCaseReport",
                       "category": "testcase",
                       "parent_uids": ["Multiply", "MultiplyTest", "BasicSuite", "basic_multiply"],
-                      "name": "basic_multiply__p1_bbbb__p2_2222",
+                      "name": "basic multiply <p1='bbbb', p2=22222>",
+                      "uid": "basic_multiply__p1_bbbb__p2_22222",
                     }
                   ],
                   "type": "TestGroupReport"
@@ -242,6 +246,7 @@ describe('Report/reportUtils', () => {
         }
       ],
       "name": "Multiply",
+      "uid": "Multiply",
       "project": "testplan",
       "timeout": 14400
     };

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -56,13 +56,13 @@ const MergeSplittedReport = (mainReport, assertions, structure) => {
   const _mergeStructure = (_structure, _assertions) => {
     _structure.forEach(element => {
       if (element.category === 'testcase') {
-        element.entries = _assertions[element.name];
+        element.entries = _assertions[element.uid];
       } else {
-        _mergeStructure(element.entries, _assertions[element.name]);
+        _mergeStructure(element.entries, _assertions);
       }
     });
   };
-  _mergeStructure(structure, assertions[mainReport.name]);
+  _mergeStructure(structure, assertions);
   mainReport.entries = structure;
   return mainReport;
 };


### PR DESCRIPTION
* `uid` shoud be a unique value through out the test report, so when
  a test report is split into smaller ones, the `uid` shoube used as
  reference, however name might be same (currently not allowed maybe
  the rule changes in the future).