### PR TITLE
Fix a bug that `result.dict.check` rendering fails on web UI

### DIFF
--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/BasicAssertion.test.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/BasicAssertion.test.js
@@ -498,6 +498,25 @@ function propsDictCheck() {
   }
 }
 
+function propsDictCheckWithoutCheckingAbsent() {
+  return {
+    assertion: {
+      "category": "DEFAULT",
+      "machine_time": "2019-02-12T17:41:43.311722+00:00",
+      "description": null,
+      "has_keys": ["foo", "alpha"],
+      "line_no": 570,
+      "meta_type": "assertion",
+      "absent_keys_diff": [],
+      "passed": false,
+      "has_keys_diff": ["alpha"],
+      "type": "DictCheck",
+      "absent_keys": [],
+      "utc_time": "2019-02-12T17:41:43.312097+00:00"
+    }
+  }
+}
+
 function propsFixCheck() {
   return {
     assertion: {
@@ -680,6 +699,12 @@ describe('BasicAssertion', () => {
 
   it('shallow renders the DictCheck assertion', () => {
     props = propsDictCheck();
+    shallowComponent = shallow(<BasicAssertion {...props} />);
+    expect(shallowComponent).toMatchSnapshot();
+  });
+
+  it('shallow renders the DictCheck assertion which has no absent key', () => {
+    props = propsDictCheckWithoutCheckingAbsent();
     shallowComponent = shallow(<BasicAssertion {...props} />);
     expect(shallowComponent).toMatchSnapshot();
   });

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/BasicAssertion.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/BasicAssertion.test.js.snap
@@ -361,6 +361,184 @@ exports[`BasicAssertion shallow renders the DictCheck assertion 1`] = `
 </Fragment>
 `;
 
+exports[`BasicAssertion shallow renders the DictCheck assertion which has no absent key 1`] = `
+<Fragment>
+  <Row
+    tag="div"
+  >
+    <Col
+      lg="12"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <strong />
+    </Col>
+  </Row>
+  <Row
+    tag="div"
+  >
+    <Col
+      className="contentSpan_11nzg99"
+      lg="12"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <span>
+        Existence check: [
+        <span
+          key="check_foo_0"
+          style={
+            Object {
+              "color": "black",
+            }
+          }
+        >
+          "foo"
+        </span>
+        , 
+        <span
+          key="check_alpha_1"
+          style={
+            Object {
+              "color": "red",
+            }
+          }
+        >
+          "alpha"
+        </span>
+        ]
+        <br />
+        Absence check: [
+        ]
+      </span>
+    </Col>
+  </Row>
+  <Row
+    tag="div"
+  >
+    <Col
+      lg="6"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <strong />
+    </Col>
+    <Col
+      lg="6"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <strong />
+    </Col>
+  </Row>
+  <Row
+    tag="div"
+  >
+    <Col
+      className="contentSpan_11nzg99"
+      lg="6"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <span />
+    </Col>
+    <Col
+      className="contentSpan_11nzg99"
+      lg="6"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <span />
+    </Col>
+  </Row>
+  <Row
+    tag="div"
+  >
+    <Col
+      lg="12"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <strong />
+    </Col>
+  </Row>
+  <Row
+    tag="div"
+  >
+    <Col
+      className="contentSpan_11nzg99"
+      lg="12"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    />
+  </Row>
+</Fragment>
+`;
+
 exports[`BasicAssertion shallow renders the Equal assertion 1`] = `
 <Fragment>
   <Row

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/basicAssertionUtils.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/basicAssertionUtils.js
@@ -523,26 +523,30 @@ function prepareDictCheckContent(assertion, defaultContent) {
   const preContent = (
     <span>
       Existence check:
-      [{assertion.has_keys.map((key, index) =>
-        <span
-          style={{
-            color: assertion.has_keys_diff.indexOf(key) >= 0 ? 'red' : 'black'
-          }}
-          key={`check_${key}_${index}`}>
-          {JSON.stringify(key)}
-        </span>).reduce((prev, curr) => [prev, ', ', curr])}]
+      [{_.isEmpty(assertion.has_keys) ? ""
+        : assertion.has_keys.map((key, index) =>
+          <span
+            style={{
+              color: assertion.has_keys_diff.indexOf(key) >= 0
+              ? 'red' : 'black'
+            }}
+            key={`check_${key}_${index}`}>
+            {JSON.stringify(key)}
+          </span>).reduce((prev, curr) => [prev, ', ', curr])
+      }]
       <br />
       Absence check:
-      [{assertion.absent_keys.map((key, index) =>
-        <span
-          style={{
-            color: assertion.absent_keys_diff.indexOf(key) >= 0
-            ? 'red'
-            : 'black'
-          }}
-          key={`check_${key}_${index}`}>
-          {JSON.stringify(key)}
-        </span>).reduce((prev, curr) => [prev, ', ', curr])}]
+      [{_.isEmpty(assertion.absent_keys) ? ""
+        : assertion.absent_keys.map((key, index) =>
+          <span
+            style={{
+              color: assertion.absent_keys_diff.indexOf(key) >= 0
+              ? 'red' : 'black'
+            }}
+            key={`check_${key}_${index}`}>
+            {JSON.stringify(key)}
+          </span>).reduce((prev, curr) => [prev, ', ', curr])
+      }]
     </span>
   );
 


### PR DESCRIPTION
* If arguent `has_keys` or `absent_keys` not specified, then in JSON
  report the corresponding value is `None`, JS code has used `map` that
  cannot accepts `null`, even the value is an empty array, `reduce`
  function cannot work on it. Should add some logic to check its value.
* Add a new testcase.