### PR TITLE
Testplan core: bug fix and functional improvement

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -462,7 +462,7 @@ class Entity(logger.Loggable):
         timeout = wait_timeout or self.cfg.abort_wait_timeout
         try:
             self.logger.debug("Aborting {}".format(entity))
-            entity.abort()
+            entity.abort()  # Here entity can be a function and will raise
             self.logger.debug("Aborted {}".format(entity))
         except Exception as exc:
             self.logger.error(traceback.format_exc())
@@ -617,6 +617,7 @@ class RunnableResult(object):
 
     def __init__(self):
         self.step_results = OrderedDict()
+        self.run = False
 
     def __repr__(self):
         return "{}[{}]".format(self.__class__.__name__, self.__dict__)

--- a/testplan/runners/base.py
+++ b/testplan/runners/base.py
@@ -64,7 +64,8 @@ class Executor(Resource):
             self._input[uid] = item
             # `NoRunpathPool` adds item after calling `_prepopulate_runnables`
             # so the following step is still needed
-            self.ongoing.append(uid)
+            if uid not in self.ongoing:
+                self.ongoing.append(uid)
 
     def get(self, uid):
         """Get item result by uid."""

--- a/testplan/runners/local.py
+++ b/testplan/runners/local.py
@@ -27,20 +27,24 @@ class LocalRunner(Executor):
         # First retrieve the input from its UID.
         target = self._input[uid]
 
-        # Inspect the input type. Tasks must be materialized before they can be
-        # run.
-        if isinstance(target, tasks.Task):
-            runnable = target.materialize()
-            if not runnable.parent:
-                runnable.parent = self
-            if not runnable.cfg.parent:
-                runnable.cfg.parent = self.cfg
-        elif isinstance(target, entity.Runnable):
+        # Inspect the input type. Tasks must be materialized before
+        # they can be run.
+        if isinstance(target, entity.Runnable):
             runnable = target
+        elif isinstance(target, tasks.Task):
+            runnable = target.materialize()
+        elif callable(target):
+            runnable = target()
         else:
             raise TypeError(
                 "Cannot execute target of type {}".format(type(target))
             )
