### PR TITLE
post_testcase exception should be logged in report

### DIFF
--- a/examples/Assertions/Basic/test_plan.py
+++ b/examples/Assertions/Basic/test_plan.py
@@ -5,20 +5,20 @@ This example shows usage of assertions,
 assertion groups and assertion namespaces.
 """
 import os
-import random
 import re
 import sys
-
-import matplotlib
-
-matplotlib.use("agg")
-import matplotlib.pyplot as plot
+import random
 
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 
 from testplan import test_plan
 from testplan.common.utils import comparison
 from testplan.report.testing.styles import Style, StyleEnum
+
+import matplotlib
+
+matplotlib.use("agg")
+import matplotlib.pyplot as plot
 
 
 @testsuite

--- a/tests/functional/testplan/testing/multitest/test_suite_decorators.py
+++ b/tests/functional/testplan/testing/multitest/test_suite_decorators.py
@@ -14,6 +14,7 @@ from testplan.report import (
     TestGroupReport,
     TestCaseReport,
     ReportCategories,
+    Status,
 )
 from testplan.testing.multitest.suite import (
     testcase,
@@ -26,22 +27,24 @@ from testplan.testing.multitest.suite import (
 
 def pre1(name, self, env, result):
     result.equal(2, 2)
-    result.contain("testcase", name)
+    result.contain("case", name)
 
 
 def post1(name, self, env, result):
     result.equal(2, 2)
-    result.contain("testcase", name)
+    result.contain("case", name)
 
 
 def pre2(name, self, env, result, a=None, b=None):
     result.equal(2, 2)
-    result.contain("testcase", name)
+    result.contain("case", name)
 
 
 def post2(name, self, env, result, a=None, b=None):
     result.equal(2, 2)
-    result.contain("testcase", name)
+    result.contain("case", name)
+    if name == "case5":
+        raise RuntimeError("raise for no reason")
 
 
 @pre_testcase(pre1)
@@ -130,6 +133,9 @@ def test_basic_multitest(mockplan):
                 assert len(tc_entry.entries) == 2  # 2 generated testcases
             else:
                 assert isinstance(tc_entry, TestCaseReport)
+                if tc_entry.name == "case5":
+                    assert tc_entry.status == Status.ERROR
+                    assert "raise for no reason" in tc_entry.logs[0]["message"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* If a testcase raises the exception is logged, the following epilogues
    should still be executed, but if any of them raises, then the error
    is output by `TESTPLAN_LOGGER`, or the testcase is executed nicely
    then the first exception raised in epilogues will be logged in test
    report. But if the testcase itself raises, exceptions raised from
    epilogues should not overwrite it.
