### PR TITLE
Improve sorting on web UI for dictmatch/fixmatch

### DIFF
--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -875,7 +875,7 @@ class DictNamespace(AssertionNamespace):
         :param include_keys: Keys to exclusively consider in the comparison.
         :type include_keys: ``list`` of ``object`` (items must be hashable)
         :param exclude_keys: Keys to ignore in the comparison.
-        :type include_keys: ``list`` of ``object`` (items must be hashable)
+        :type exclude_keys: ``list`` of ``object`` (items must be hashable)
         :param report_mode: Specify which comparisons should be kept and
                             reported. Default option is to report all
                             comparisons but this can be restricted if desired.

--- a/testplan/web_ui/testing/package.json
+++ b/testplan/web_ui/testing/package.json
@@ -51,10 +51,10 @@
     "npm-force-resolutions": "0.0.3"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "react-scripts --max_old_space_size=4096 start",
+    "build": "react-scripts --max_old_space_size=4096 build",
     "prebuild": "pegjs --format es src/Parser/SearchFieldParser.pegjs",
-    "test": "react-scripts test",
+    "test": "react-scripts --max_old_space_size=4096 test",
     "lint": "eslint --ext .js --ext .jsx src",
     "lint:fix": "eslint --ext .js --ext .jsx src --fix",
     "eject": "react-scripts eject"

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/DictBaseAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/DictBaseAssertion.js
@@ -25,7 +25,7 @@ export default function DictBaseAssertion(props) {
 
   const [gridApi, setGridApi] = useState(null);
   const [, setGridColumnApi] = useState(null);
-  
+
   const sizeToFit = (api) => {
     if (api) api.sizeColumnsToFit();
   };
@@ -48,9 +48,9 @@ export default function DictBaseAssertion(props) {
   return (
     <>
       {props.buttons}
-      <div 
+      <div
         className={`ag-theme-balham ${css(styles.grid)}`}
-        style={{height: `${height}px`, width: "100%"}}
+        style={{height: `${height}px`, width: "99.9%"}}
       >
         <AgGridReact
           onGridReady={onGridReady}

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/DictButtonGroup.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/DictButtonGroup.js
@@ -9,7 +9,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import CopyButton from './../CopyButton';
 import {sortFlattenedJSON, flattenedDictToDOM} from './dictAssertionUtils';
-import {SORT_TYPES} from './../../../Common/defaults';
+import {SORT_TYPES, FILTER_OPTIONS} from './../../../Common/defaults';
 import {uniqueId} from './../../../Common/utils';
 
 library.add(
@@ -30,20 +30,26 @@ library.add(
 class DictButtonGroup extends Component {
   constructor(props) {
     super(props);
+    this.state = {
+      selectedSortType: this.props.defaultSortType || SORT_TYPES.NONE,
+      selectedFilterOptions: this.props.defaultFilterOptions || [],
+      sortedData: this.props.flattenedDict
+    };
+    this.sortAndFilterData = this.sortAndFilterData.bind(this);
 
     this.uid = this.props.uid || uniqueId();
+    this.buttonMap = {};
 
-    this.state = {
-      selectedSortType: this.props.defaultSortType,
-      sortedData: this.props.flattenedDict,
+    this.buttonMap[SORT_TYPES.NONE] = {
+      display: 'Original order',
+      onClick: this.noSort.bind(this)
     };
 
-    this.buttonMap = {};
     this.buttonMap[SORT_TYPES.ALPHABETICAL] = {
       display: 
-        <FontAwesomeIcon 
-          size='sm' 
-          key='faSortAmountDown' 
+        <FontAwesomeIcon
+          size='sm'
+          key='faSortAmountDown'
           icon='sort-amount-down'
         />,
       onClick: this.sortByChar.bind(this)
@@ -51,9 +57,9 @@ class DictButtonGroup extends Component {
 
     this.buttonMap[SORT_TYPES.REVERSE_ALPHABETICAL] = {
       display: 
-        <FontAwesomeIcon 
-          size='sm' 
-          key='faSortAmountUp' 
+        <FontAwesomeIcon
+          size='sm'
+          key='faSortAmountUp'
           icon='sort-amount-up'
         />,
       onClick: this.sortByCharReverse.bind(this)
@@ -64,15 +70,30 @@ class DictButtonGroup extends Component {
       onClick: this.sortByStatus.bind(this)
     };
 
-    this.buttonMap[SORT_TYPES.ONLY_FAILURES] = {
+    this.buttonMap[FILTER_OPTIONS.FAILURES_ONLY] = {
       display: 'Failures only',
       onClick: this.filterFailure.bind(this)
     };
+
+    this.buttonMap[FILTER_OPTIONS.EXCLUDE_IGNORABLE] = {
+      display: 'Hide ignored items',
+      onClick: this.filterIgnorable.bind(this)
+    };
+  };
+
+  noSort() {
+    let sortedData = this.props.flattenedDict;
+    this.props.setRowData(sortedData);
+    this.setState({
+      selectedSortType: SORT_TYPES.NONE,
+      sortedData: sortedData
+    });
   }
 
   sortByChar() {
-    let sortedData = sortFlattenedJSON(
-      this.props.flattenedDict, 0, false, false
+    let sortedData = this.sortAndFilterData(
+      SORT_TYPES.ALPHABETICAL,
+      this.state.selectedFilterOptions
     );
     this.props.setRowData(sortedData);
     this.setState({
@@ -82,8 +103,9 @@ class DictButtonGroup extends Component {
   }
 
   sortByCharReverse() {
-    let sortedData = sortFlattenedJSON(
-      this.props.flattenedDict, 0, true, false
+    let sortedData = this.sortAndFilterData(
+      SORT_TYPES.REVERSE_ALPHABETICAL,
+      this.state.selectedFilterOptions
     );
     this.props.setRowData(sortedData);
     this.setState({
@@ -93,8 +115,9 @@ class DictButtonGroup extends Component {
   }
 
   sortByStatus() {
-    let sortedData = sortFlattenedJSON(
-      this.props.flattenedDict, 0, false, true
+    let sortedData = this.sortAndFilterData(
+      SORT_TYPES.BY_STATUS,
+      this.state.selectedFilterOptions
     );
     this.props.setRowData(sortedData);
     this.setState({
@@ -104,33 +127,91 @@ class DictButtonGroup extends Component {
   }
 
   filterFailure() {
-    let sortedData = this.props.flattenedDict.filter(
-      line => line[2] === 'Failed'
+    let filterOptions = this.state.selectedFilterOptions;
+    filterOptions = (
+      filterOptions.indexOf(FILTER_OPTIONS.FAILURES_ONLY) >= 0 ?
+      filterOptions.filter(opt => opt !== FILTER_OPTIONS.FAILURES_ONLY) :
+      filterOptions.concat([FILTER_OPTIONS.FAILURES_ONLY])
+    );
+    let sortedData = this.sortAndFilterData(
+      this.state.selectedSortType,
+      filterOptions
     );
     this.props.setRowData(sortedData);
     this.setState({
-      selectedSortType: SORT_TYPES.ONLY_FAILURES,
+      selectedFilterOptions: filterOptions,
       sortedData: sortedData
     });
   }
 
+  filterIgnorable() {
+    let filterOptions = this.state.selectedFilterOptions;
+    filterOptions = (
+      filterOptions.indexOf(FILTER_OPTIONS.EXCLUDE_IGNORABLE) >= 0 ?
+      filterOptions.filter(opt => opt !== FILTER_OPTIONS.EXCLUDE_IGNORABLE) :
+      filterOptions.concat([FILTER_OPTIONS.EXCLUDE_IGNORABLE])
+    );
+    let sortedData = this.sortAndFilterData(
+      this.state.selectedSortType,
+      filterOptions
+    );
+    this.props.setRowData(sortedData);
+    this.setState({
+      selectedFilterOptions: filterOptions,
+      sortedData: sortedData
+    });
+  }
+
+  sortAndFilterData(SortType, filterOptions) {
+    let sortedData = sortFlattenedJSON(
+      this.props.flattenedDict,
+      0,
+      SortType === SORT_TYPES.REVERSE_ALPHABETICAL,
+      SortType === SORT_TYPES.BY_STATUS
+    );
+    if (filterOptions.indexOf(FILTER_OPTIONS.FAILURES_ONLY) >= 0) {
+      sortedData = sortedData.filter(line => line[2] === 'Failed');
+    }
+    if (filterOptions.indexOf(FILTER_OPTIONS.EXCLUDE_IGNORABLE) >= 0) {
+      sortedData = sortedData.filter(line => line[2] !== 'Ignored');
+    }
+    return sortedData;
+  }
 
   render() {
     let buttonGroup = [];
-    this.props.sortTypeList.forEach(function(sortType){
+
+    this.props.sortTypeList.forEach(function(sortType) {
       buttonGroup.push(
         <Button
-          key={this.uid+sortType}
+          key={this.uid+'-'+sortType.toString()}
           outline
           color='secondary'
           size='sm'
           onClick={this.buttonMap[sortType]['onClick']}
-          active={this.state.selectedSortType===sortType}
+          active={this.state.selectedSortType === sortType}
         >
           {this.buttonMap[sortType]['display']}
         </Button>
       );
     }.bind(this));
+
+    if (this.props.filterOptionList) {
+      this.props.filterOptionList.forEach(function(filterOption) {
+        buttonGroup.push(
+          <Button
+            key={this.uid+'-'+filterOption.toString()}
+            outline
+            color='secondary'
+            size='sm'
+            onClick={this.buttonMap[filterOption]['onClick']}
+            active={this.state.selectedFilterOptions.indexOf(filterOption) >= 0}
+          >
+            {this.buttonMap[filterOption]['display']}
+          </Button>
+        );
+      }.bind(this));
+    }
 
     let copyButton =
       <CopyButton value={flattenedDictToDOM(this.state.sortedData)} />;
@@ -144,14 +225,18 @@ class DictButtonGroup extends Component {
 }
 
 DictButtonGroup.propTypes = {
-  /** Types of button should be rendered.  */
+  /** Button for sorting should be rendered. */
   sortTypeList: PropTypes.arrayOf(
-    PropTypes.number
+    PropTypes.symbol
+  ).isRequired,
+  /** Button for filtering should be rendered. */
+  filterOptionList: PropTypes.arrayOf(
+    PropTypes.symbol
   ),
   /** Function to update the sort state if sort type changed */
   setRowData: PropTypes.func.isRequired,
   /** Default type of sort button */
-  defaultSortType: PropTypes.number,
+  defaultSortType: PropTypes.symbol,
   /** The data will be sorted */
   flattenedDict: PropTypes.array,
   /** unique id */

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/DictLogAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/DictLogAssertion.js
@@ -48,9 +48,12 @@ export default function DictLogAssertion(props) {
     <DictButtonGroup
       sortTypeList={[
         SORT_TYPES.ALPHABETICAL,
-        SORT_TYPES.REVERSE_ALPHABETICAL]}
+        SORT_TYPES.REVERSE_ALPHABETICAL,
+        SORT_TYPES.NONE
+      ]}
       flattenedDict={flattenedDict}
       setRowData={setRowData}
+      defaultSortType={SORT_TYPES.NONE}
     />
   );
 

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/DictMatchAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/DictMatchAssertion.js
@@ -9,7 +9,7 @@ import {
   sortFlattenedJSON,
   dictCellStyle
 } from './dictAssertionUtils';
-import {SORT_TYPES} from '../../../Common/defaults';
+import {SORT_TYPES, FILTER_OPTIONS} from './../../../Common/defaults';
 
 
 /**
@@ -38,7 +38,7 @@ import {SORT_TYPES} from '../../../Common/defaults';
  * The grid consists of three columns: Key, Expected and Value.
  *  - Key: a key of the dictionary. Nested objects are displayed with indented
  *    keys.
- *  - Expected: expected value for the given key. 
+ *  - Expected: expected value for the given key.
  *  - Value: Actual value for the given key.
  *
  */
@@ -56,12 +56,16 @@ export default function DictMatchAssertion(props) {
       sortTypeList={[
         SORT_TYPES.ALPHABETICAL,
         SORT_TYPES.REVERSE_ALPHABETICAL,
-        SORT_TYPES.BY_STATUS,
-        SORT_TYPES.ONLY_FAILURES
+        SORT_TYPES.BY_STATUS
+      ]}
+      filterOptionList={[
+        FILTER_OPTIONS.FAILURES_ONLY,
+        FILTER_OPTIONS.EXCLUDE_IGNORABLE
       ]}
       flattenedDict={flattenedDict}
       setRowData={setRowData}
       defaultSortType={SORT_TYPES.BY_STATUS}
+      defaultFilterOptions={[]}
     />
   );
 

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/FixLogAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/FixLogAssertion.js
@@ -1,8 +1,8 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import DictBaseAssertion from './DictBaseAssertion';
-import FixCellRenderer from './FixCellRenderer';
 import DictButtonGroup from './DictButtonGroup';
+import FixCellRenderer from './FixCellRenderer';
 import {
   prepareDictColumnDefs,
   prepareDictRowData,
@@ -48,10 +48,12 @@ export default function FixLogAssertion(props) {
     <DictButtonGroup
       sortTypeList={[
         SORT_TYPES.ALPHABETICAL, 
-        SORT_TYPES.REVERSE_ALPHABETICAL
+        SORT_TYPES.REVERSE_ALPHABETICAL,
+        SORT_TYPES.NONE
       ]}
       flattenedDict={flattenedDict}
       setRowData={setRowData}
+      defaultSortType={SORT_TYPES.NONE}
     />
   );
 

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/FixMatchAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/FixMatchAssertion.js
@@ -1,15 +1,15 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import DictBaseAssertion from './DictBaseAssertion';
 import DictButtonGroup from './DictButtonGroup';
 import FixCellRenderer from './FixCellRenderer';
-import DictBaseAssertion from './DictBaseAssertion';
 import {
   prepareDictColumnDefs,
   prepareDictRowData,
   sortFlattenedJSON,
   dictCellStyle
 } from './dictAssertionUtils';
-import {SORT_TYPES} from './../../../Common/defaults';
+import {SORT_TYPES, FILTER_OPTIONS} from './../../../Common/defaults';
 
 
 /**
@@ -53,14 +53,18 @@ export default function FixMatchAssertion(props) {
   const buttonGroup = (
     <DictButtonGroup
       sortTypeList={[
-        SORT_TYPES.ALPHABETICAL, 
+        SORT_TYPES.ALPHABETICAL,
         SORT_TYPES.REVERSE_ALPHABETICAL,
-        SORT_TYPES.BY_STATUS,
-        SORT_TYPES.ONLY_FAILURES
+        SORT_TYPES.BY_STATUS
+      ]}
+      filterOptionList={[
+        FILTER_OPTIONS.FAILURES_ONLY,
+        FILTER_OPTIONS.EXCLUDE_IGNORABLE
       ]}
       flattenedDict={flattenedDict}
       setRowData={setRowData}
       defaultSortType={SORT_TYPES.BY_STATUS}
+      defaultFilterOptions={[]}
     />
   );
   

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/DictButtonGroup.test.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/DictButtonGroup.test.js
@@ -2,13 +2,23 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {StyleSheetTestUtils} from "aphrodite";
 
+import {SORT_TYPES, FILTER_OPTIONS} from './../../../../Common/defaults';
 import DictButtonGroup from '../DictButtonGroup';
 
 function defaultProps() {
   return {
     uid: 'sort-test-uid',
-    defaultSortType: 3,
-    sortTypeList: [1, 2, 3, 4],
+    defaultSortType: SORT_TYPES.BY_STATUS,
+    sortTypeList: [
+      SORT_TYPES.NONE,
+      SORT_TYPES.ALPHABETICAL,
+      SORT_TYPES.REVERSE_ALPHABETICAL,
+      SORT_TYPES.BY_STATUS
+    ],
+    filterOptionList: [
+      FILTER_OPTIONS.FAILURES_ONLY,
+      FILTER_OPTIONS.EXCLUDE_IGNORABLE
+    ],
     flattenedDict: [
       [0,"foo","Passed",["int","1"],["int","1"]],
       [0,"bar","Failed",["int","2"],["int","5"]],

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/__snapshots__/DictButtonGroup.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/__snapshots__/DictButtonGroup.test.js.snap
@@ -13,7 +13,18 @@ exports[`DictLogAssertion shallow renders DictButtonGroup component 1`] = `
   <Button
     active={false}
     color="secondary"
-    key="sort-test-uid1"
+    key="sort-test-uid-Symbol(NONE)"
+    onClick={[Function]}
+    outline={true}
+    size="sm"
+    tag="button"
+  >
+    Original order
+  </Button>
+  <Button
+    active={false}
+    color="secondary"
+    key="sort-test-uid-Symbol(ALPHABETICAL)"
     onClick={[Function]}
     outline={true}
     size="sm"
@@ -42,7 +53,7 @@ exports[`DictLogAssertion shallow renders DictButtonGroup component 1`] = `
   <Button
     active={false}
     color="secondary"
-    key="sort-test-uid2"
+    key="sort-test-uid-Symbol(REVERSE_ALPHABETICAL)"
     onClick={[Function]}
     outline={true}
     size="sm"
@@ -71,7 +82,7 @@ exports[`DictLogAssertion shallow renders DictButtonGroup component 1`] = `
   <Button
     active={true}
     color="secondary"
-    key="sort-test-uid3"
+    key="sort-test-uid-Symbol(BY_STATUS)"
     onClick={[Function]}
     outline={true}
     size="sm"
@@ -82,13 +93,24 @@ exports[`DictLogAssertion shallow renders DictButtonGroup component 1`] = `
   <Button
     active={false}
     color="secondary"
-    key="sort-test-uid4"
+    key="sort-test-uid-Symbol(FAILURES_ONLY)"
     onClick={[Function]}
     outline={true}
     size="sm"
     tag="button"
   >
     Failures only
+  </Button>
+  <Button
+    active={false}
+    color="secondary"
+    key="sort-test-uid-Symbol(EXCLUDE_IGNORABLE)"
+    onClick={[Function]}
+    outline={true}
+    size="sm"
+    tag="button"
+  >
+    Hide ignored items
   </Button>
   <CopyButton
     value="<table><tr><th>Key</th><th>Expected</th><th>Value</th></tr><tr><td></td><td><small></small></td><td><small></small></td></tr><tr style=\\"color: red;\\"><td></td><td><small></small></td><td><small></small></td></tr><tr style=\\"color: red;\\"><td></td><td><small></small></td><td><small></small></td></tr></table>"

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/__snapshots__/DictLogAssertion.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/__snapshots__/DictLogAssertion.test.js.snap
@@ -4,6 +4,7 @@ exports[`DictLogAssertion shallow renders the correct HTML structure 1`] = `
 <DictBaseAssertion
   buttons={
     <DictButtonGroup
+      defaultSortType={Symbol(NONE)}
       flattenedDict={
         Array [
           Array [
@@ -61,8 +62,9 @@ exports[`DictLogAssertion shallow renders the correct HTML structure 1`] = `
       setRowData={[Function]}
       sortTypeList={
         Array [
-          1,
-          2,
+          Symbol(ALPHABETICAL),
+          Symbol(REVERSE_ALPHABETICAL),
+          Symbol(NONE),
         ]
       }
     />

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/__snapshots__/DictMatchAssertion.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/__snapshots__/DictMatchAssertion.test.js.snap
@@ -4,7 +4,14 @@ exports[`DictMatchAssertion shallow renders the correct HTML structure 1`] = `
 <DictBaseAssertion
   buttons={
     <DictButtonGroup
-      defaultSortType={3}
+      defaultFilterOptions={Array []}
+      defaultSortType={Symbol(BY_STATUS)}
+      filterOptionList={
+        Array [
+          Symbol(FAILURES_ONLY),
+          Symbol(EXCLUDE_IGNORABLE),
+        ]
+      }
       flattenedDict={
         Array [
           Array [
@@ -51,10 +58,9 @@ exports[`DictMatchAssertion shallow renders the correct HTML structure 1`] = `
       setRowData={[Function]}
       sortTypeList={
         Array [
-          1,
-          2,
-          3,
-          4,
+          Symbol(ALPHABETICAL),
+          Symbol(REVERSE_ALPHABETICAL),
+          Symbol(BY_STATUS),
         ]
       }
     />

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/__snapshots__/FixLogAssertion.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/__snapshots__/FixLogAssertion.test.js.snap
@@ -4,6 +4,7 @@ exports[`FixLogAssertion shallow renders the correct HTML structure 1`] = `
 <DictBaseAssertion
   buttonGroup={
     <DictButtonGroup
+      defaultSortType={Symbol(NONE)}
       flattenedDict={
         Array [
           Array [
@@ -90,8 +91,9 @@ exports[`FixLogAssertion shallow renders the correct HTML structure 1`] = `
       setRowData={[Function]}
       sortTypeList={
         Array [
-          1,
-          2,
+          Symbol(ALPHABETICAL),
+          Symbol(REVERSE_ALPHABETICAL),
+          Symbol(NONE),
         ]
       }
     />

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/__snapshots__/FixMatchAssertion.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/__snapshots__/FixMatchAssertion.test.js.snap
@@ -4,7 +4,14 @@ exports[`FixMatchAssertion shallow renders the correct HTML structure 1`] = `
 <DictBaseAssertion
   buttons={
     <DictButtonGroup
-      defaultSortType={3}
+      defaultFilterOptions={Array []}
+      defaultSortType={Symbol(BY_STATUS)}
+      filterOptionList={
+        Array [
+          Symbol(FAILURES_ONLY),
+          Symbol(EXCLUDE_IGNORABLE),
+        ]
+      }
       flattenedDict={
         Array [
           Array [
@@ -283,10 +290,9 @@ exports[`FixMatchAssertion shallow renders the correct HTML structure 1`] = `
       setRowData={[Function]}
       sortTypeList={
         Array [
-          1,
-          2,
-          3,
-          4,
+          Symbol(ALPHABETICAL),
+          Symbol(REVERSE_ALPHABETICAL),
+          Symbol(BY_STATUS),
         ]
       }
     />

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/dictAssertionUtils.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/dictAssertionUtils.js
@@ -29,6 +29,23 @@ export function dictCellStyle(params) {
 }
 
 /**
+ * Sort the result of DictMatch and FixMatch assertions by status of comparison
+ * items. "Failed" items are placed at the top while "Ignored" items at bottom.
+ */
+const statusIndex = (status) => {
+  switch (status.toLowerCase()) {
+    case 'failed':
+      return 0;
+    case 'passed':
+      return 1;
+    case 'ignored':
+      return 2;
+    default:
+      return 99;
+  }
+};
+
+/**
  * Helper function used to sort the data of DictMatch and FixMatch assertions.
  * The output of these assertions is a flattened JSON where the rows are in the
  * following format:
@@ -69,7 +86,7 @@ export function sortFlattenedJSON(
     sortedFlattenedJSONList.push(origFlattenedJSON.shift());
 
     // if only 1 item remains after removing the key, 
-    // add it do the sorted list and return it
+    // add it to the sorted list and return it
     if (origFlattenedJSON.length === 1) {
       sortedFlattenedJSONList.push(...origFlattenedJSON);
       return sortedFlattenedJSONList;
@@ -85,11 +102,10 @@ export function sortFlattenedJSON(
     sortedFlattenedJSONList.push(
       ...sorted(
         origFlattenedJSON, 
-        (item) => orderByStatus ? item[2] : item[1],
-        reverse
+        (item) => orderByStatus ? statusIndex(item[2]) : item[1],
+        reverse && !orderByStatus
       )
     );
-
     return sortedFlattenedJSONList;
   } else {
     // create a new object that contains the indexes of the rows
@@ -139,7 +155,8 @@ export function sortFlattenedJSON(
     // sort the list
     startingAndEndingIndexes = sorted(
       startingAndEndingIndexes, 
-      item => orderByStatus ? item.data[2] : item.data[1], reverse
+      item => orderByStatus ? statusIndex(item.data[2]) : item.data[1],
+      reverse && !orderByStatus
     );
 
     // start recursion on the sorted slices of the list

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/TableBaseAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/TableBaseAssertion.js
@@ -47,7 +47,7 @@ export default function TableBaseAssertion(props) {
       </div>
       <div
         className={`ag-theme-balham ${css(styles.grid)}`}
-        style={{height: `${height}px`, width: "100%"}}
+        style={{height: `${height}px`, width: "99.9%"}}
       >
         <AgGridReact
           onGridReady={onGridReady}

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/tableAssertionUtils.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/tableAssertionUtils.js
@@ -59,7 +59,7 @@ export function prepareTableLogColumnDefs(columns) {
       filterParams: {excelMode: 'windows'}
     });
   });
-  
+
   return columnDefs;
 }
 

--- a/testplan/web_ui/testing/src/Common/defaults.js
+++ b/testplan/web_ui/testing/src/Common/defaults.js
@@ -150,13 +150,19 @@ const BASIC_ASSERTION_TYPES = [
   'RawAssertion',
 ];
 
-const SORT_TYPES = {
-  NONE: 0,
-  ALPHABETICAL: 1,
-  REVERSE_ALPHABETICAL: 2,
-  BY_STATUS: 3,
-  ONLY_FAILURES: 4,
-};
+// identifier of radio button
+const SORT_TYPES = Object.freeze({
+  NONE: Symbol('NONE'),
+  ALPHABETICAL: Symbol('ALPHABETICAL'),
+  REVERSE_ALPHABETICAL: Symbol('REVERSE_ALPHABETICAL'),
+  BY_STATUS: Symbol('BY_STATUS'),
+});
+
+// identifier of checkbox
+const FILTER_OPTIONS = Object.freeze({
+  FAILURES_ONLY:  Symbol('FAILURES_ONLY'),
+  EXCLUDE_IGNORABLE: Symbol('EXCLUDE_IGNORABLE')
+});
 
 const DICT_GRID_STYLE = {
   MAX_VISIBLE_ROW: 20,
@@ -200,6 +206,7 @@ export {
   NAV_ENTRY_DISPLAY_DATA,
   BASIC_ASSERTION_TYPES,
   SORT_TYPES,
+  FILTER_OPTIONS,
   DICT_GRID_STYLE,
   POLL_MS,
 };


### PR DESCRIPTION
* Sort by alphabetical/reverse-alphabetical/status are mutually
  exclusive options, while 'show only failures' and 'hide ignored
  items' are additional options that can be selected at the same time.
* For dictlog and fixlog, add a new selected button for displaying
  the data in original order, if user click sort arphabetically or
  reversed, they can still recover the order.
* For dictmatch and fixmatch, the precedence of comparison status
  should "Passed"/"Failed"/"Ignored".