### PR TITLE
pass runtime info to tests with env.multitest.runtime_info

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -94,7 +94,7 @@ A MultiTest instance can be constructed from the following parameters:
   would typically be defined, as well as drivers for the interfaces that are
   required for interacting with it, such as network connections.
 
-* **Runtime Information**: The environment is always contains a member called
+* **Runtime Information**: The environment always contains a member called
   ``multitest_runtime_info`` which contains information about the current state of
   the run. See: :py:class:`MultiTestRuntimeInfo <testplan.testing.multitest.base.MultiTestRuntimeInfo>`
 

--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -94,6 +94,10 @@ A MultiTest instance can be constructed from the following parameters:
   would typically be defined, as well as drivers for the interfaces that are
   required for interacting with it, such as network connections.
 
+* **Runtime Information**: The environment is always contains a member called
+  ``multitest.runtime_info`` which contains information about the current state of
+  the run. See: :py:class:`MultiTestRuntimeInfo <testplan.testing.multitest.base.MultiTestRuntimeInfo>`
+
 * **Initial Context**: The initial context is an optional way to pass
   information to be used by drivers and from within testcases. When drivers are
   added, they are provided with access to the driver environment that also

--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -95,7 +95,7 @@ A MultiTest instance can be constructed from the following parameters:
   required for interacting with it, such as network connections.
 
 * **Runtime Information**: The environment is always contains a member called
-  ``multitest.runtime_info`` which contains information about the current state of
+  ``multitest_runtime_info`` which contains information about the current state of
   the run. See: :py:class:`MultiTestRuntimeInfo <testplan.testing.multitest.base.MultiTestRuntimeInfo>`
 
 * **Initial Context**: The initial context is an optional way to pass

--- a/examples/Multitest/Basic/Name Customization/test_plan.py
+++ b/examples/Multitest/Basic/Name Customization/test_plan.py
@@ -26,9 +26,11 @@ def case_name_func(func_name, kwargs):
 
 @testsuite(name="A Simple Suite")
 class SimpleSuite(object):
-    @testcase(name="An empty testcase")
+    @testcase(name="A simple testcase")
     def test_example(self, env, result):
-        pass
+        result.equal(
+            env.multitest.runtime_info.testcase.name, "A simple testcase"
+        )
 
     @testcase(
         name="Parametrized testcases",
@@ -37,6 +39,13 @@ class SimpleSuite(object):
     )
     def test_equal(self, env, result, a, b, expected):
         result.equal(a + b, expected, description="Equality test")
+        result.equal(
+            env.multitest.runtime_info.testcase.name,
+            case_name_func(
+                "Parametrized testcases",
+                {"a": a, "b": b, "expected": expected},
+            ),
+        )
 
 
 # In @testsuite decorator, ``name`` can be a normal string or a callable

