### PR TITLE
Fix TextAttachment download button

### DIFF
--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TextAttachment.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TextAttachment.js
@@ -107,6 +107,7 @@ function TextAttachment(props) {
     <AttachmentAssertionCardHeader
       file_name={props.file_name}
       file_size={props.file_size}
+      src={props.src}
       extra_action_items={
         lines && !tooLongToExpand && !showAll ? (
           <Button

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/AttachmentAssertions.test.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/AttachmentAssertions.test.js
@@ -7,6 +7,9 @@ import {
   AttachmentAssertion,  
 } from '../AttachmentAssertions.js';
 
+import TextAttachment from '../TextAttachment'
+import AttachmentAssertionCardHeader from '../AttachmentAssertionCardHeader'
+
 const defaultAssertionProps = {
 "category": "DEFAULT",
 "machine_time": "2019-02-12T17:41:43.312797+00:00",
@@ -40,6 +43,8 @@ describe('AttachmentAssertion', () => {
         reportUid={defaultReportUid}
       />
     );
+
+    expect(shallowComponent.find(TextAttachment).first().props().src).toBe("/api/v1/reports/123/attachments/tmpthpcdtwn-cd4f4c6e94971896a71b4a1d47785a90b19f6565-900.txt")
     expect(shallowComponent).toMatchSnapshot();
   });
 
@@ -59,6 +64,7 @@ describe('AttachmentAssertion', () => {
         reportUid={defaultReportUid}
       />
     );
+    expect(shallowComponent.find(AttachmentAssertionCardHeader).first().props().src).toBe("/api/v1/reports/123/attachments/tmpthpcdtwo-ad4f4c6e94971896a71b4a1d47785a90b19f6565-990.png")
     expect(shallowComponent).toMatchSnapshot();
   });
 
@@ -78,6 +84,7 @@ describe('AttachmentAssertion', () => {
         reportUid={defaultReportUid}
       />
     );
+    expect(shallowComponent.find(AttachmentAssertionCardHeader).first().props().src).toBe("/api/v1/reports/123/attachments/tmpthpcdtwy-bd4f4c6e94971896a71b4a1d47785a90b19f6565-200.xyz")
     expect(shallowComponent).toMatchSnapshot();
   });
 

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/TextAttachment.test.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/TextAttachment.test.js
@@ -6,7 +6,8 @@ import moxios from 'moxios';
 import {CardContent} from "@material-ui/core"
 import SyntaxHighlighter from "react-syntax-highlighter"
 
-import TextAttachment from '../TextAttachment.js';
+import TextAttachment from '../TextAttachment';
+import AttachmentAssertionCardHeader from '../AttachmentAssertionCardHeader';
 
 describe('TextAttachment', () => {
   beforeEach(() => {
@@ -23,9 +24,10 @@ describe('TextAttachment', () => {
 
   it('renders text returned from the backend', done => {
     const text = "testplan\n".repeat(100);
+    const src = "/var/tmp/attachment.txt";
     const renderedText = shallow(
       <TextAttachment
-        src="/var/tmp/attachment.txt"
+        src={src}
         file_name="attachment.txt"
       />
     );
@@ -40,6 +42,7 @@ describe('TextAttachment', () => {
         renderedText.update();
         const highlighter = renderedText.find(SyntaxHighlighter)
         expect(highlighter.first().props().children).toEqual("...\n" + line.repeat(19) + "<newline>")
+        expect(renderedText.find(AttachmentAssertionCardHeader).first().props().src).toBe(src)
         expect(renderedText).toMatchSnapshot();
         done();
       });

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/TextAttachment.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/TextAttachment.test.js.snap
@@ -5,6 +5,7 @@ exports[`TextAttachment displays error message if API request fails 1`] = `
   <AttachmentAssertionCardHeader
     extra_action_items={null}
     file_name="attachment.txt"
+    src="/var/tmp/attachment.txt"
   />
   <WithStyles(ForwardRef(CardContent))>
     Service Unavailable
@@ -30,6 +31,7 @@ exports[`TextAttachment renders text returned from the backend 1`] = `
       </ForwardRef(WithStyles)>
     }
     file_name="attachment.txt"
+    src="/var/tmp/attachment.txt"
   />
   <WithStyles(ForwardRef(CardContent))
     className="cardContent_faxwgb"


### PR DESCRIPTION
## Bug / Requirement Description
Download button on text attachments do not work

the src props is not passed to the card header component which renders the button

## Solution description
pass the src props to the card header used in TextAttachment component

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
