### PR TITLE
reimplement recursive change of bytes type in asseertion with boltons.remap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ REQUIRED = [
     "futures; python_version <= '2.7'",
     "Werkzeug<1.0.0",
     "mock; python_version <= '2.7'",
+    "boltons",
 ]
 
 setup(


### PR DESCRIPTION
- boltons.remap can handle tuples and edge cases properly
- readability of the code improved
- added testcase with dict.match that having tuples, which previously failed