+
+        if isinstance(runnable, entity.Runnable):
+            if not runnable.parent:
+                runnable.parent = self
+            if not runnable.cfg.parent:
+                runnable.cfg.parent = self.cfg
 
         result = runnable.run()
         self._results[uid] = result

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -159,17 +159,13 @@ class Worker(entity.Resource):
         :rtype: :py:class:`~testplan.runners.pools.tasks.base.TaskResult`
         """
         try:
-            target = task.materialize()
-            if isinstance(target, entity.Runnable):
-                if not target.parent:
-                    target.parent = self
-                if not target.cfg.parent:
-                    target.cfg.parent = self.cfg
-                result = target.run()
-            elif callable(target):
-                result = target()
-            else:
-                result = target.run()
+            runnable = task.materialize()
+            if isinstance(runnable, entity.Runnable):
+                if not runnable.parent:
+                    runnable.parent = self
+                if not runnable.cfg.parent:
+                    runnable.cfg.parent = self.cfg
+            result = runnable.run()
         except BaseException:
             task_result = TaskResult(
                 task=task,

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -82,7 +82,6 @@ class TestResult(RunnableResult):
     def __init__(self):
         super(TestResult, self).__init__()
         self.report = None
-        self.run = False
 
 
 class Test(Runnable):
@@ -407,8 +406,12 @@ class ProcessRunnerTest(Test):
     Test report will be populated by parsing the generated report output file
     (report.xml file by default.)
 
-    :param binary: Path to the application binary or script.
+    :param name: Test instance name. Also used as uid.
+    :type name: ``str``
+    :param binary: Path the to application binary or script.
     :type binary: ``str``
+    :param description: Description of test instance.
+    :type description: ``str``
     :param proc_env: Environment overrides for ``subprocess.Popen``.
     :type proc_env: ``dict``
     :param proc_cwd: Directory override for ``subprocess.Popen``.

--- a/testplan/testing/pyunit.py
+++ b/testplan/testing/pyunit.py
@@ -26,6 +26,8 @@ class PyUnit(testing.Test):
 
     :param name: Test instance name. Also used as uid.
     :type name: ``str``
+    :param description: Description of test instance.
+    :type description: ``str``
     :param testcases: PyUnit testcases
     :type testcases: :py:class:`~unittest.TestCase`
 

--- a/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -52,17 +52,26 @@ class SuiteKillingWorker(object):
         assert env.runpath.endswith(slugify(env.cfg.name))
 
 
-def multitest_kill_one_worker(name, parent_pid, size):
+def multitest_kill_one_worker(parent_pid, size):
     """Test that kills one worker."""
     return MultiTest(
-        name="MTest{}".format(name),
-        suites=[SuiteKillingWorker(parent_pid, size)],
+        name="MTestKiller", suites=[SuiteKillingWorker(parent_pid, size)],
     )
 
 
-def multitest_kills_worker():
+@testsuite
+class SimpleSuite(object):
+    @testcase
+    def test_simple(self, env, result):
+        pass
+
+
+def multitest_kills_worker(parent_pid):
     """To kill all child workers."""
-    os.kill(os.getpid(), 9)
+    if os.getpid() != parent_pid:  # Main process should not be killed
+        os.kill(os.getpid(), 9)
+    else:
+        return MultiTest(name="MTestKiller", suites=[SimpleSuite()])
 
 
 def schedule_tests_to_pool(plan, pool, schedule_path=None, **pool_cfg):

--- a/tests/functional/testplan/runners/pools/test_pool_process.py
+++ b/tests/functional/testplan/runners/pools/test_pool_process.py
@@ -43,7 +43,7 @@ def test_kill_one_worker(mockplan):
         target="multitest_kill_one_worker",
         module="func_pool_base_tasks",
         path=dirname,
-        args=("killer", os.getpid(), pool_size),  # kills 4th worker
+        args=(os.getpid(), pool_size),  # kills 4th worker
         resource=pool_name,
     )
 
@@ -106,6 +106,7 @@ def test_kill_all_workers(mockplan):
         target="multitest_kills_worker",
         module="func_pool_base_tasks",
         path=dirname,
+        args=(os.getpid(),),
         resource=pool_name,
     )
 
@@ -121,7 +122,7 @@ def test_kill_all_workers(mockplan):
                 if worker._aborted is True
             ]
         )
-        == pool_size  # == retries_limit + 1
+        == pool_size
     )
 
     assert res.success is False
@@ -133,7 +134,6 @@ def test_kill_all_workers(mockplan):
 def test_reassign_times_limit(mockplan):
     """Kill workers and reassign task up to limit times."""
     pool_name = ProcessPool.__name__
-
     pool_size = 4
     retries_limit = int(pool_size / 2)
     pool = ProcessPool(
@@ -153,6 +153,7 @@ def test_reassign_times_limit(mockplan):
         target="multitest_kills_worker",
         module="func_pool_base_tasks",
         path=dirname,
+        args=(os.getpid(),),
         resource=pool_name,
     )
 
@@ -231,6 +232,7 @@ def test_custom_rerun_condition(mockplan):
     assert pool.added_item(uid).reassign_cnt == rerun_limit
 
 
+@pytest.mark.skip("Target is materialized before scheduling")
 def test_schedule_from_main(mockplan):
     """
     Test scheduling Tasks from __main__ - it should not be allowed for
@@ -317,6 +319,7 @@ def test_restart_worker(mockplan):
         target="multitest_kills_worker",
         module="func_pool_base_tasks",
         path=dirname,
+        args=(os.getpid(),),
         resource=pool_name,
     )
 

--- a/tests/functional/testplan/testing/multitest/test_multitest_parts.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_parts.py
@@ -1,3 +1,5 @@
+import itertools
+
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 
 from testplan import TestplanMock
@@ -21,7 +23,7 @@ class Suite1(object):
 class Suite2(object):
     """A test suite with parameterized testcases."""
 
-    @testcase(parameters=(False, True, None))
+    @testcase(parameters=(False, None, ""))
     def test_false(self, env, result, val):
         result.false(val, description="Check if value is false")
 
@@ -35,15 +37,35 @@ class Suite3(object):
         result.not_equal(0, val, description="Check if values are not equal")
 
 
+class MockMultiTest(MultiTest):
+    """A Multitest mock that creates test result with exception caught."""
+
+    def _post_run_checks(self, start_threads, start_procs):
+        super(MockMultiTest, self)._post_run_checks(start_threads, start_procs)
+        if self.cfg.part[0] % 2 == 0:
+            raise RuntimeError("Deliberately raises")
+
+
+uid_gen = itertools.cycle([i for i in range(10)])
+
+
 def get_mtest(part_tuple=None):
