### PR TITLE
Fix remote pool issue with Attachment assertion.

### DIFF
--- a/examples/ExecutionPools/Remote/tasks.py
+++ b/examples/ExecutionPools/Remote/tasks.py
@@ -28,14 +28,6 @@ class TCPTestsuite(object):
     def setup(self, env, result):
         result.log("LOCAL_USER: {}".format(os.environ["LOCAL_USER"]))
 
-        # Check if the local workspace soft link could be created.
-        local_workspace = os.environ["LOCAL_WORKSPACE"]
-        result.log(
-            "Local workspace {} exists: {} ".format(
-                local_workspace, os.path.exists(local_workspace)
-            )
-        )
-
         for _file in self._files:
             with open(_file) as fobj:
                 result.log("Source file contents: {}".format(fobj.read()))

--- a/examples/ExecutionPools/Remote/test_plan.py
+++ b/examples/ExecutionPools/Remote/test_plan.py
@@ -63,11 +63,8 @@ def main(plan):
     :return: Testplan result object.
     :rtype:  ``testplan.base.TestplanResult``
     """
-    import testplan
 
-    workspace = os.path.abspath(
-        os.path.join(os.path.dirname(module_abspath(testplan)), "..", "..")
-    )
+    workspace = os.path.dirname(__file__)
 
     # Create two temporary files locally. For demonstration, just write the
     # filename as the content of each.

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -50,7 +50,7 @@ class Worker(entity.Resource):
     :type index: ``int`` or ``str``
     :param transport: Transport class for pool/worker communication.
     :type transport: :py:class:`~testplan.runners.pools.connection.Client`
-    :param restart_count: How many times the worker had restarted.
+    :param restart_count: How many times a worker in pool can be restarted.
     :type restart_count: ``int``
 
     Also inherits all :py:class:`~testplan.common.entity.base.Resource`

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -143,7 +143,6 @@ class ChildLoop(object):
         for idx, cfg in enumerate(response.data):
             try:
                 cfg.parent = response.data[idx + 1]
-                print(cfg.parent)
             except IndexError:
                 break
         self._pool_cfg = pool_cfg
@@ -278,12 +277,7 @@ class RemoteChildLoop(ChildLoop):
         if self._setup_metadata.env:
             for key, value in self._setup_metadata.env.items():
                 os.environ[key] = value
-        os.environ[
-            "TESTPLAN_LOCAL_WORKSPACE"
-        ] = self._setup_metadata.workspace_paths.local
-        os.environ[
-            "TESTPLAN_REMOTE_WORKSPACE"
-        ] = self._setup_metadata.workspace_paths.remote
+
         if self._setup_metadata.push_dir:
             os.environ["TESTPLAN_PUSH_DIR"] = self._setup_metadata.push_dir
 
@@ -320,9 +314,13 @@ class RemoteChildLoop(ChildLoop):
 def child_logic(args):
     """Able to be imported child logic."""
     if args.log_level:
-        from testplan.common.utils.logger import TESTPLAN_LOGGER
+        from testplan.common.utils.logger import (
+            TESTPLAN_LOGGER,
+            STDOUT_HANDLER,
+        )
 
         TESTPLAN_LOGGER.setLevel(args.log_level)
+        TESTPLAN_LOGGER.removeHandler(STDOUT_HANDLER)
 
     import psutil
 
@@ -444,3 +442,5 @@ if __name__ == "__main__":
         os.environ[testplan.TESTPLAN_DEPENDENCIES_PATH] = ARGS.testplan_deps
 
     child_logic(ARGS)
+    print("child.py exiting")
+    os._exit(0)

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -841,7 +841,9 @@ class MultiTest(testing_base.Test):
         method_report = testplan.report.TestCaseReport(
             method, uid=method, suite_related=True
         )
-        case_result = self.cfg.result(stdout_style=self.stdout_style)
+        case_result = self.cfg.result(
+            stdout_style=self.stdout_style, _scratch=self._scratch
+        )
 
         try:
             interface.check_signature(attr, ["self", "env", "result"])

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -73,7 +73,7 @@ class App(Driver):
     :type working_dir: ``str``
 
     Also inherits all
-    :py:class:`~testplan.testing.multitest.driver.base.DriverConfig` options.
+    :py:class:`~testplan.testing.multitest.driver.base.Driver` options.
     """
 
     CONFIG = AppConfig
@@ -295,18 +295,22 @@ class App(Driver):
     def _install_target(self):
         return self.etcpath
 
-    def restart(self):
+    def restart(self, clean=True):
         """
         Stop the driver, archive the app_dir or rename std/log, and then restart
         the driver.
+
+        :param clean: set to False to not archive app_dir or rotate std/log.
+        :type clean: ``bool``
+
         """
         self.stop()
         self.wait(self.status.STOPPED)
-
-        if self.cfg.app_dir_name:
-            self._move_app_path()
-        else:
-            self._rename_std_and_log()
+        if clean:
+            if self.cfg.app_dir_name:
+                self._move_app_path()
+            else:
+                self._rename_std_and_log()
 
         # we don't want to cleanup runpath during restart
         path_cleanup = self.cfg.path_cleanup

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -9,6 +9,8 @@ after testcases have finished running.
 import inspect
 import os
 import re
+import uuid
+import shutil
 
 from testplan import defaults
 from testplan.defaults import STDOUT_STYLE
@@ -2161,7 +2163,15 @@ class Result(object):
 
     def attach(self, filepath, description=None):
         """Attaches a file to the report."""
-        attachment = base.Attachment(filepath, description)
+        filename = os.path.basename(filepath)
+        try:
+            # will best effort make a copy of the file
+            copy_of_file = os.path.join(self._scratch, filename)
+            shutil.copyfile(filepath, copy_of_file)
+        except Exception:
+            copy_of_file = filepath
+
+        attachment = base.Attachment(copy_of_file, description)
         self.attachments.append(attachment)
         _bind_entry(attachment, self)
         return attachment

--- a/tests/unit/testplan/testing/multitest/test_result.py
+++ b/tests/unit/testplan/testing/multitest/test_result.py
@@ -380,7 +380,7 @@ class TestResultBaseNamespace(object):
         with open(tmpfile, "w") as f:
             f.write("testplan\n" * 1000)
 
-        result = result_mod.Result()
+        result = result_mod.Result(_scratch=str(tmpdir))
         assert result.attach(tmpfile, description="Attach a text file")
 
         assert len(result.entries) == 1
@@ -406,7 +406,7 @@ class TestResultBaseNamespace(object):
 
         description = "Attach a text file at level: {}"
 
-        result = result_mod.Result()
+        result = result_mod.Result(_scratch=str(tmpdir))
         assert result.attach(tmpfile, description=description.format(0))
 
         assert len(result.entries) == 1


### PR DESCRIPTION
## Bug / Requirement Description
When result.attach() or result.matplot() is used in remote pool, the attached file is not accessible in the final report.

## Solution description
1) Local & remote testplan now use the same runpath
2) Attachment file will be copied to scratch dir so that it's still available even if user clean it up after testcase run
3) Clean up remote pool example
4) Fix child.py double logging and not exiting issue 
5) Add a new clean param to app driver restart

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
