### PR TITLE
Make EnvWithRuntimeInfo more closer to Environment

### DIFF
--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -81,11 +81,20 @@ class MultiTestRuntimeInfo(object):
 
 class EnvWithRuntimeInfo(object):
     def __init__(self, environment, runtime_info):
-        self.__environment = environment
+        self._environment = environment
         self.multitest_runtime_info = runtime_info
 
     def __getattr__(self, attr):
-        return getattr(self.__environment, attr)
+        return getattr(self._environment, attr)
+
+    def __getitem__(self, item):
+        return self._environment[item]
+
+    def __contains__(self, item):
+        return item in self._environment
+
+    def __iter__(self):
+        return iter(self._environment)
 
 
 class MultiTestConfig(testing_base.TestConfig):


### PR DESCRIPTION
- added indexing, iteration, contains check
- fixed up the test_multitest_drivers so it fails when assertion fails in the multitest

## Bug / Requirement Description
EnvWithRuntimeInfo had some missing charcteristic

- not iterable
- not indexable
- could not check containment

## Solution description
- the needed functions implemented and passing control to the underlying _environment
- testcase updated to actually catch the errors

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