-    test = MultiTest(
+    return MultiTest(
         name="MTest", suites=[Suite1(), Suite2()], part=part_tuple
     )
-    return test
+
+
+def get_mtest_with_custom_uid(part_tuple=None):
+    return MultiTest(
+        name="MTest",
+        suites=[Suite1(), Suite2()],
+        part=part_tuple,
+        multi_part_uid=lambda name: "{} - {}".format(name, next(uid_gen)),
+    )
 
 
 def test_multi_parts_not_merged():
-    """Execute MultiTest parts but do not merge report."""
+    """Execute MultiTest parts but do not merge reports."""
     plan = TestplanMock(name="plan", merge_scheduled_parts=False)
     pool = ThreadPool(name="MyThreadPool", size=2)
     plan.add_resource(pool)
@@ -56,9 +78,9 @@ def test_multi_parts_not_merged():
         assert plan.run().run is True
 
     assert len(plan.report.entries) == 3
-    assert plan.report.entries[0].name == "MTest - part(1/3)"
-    assert plan.report.entries[1].name == "MTest - part(2/3)"
-    assert plan.report.entries[2].name == "MTest - part(3/3)"
+    assert plan.report.entries[0].name == "MTest - part(0/3)"
+    assert plan.report.entries[1].name == "MTest - part(1/3)"
+    assert plan.report.entries[2].name == "MTest - part(2/3)"
     assert len(plan.report.entries[0].entries) == 2  # 2 suites
     assert plan.report.entries[0].entries[0].name == "Suite1"
     assert plan.report.entries[0].entries[1].name == "Suite2"
@@ -71,14 +93,23 @@ def test_multi_parts_not_merged():
 
 
 def test_multi_parts_merged():
-    """Execute MultiTest parts and merge report."""
+    """
+    Schedule MultiTest parts in different ways, execute them and merge reports.
+    """
     plan = TestplanMock(name="plan", merge_scheduled_parts=True)
     pool = ThreadPool(name="MyThreadPool", size=2)
     plan.add_resource(pool)
 
-    for idx in range(3):
-        task = Task(target=get_mtest(part_tuple=(idx, 3)))
-        plan.schedule(task, resource="MyThreadPool")
+    def _get_mtest():
+        return MultiTest(
+            name="MTest", suites=[Suite1(), Suite2()], part=(2, 3)
+        )
+
+    plan.add(target=_get_mtest())  # local_runner
+    plan.add(Task(target=get_mtest(part_tuple=(1, 3))))  # local_runner
+    plan.schedule(
+        Task(target=get_mtest(part_tuple=(0, 3))), resource="MyThreadPool"
+    )
 
     with log_propagation_disabled(TESTPLAN_LOGGER):
         assert plan.run().run is True
@@ -96,38 +127,7 @@ def test_multi_parts_merged():
     assert len(plan.report.entries[0].entries[1].entries[0].entries) == 3
 
 
-def test_multi_parts_invalid_parameter_1():
-    """
-    Execute MultiTest parts with invalid parameters that a part
-    of MultiTest has been scheduled twice.
-    """
-    plan = TestplanMock(name="plan", merge_scheduled_parts=True)
-    pool = ThreadPool(name="MyThreadPool", size=2)
-    plan.add_resource(pool)
-
-    for idx in range(3):
-        task = Task(target=get_mtest(part_tuple=(idx, 3)))
-        plan.schedule(task, resource="MyThreadPool")
-    plan.schedule(
-        Task(target=get_mtest(part_tuple=(1, 3))), resource="MyThreadPool"
-    )
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert plan.run().run is False
-
-    assert len(plan.report.entries) == 1
-    assert len(plan.report.entries[0].entries) == 2
-    assert plan.report.status == Status.ERROR  # Testplan result
-    assert plan.report.entries[0].status == Status.ERROR  # Multitest
-    assert plan.report.entries[0].entries[0].status == Status.UNKNOWN  # Suite1
-    assert plan.report.entries[0].entries[1].status == Status.UNKNOWN  # Suite2
-    assert (
-        "duplicate MultiTest parts had been scheduled"
-        in plan.report.entries[0].logs[0]["message"]
-    )
-
-
-def test_multi_parts_invalid_parameter_2():
+def test_multi_parts_incorrect_schedule():
     """
     Execute MultiTest parts with invalid parameters that a MultiTest
     has been scheduled twice and each time split into different parts.
@@ -139,21 +139,51 @@ def test_multi_parts_invalid_parameter_2():
     for idx in range(3):
         task = Task(target=get_mtest(part_tuple=(idx, 3)))
         plan.schedule(task, resource="MyThreadPool")
+
     for idx in range(2):
         task = Task(target=get_mtest(part_tuple=(idx, 2)))
         plan.schedule(task, resource="MyThreadPool")
 
+    assert len(plan._tests) == 5
+
     with log_propagation_disabled(TESTPLAN_LOGGER):
         assert plan.run().run is False
 
-    assert len(plan.report.entries) == 1
-    assert len(plan.report.entries[0].entries) == 2
+    assert len(plan.report.entries) == 6  # one placeholder report & 5 siblings
+    assert len(plan.report.entries[0].entries) == 0  # already cleared
     assert plan.report.status == Status.ERROR  # Testplan result
-    assert plan.report.entries[0].status == Status.ERROR  # Multitest
-    assert plan.report.entries[0].entries[0].status == Status.UNKNOWN  # Suite1
-    assert plan.report.entries[0].entries[1].status == Status.UNKNOWN  # Suite2
     assert (
         "invalid parameter of part provided"
+        in plan.report.entries[0].logs[0]["message"]
+    )
+
+
+def test_multi_parts_duplicate_part():
+    """
+    Execute MultiTest parts with a part of MultiTest has been
+    scheduled twice and automatically be filtered out.
+    """
+    plan = TestplanMock(name="plan", merge_scheduled_parts=True)
+    pool = ThreadPool(name="MyThreadPool", size=2)
+    plan.add_resource(pool)
+
+    for idx in range(3):
+        task = Task(target=get_mtest_with_custom_uid(part_tuple=(idx, 3)))
+        plan.schedule(task, resource="MyThreadPool")
+
+    task = Task(target=get_mtest_with_custom_uid(part_tuple=(1, 3)))
+    plan.schedule(task, resource="MyThreadPool")
+
+    assert len(plan._tests) == 4
+
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        assert plan.run().run is False
+
+    assert len(plan.report.entries) == 5  # one placeholder report & 4 siblings
+    assert len(plan.report.entries[0].entries) == 0  # already cleared
+    assert plan.report.status == Status.ERROR  # Testplan result
+    assert (
+        "duplicate MultiTest parts had been scheduled"
         in plan.report.entries[0].logs[0]["message"]
     )
 
@@ -174,42 +204,29 @@ def test_multi_parts_missing_parts():
     with log_propagation_disabled(TESTPLAN_LOGGER):
         assert plan.run().run is False
 
-    assert len(plan.report.entries) == 1
-    assert len(plan.report.entries[0].entries) == 2
+    assert len(plan.report.entries) == 3  # one placeholder report & 2 siblings
+    assert len(plan.report.entries[0].entries) == 0  # already cleared
     assert plan.report.status == Status.ERROR  # Testplan result
-    assert plan.report.entries[0].status == Status.ERROR  # Multitest
-    assert plan.report.entries[0].entries[0].status == Status.UNKNOWN  # Suite1
-    assert plan.report.entries[0].entries[1].status == Status.UNKNOWN  # Suite2
     assert (
         "not all MultiTest parts had been scheduled"
         in plan.report.entries[0].logs[0]["message"]
     )
 
 
-def test_multi_parts_duplicate_names():
+def test_multi_parts_not_successfully_executed():
     """
-    The name of schedule MultiTest part objects is duplicate as another one
-    thus an exception will be raised.
+    Any part did not run successfully then parts cannot be merged
+    and error will be logged.
     """
     plan = TestplanMock(name="plan", merge_scheduled_parts=True)
-    plan.add(MultiTest(name="MTest", suites=[Suite3()]))
-
-    pool = ThreadPool(name="MyThreadPool", size=2)
-    plan.add_resource(pool)
-
-    for idx in range(1, 3):
-        task = Task(target=get_mtest(part_tuple=(idx, 3)))
-        plan.schedule(task, resource="MyThreadPool")
+    plan.add(MockMultiTest(name="MTest", suites=[Suite1()], part=(0, 2)))
+    plan.add(MockMultiTest(name="MTest", suites=[Suite1()], part=(1, 2)))
 
     with log_propagation_disabled(TESTPLAN_LOGGER):
         assert plan.run().run is False
 
-    assert len(plan.report.entries) == 1
-    assert len(plan.report.entries[0].entries) == 1
-    assert plan.report.status == Status.PASSED  # Testplan result
-    assert plan.report.entries[0].status == Status.PASSED  # Multitest
-    assert plan.report.entries[0].entries[0].status == Status.PASSED  # Suite3
-
-    exc = plan.result.step_results["_create_result"]
-    assert isinstance(exc, ValueError)
-    assert "MTest already exists" in str(exc)
+    assert len(plan.report.entries) == 3  # one placeholder report & 2 siblings
+    assert len(plan.report.entries[0].entries) == 0  # already cleared
+    assert plan.report.status == Status.ERROR  # Testplan result
+    assert plan.report.entries[0].status == Status.ERROR  # 1st part raised
+    assert "Deliberately raises" in plan.report.entries[0].logs[0]["message"]

--- a/tests/functional/testplan/testing/test_filtering.py
+++ b/tests/functional/testplan/testing/test_filtering.py
@@ -209,7 +209,7 @@ def test_programmatic_filtering(filter_obj, report_ctx):
             ("--patterns", "XXX:*:test_two"),
             [("XXX", [("Alpha", ["test_two"]), ("Beta", ["test_two"])])],
         ),
-        # Case 2, pattern filtering (multiple params)
+        # Case 3, pattern filtering (multiple params)
         (
             ("--patterns", "XXX:*:test_two", "--patterns", "YYY:*:test_three"),
             [
@@ -217,7 +217,7 @@ def test_programmatic_filtering(filter_obj, report_ctx):
                 ("YYY", (("Gamma", ["test_three"]),)),
             ],
         ),
-        # Case 3, tag filtering
+        # Case 4, tag filtering
         (
             ("--tags", "bar color=red"),
             [
@@ -231,7 +231,7 @@ def test_programmatic_filtering(filter_obj, report_ctx):
                 ("YYY", (("Gamma", ["test_three"]),)),
             ],
         ),
-        # Case 4, tag filtering (multiple params)
+        # Case 5, tag filtering (multiple params)
         (
             # Run tests that match ANY of these rules
             # as they belong to the same category (tags)
@@ -252,7 +252,7 @@ def test_programmatic_filtering(filter_obj, report_ctx):
                 ("YYY", (("Gamma", ["test_two", "test_three"]),)),
             ],
         ),
-        # Case 5, pattern & tag composite filtering
+        # Case 6, pattern & tag composite filtering
         # Tag filters will be wrapped by Any
         # Pattern and tag filters will be wrapped by All
         (

--- a/tests/unit/testplan/runners/pools/tasks/data/relative/sample_tasks.py
+++ b/tests/unit/testplan/runners/pools/tasks/data/relative/sample_tasks.py
@@ -16,6 +16,10 @@ class Runnable(object):
         """TODO."""
         return self._number * self._multiplier
 
+    def uid(self):
+        """TODO."""
+        return "{} * {}".format(self._number, self._multiplier)
+
 
 def callable_to_runnable(number):
     """TODO."""
@@ -72,6 +76,15 @@ class Multiplier(Runnable):
 def callable_to_non_runnable(number):
     """TODO."""
     return NonRunnable(number)
+
+
+def callable_to_none():
+    """TODO."""
+
+    def _inner():
+        return None
+
+    return _inner
 
 
 def multiply(number, multiplier=2):


### PR DESCRIPTION
* Should check the uid of real test target even if they are wrapped
  in a `Task` object as much as possible to prevent duplicate tests
  being schedule and then exception raised during creating results.
* Fix a bug that `local_runner` cannot execute a callable object.
* Fix a bug that in interactive mode a callable object that returns
  a test entity cannot be correctly added into TestRunner.
* Fix a bug that in interactive mode Multitest-parts cannot work.
* Modify uid of Multitest parts automatically to avoid conflict, and
  set it back as test entity's name for merge sibling reports.
* If fails to merge reports of MultiTest parts then error message will
  be logged and then append sibling reports at the end of plan report.
* Be cautious about the return value of step `_create_result` because
  `run` attribute in returned result of each test entity can be a
  non-boolean value.
* Fix a small issue that when unhandled exception raised during adding
  tests into plan, all tests should abort but function has no `abort`
  method, the extra error log is confusing.
* Fix a potential bug that if scheduled task return None then program
  can enter an infinite recursion.