--- a/examples/Multitest/Basic/Name Customization/test_plan.py
+++ b/examples/Multitest/Basic/Name Customization/test_plan.py
@@ -29,7 +29,7 @@ class SimpleSuite(object):
     @testcase(name="A simple testcase")
     def test_example(self, env, result):
         result.equal(
-            env.multitest.runtime_info.testcase.name, "A simple testcase"
+            env.multitest_runtime_info.testcase.name, "A simple testcase"
         )
 
     @testcase(
@@ -40,7 +40,7 @@ class SimpleSuite(object):
     def test_equal(self, env, result, a, b, expected):
         result.equal(a + b, expected, description="Equality test")
         result.equal(
-            env.multitest.runtime_info.testcase.name,
+            env.multitest_runtime_info.testcase.name,
             case_name_func(
                 "Parametrized testcases",
                 {"a": a, "b": b, "expected": expected},

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -79,7 +79,7 @@ class MultiTestRuntimeInfo(object):
         self.testcase = self.TestcaseInfo()
 
 
-class MultiTestRuntimeInfoEnvWrapper(object):
+class EnvWithRuntimeInfo(object):
     def __init__(self, environment, runtime_info):
         self.__environment = environment
         self.multitest_runtime_info = runtime_info
@@ -873,9 +873,7 @@ class MultiTest(testing_base.Test):
         runtime_info = MultiTestRuntimeInfo()
         runtime_info.testcase.name = testcase.name
 
-        resources = MultiTestRuntimeInfoEnvWrapper(
-            self.resources, runtime_info
-        )
+        resources = EnvWithRuntimeInfo(self.resources, runtime_info)
 
         with testcase_report.timer.record("run"):
             with testcase_report.logged_exceptions():

--- a/tests/unit/testplan/testing/multitest/test_multitest.py
+++ b/tests/unit/testplan/testing/multitest/test_multitest.py
@@ -86,7 +86,7 @@ class Suite(object):
         """Basic testcase."""
         result.true(True)
         assert (
-            env.multitest.runtime_info.testcase.name == "case"
+            env.multitest_runtime_info.testcase.name == "case"
         )  # using pytest assert to check multitest runtime info
 
     @multitest.testcase(parameters=[1, 2, 3])
@@ -94,7 +94,7 @@ class Suite(object):
         """Parametrized testcase."""
         result.gt(val, 0)
         assert (
-            env.multitest.runtime_info.testcase.name
+            env.multitest_runtime_info.testcase.name
             == "parametrized <val={}>".format(val)
         )
 
@@ -117,7 +117,7 @@ class ParallelSuite(object):
         """Testcase 1"""
         self._barrier.wait()
         result.eq(0, 0)
-        assert env.multitest.runtime_info.testcase.name == "case1"
+        assert env.multitest_runtime_info.testcase.name == "case1"
         self._barrier.wait()
 
     @multitest.testcase(execution_group="A")
@@ -125,7 +125,7 @@ class ParallelSuite(object):
         """Testcase 2"""
         self._barrier.wait()
         result.eq(1, 1)
-        assert env.multitest.runtime_info.testcase.name == "case2"
+        assert env.multitest_runtime_info.testcase.name == "case2"
         self._barrier.wait()
 
     @multitest.testcase(execution_group="A")
@@ -133,7 +133,7 @@ class ParallelSuite(object):
         """Testcase 3"""
         self._barrier.wait()
         result.eq(2, 2)
-        assert env.multitest.runtime_info.testcase.name == "case3"
+        assert env.multitest_runtime_info.testcase.name == "case3"
         self._barrier.wait()
 
     @multitest.testcase(execution_group="B", parameters=[1, 2, 3])
@@ -142,7 +142,7 @@ class ParallelSuite(object):
         self._barrier.wait()
         result.gt(val, 0)
         assert (
-            env.multitest.runtime_info.testcase.name
+            env.multitest_runtime_info.testcase.name
             == "parametrized <val={}>".format(val)
         )
         self._barrier.wait()
@@ -223,7 +223,6 @@ def test_run_all_tests():
     mtest = multitest.MultiTest(
         name="MTest", suites=[Suite()], **MTEST_DEFAULT_PARAMS
     )
-    mtest._inject_runtime_info()
     mtest_report = mtest.run_tests()
     assert mtest_report.passed
     assert mtest_report.name == "MTest"
@@ -259,7 +258,6 @@ def test_run_tests_parallel():
         thread_pool_size=3,
         **MTEST_DEFAULT_PARAMS
     )
-    mtest._inject_runtime_info()
     mtest_report = mtest.run_tests()
     assert mtest_report.passed
     assert mtest_report.name == "MTest"
@@ -287,7 +285,6 @@ def test_run_testcases_iter():
         thread_pool_size=3,
         **MTEST_DEFAULT_PARAMS
     )
-    mtest._inject_runtime_info()
 
     results = list(mtest.run_testcases_iter())
     assert len(results) == 4


### PR DESCRIPTION
## Bug / Requirement Description
In case of parametrized testcases the testcase name could be usefull for debugging, logging purpose
The current change delivering a framework to be able to provide more runtime info later to testcase
the testcase name is accessible as env.multitest.runtime_info.testcase.name

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [X] Test
- [X] Example (both test_plan.py and .rst)
- [X] Documentation (API)
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
