### PR TITLE
Create report with a real UUID assigned

### DIFF
--- a/testplan/base.py
+++ b/testplan/base.py
@@ -453,6 +453,6 @@ class TestplanMock(Testplan):
         kwargs.setdefault("abort_signals", [])
         kwargs.setdefault("runpath", default_runpath_mock)
         kwargs.setdefault("parse_cmdline", False)
-        kwargs.setdefault("reset_report_uid", False)
+        kwargs.setdefault("auto_report_uid", False)
 
         super(TestplanMock, self).__init__(*args, **kwargs)

--- a/testplan/common/report/base.py
+++ b/testplan/common/report/base.py
@@ -379,8 +379,9 @@ class ReportGroup(Report):
 
     def reset_uid(self, uid=None):
         """
-        Reset uid of the report and all of its children, it can be useful
-        when need to generate standard UUIDs instead of the current ones.
+        Reset uid of test report, it can be useful when need to generate
+        a standard UUID instead of the current one, will recursively reset
+        uids of all of its children with standard UUIDs format.
         """
         self.uid = uid or strings.uuid4()
         for entry in self:

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -364,6 +364,9 @@ that match ALL of the given tags.
         if args["list"] and not args["test_lister"]:
             args["test_lister"] = listing.NameLister()
 
+        if args["interactive_port"] is not None:
+            args["auto_report_uid"] = False
+
         return args
 
 

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -699,9 +699,7 @@ class TestRunnerIHandler(entity.Entity):
     def _initial_report(self):
         """Generate the initial report skeleton."""
         report = testplan.report.TestReport(
-            name=self.cfg.name,
-            description=self.cfg.description,
-            uid=self.cfg.name,
+            name=self.cfg.name, description=self.cfg.description,
         )
 
         for test_uid in self.all_tests():

--- a/testplan/testing/cpp/cppunit.py
+++ b/testplan/testing/cpp/cppunit.py
@@ -10,11 +10,7 @@ from lxml.builder import E  # pylint: disable=no-name-in-module
 from testplan.common.config import ConfigOption
 from testplan.common.utils.strings import slugify
 
-from testplan.report import (
-    TestGroupReport,
-    TestCaseReport,
-    RuntimeStatus,
-)
+from testplan.report import ReportCategories, RuntimeStatus
 from testplan.testing.multitest.entries.assertions import RawAssertion
 from testplan.testing.multitest.entries.schemas.base import registry
 
@@ -137,12 +133,10 @@ class Cppunit(ProcessRunnerTest):
 
         ./cppunit_bin -y /path/to/test/result
 
-    :param name: Test instance name. Also used as uid.
+    :param name: Test instance name.
     :type name: ``str``
     :param binary: Path the to application binary or script.
     :type binary: ``str``
-    :param description: Description of test instance.
-    :type description: ``str``
     :param file_output_flag: Customized command line flag for specifying path
         of output file.
     :type file_output_flag: ``NoneType`` or ``str``
@@ -239,8 +233,8 @@ class Cppunit(ProcessRunnerTest):
         result = []
         for suite in test_data.getchildren():
             suite_name = suite.attrib["name"]
-            suite_report = TestGroupReport(
-                name=suite_name, uid=suite_name, category="testsuite"
+            suite_report = self._create_test_group_report(
+                name=suite_name, category=ReportCategories.TESTSUITE,
             )
 
             for testcase in suite.getchildren():
@@ -249,11 +243,11 @@ class Cppunit(ProcessRunnerTest):
 
                 testcase_classname = testcase.attrib["classname"]
                 testcase_name = testcase.attrib["name"]
-                testcase_report = TestCaseReport(
-                    name=testcase_name,
-                    uid="{}::{}".format(
-                        testcase_classname.replace(".", "::"), testcase_name
-                    ),
+                testcase_prefix = testcase_classname.split(".")[-1]
+                testcase_report = self._create_testcase_report(
+                    name="{}::{}".format(testcase_prefix, testcase_name)
+                    if testcase_prefix
+                    else testcase_name
                 )
 
                 if not testcase.getchildren():

--- a/testplan/testing/cpp/gtest.py
+++ b/testplan/testing/cpp/gtest.py
@@ -2,11 +2,7 @@ from schema import Or
 
 from testplan.common.config import ConfigOption
 
-from testplan.report import (
-    TestGroupReport,
-    TestCaseReport,
-    RuntimeStatus,
-)
+from testplan.report import ReportCategories, RuntimeStatus
 from testplan.testing.multitest.entries.assertions import RawAssertion
 from testplan.testing.multitest.entries.schemas.base import registry
 
@@ -60,12 +56,10 @@ class GTest(ProcessRunnerTest):
     Most of the configuratin options of GTest are
     just simple wrappers for native arguments.
 
-    :param name: Test instance name. Also used as uid.
+    :param name: Test instance name.
     :type name: ``str``
     :param binary: Path the to application binary or script.
     :type binary: ``str``
-    :param description: Description of test instance.
-    :type description: ``str``
     :param gtest_filter: Native test filter pattern that will be
                         used by GTest internally.
     :type gtest_filter: ``str``
@@ -159,16 +153,16 @@ class GTest(ProcessRunnerTest):
         result = []
         for suite in test_data.getchildren():
             suite_name = suite.attrib["name"]
-            suite_report = TestGroupReport(
-                name=suite_name, uid=suite_name, category="testsuite"
+            suite_report = self._create_test_group_report(
+                name=suite_name, category=ReportCategories.TESTSUITE,
             )
             suite_has_run = False
 
             for testcase in suite.getchildren():
 
                 testcase_name = testcase.attrib["name"]
-                testcase_report = TestCaseReport(
-                    name=testcase_name, uid=testcase_name
+                testcase_report = self._create_testcase_report(
+                    name=testcase_name
                 )
 
                 if not testcase.getchildren():

--- a/testplan/testing/cpp/hobbestest.py
+++ b/testplan/testing/cpp/hobbestest.py
@@ -2,7 +2,7 @@ from schema import Or
 
 from testplan.common.config import ConfigOption
 
-from testplan.report import TestGroupReport, TestCaseReport, RuntimeStatus
+from testplan.report import ReportCategories, RuntimeStatus
 from testplan.testing.multitest.entries.assertions import RawAssertion
 from testplan.testing.multitest.entries.schemas.base import registry
 
@@ -31,12 +31,10 @@ class HobbesTest(ProcessRunnerTest):
     Subprocess test runner for Hobbes Test:
     https://github.com/Morgan-Stanley/hobbes
 
-    :param name: Test instance name. Also used as uid.
+    :param name: Test instance name.
     :type name: ``str``
     :param binary: Path the to application binary or script.
     :type binary: ``str``
-    :param description: Description of test instance.
-    :type description: ``str``
     :param tests: Run one or more specified test(s).
     :type tests: ``list``
     :param json: Generate test report in JSON with the specified name. The
@@ -102,8 +100,8 @@ class HobbesTest(ProcessRunnerTest):
 
         result = []
         for suite in test_data:
-            suite_report = TestGroupReport(
-                name=suite["name"], uid=suite["name"], category="testsuite"
+            suite_report = self._create_test_group_report(
+                name=suite["name"], category=ReportCategories.TESTSUITE,
             )
             suite_has_run = False
 
@@ -111,10 +109,8 @@ class HobbesTest(ProcessRunnerTest):
                 if testcase["status"] != "skipped":
                     suite_has_run = True
 
-                    testcase_report = TestCaseReport(
-                        name=testcase["name"],
-                        uid=testcase["name"],
-                        suite_related=True,
+                    testcase_report = self._create_testcase_report(
+                        name=testcase["name"], suite_related=True,
                     )
                     assertion_obj = RawAssertion(
                         passed=testcase["status"] == "pass",

--- a/testplan/testing/pyunit.py
+++ b/testplan/testing/pyunit.py
@@ -1,10 +1,10 @@
 """PyUnit test runner."""
 
 from testplan.testing import base as testing
-from testplan.report import testing as report_testing
 from testplan.testing.multitest.entries import assertions
 from testplan.testing.multitest.entries import schemas
 from testplan.testing.multitest.entries import base as base_entries
+from testplan.report import ReportCategories
 
 import unittest
 
@@ -24,10 +24,8 @@ class PyUnit(testing.Test):
     """
     Test runner for PyUnit unit tests.
 
-    :param name: Test instance name. Also used as uid.
+    :param name: Test instance name.
     :type name: ``str``
-    :param description: Description of test instance.
-    :type description: ``str``
     :param testcases: PyUnit testcases
     :type testcases: :py:class:`~unittest.TestCase`
 
@@ -68,14 +66,11 @@ class PyUnit(testing.Test):
         test_report = self._new_test_report()
 
         for pyunit_testcase in self.cfg.testcases:
-            testsuite_report = report_testing.TestGroupReport(
+            testsuite_report = self._create_test_group_report(
                 name=pyunit_testcase.__name__,
-                uid=pyunit_testcase.__name__,
-                category=report_testing.ReportCategories.TESTSUITE,
+                category=ReportCategories.TESTSUITE,
                 entries=[
-                    report_testing.TestCaseReport(
-                        name=self._TESTCASE_NAME, uid=self._TESTCASE_NAME,
-                    )
+                    self._create_testcase_report(name=self._TESTCASE_NAME)
                 ],
             )
             test_report.append(testsuite_report)
@@ -118,8 +113,8 @@ class PyUnit(testing.Test):
         # suite, we put all results into a single "testcase" report. This
         # will only list failures and errors and not give detail on individual
         # assertions like with MultiTest.
-        testcase_report = report_testing.TestCaseReport(
-            name=self._TESTCASE_NAME, uid=self._TESTCASE_NAME
+        testcase_report = self._create_testcase_report(
+            name=self._TESTCASE_NAME
         )
 
         for call, error in suite_result.errors:
@@ -147,9 +142,8 @@ class PyUnit(testing.Test):
             testcase_report.append(schemas.base.registry.serialize(log_entry))
 
         # We have to wrap the testcase report in a testsuite report.
-        return report_testing.TestGroupReport(
+        return self._create_test_group_report(
             name=pyunit_testcase.__name__,
-            uid=pyunit_testcase.__name__,
-            category=report_testing.ReportCategories.TESTSUITE,
+            category=ReportCategories.TESTSUITE,
             entries=[testcase_report],
         )

--- a/tests/functional/testplan/testing/fixtures/cpp/cppunit/failing/report.py
+++ b/tests/functional/testplan/testing/fixtures/cpp/cppunit/failing/report.py
@@ -12,39 +12,39 @@ expected_report = TestReport(
                     category="testsuite",
                     entries=[
                         TestCaseReport(
-                            name="testEqual",
+                            name="Comparison::testEqual",
                             entries=[
                                 {"type": "RawAssertion", "passed": False}
                             ],
                         ),
                         TestCaseReport(
-                            name="testAnd",
+                            name="LogicalOp::testAnd",
                             entries=[
                                 {"type": "RawAssertion", "passed": False}
                             ],
                         ),
                         TestCaseReport(
-                            name="testGreater",
+                            name="Comparison::testGreater",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testLess",
+                            name="Comparison::testLess",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testMisc",
+                            name="Comparison::testMisc",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testOr",
+                            name="LogicalOp::testOr",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testNot",
+                            name="LogicalOp::testNot",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testXor",
+                            name="LogicalOp::testXor",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                     ],

--- a/tests/functional/testplan/testing/fixtures/cpp/cppunit/passing/report.py
+++ b/tests/functional/testplan/testing/fixtures/cpp/cppunit/passing/report.py
@@ -12,35 +12,35 @@ expected_report = TestReport(
                     category="testsuite",
                     entries=[
                         TestCaseReport(
-                            name="testNotEqual",
+                            name="Comparison::testNotEqual",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testGreater",
+                            name="Comparison::testGreater",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testLess",
+                            name="Comparison::testLess",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testMisc",
+                            name="Comparison::testMisc",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testOr",
+                            name="LogicalOp::testOr",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testAnd",
+                            name="LogicalOp::testAnd",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testNot",
+                            name="LogicalOp::testNot",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testXor",
+                            name="LogicalOp::testXor",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                     ],


### PR DESCRIPTION
* A test report object is created with a real UUID assigned by default
  and no need to reset uids of all reports after test runner creates
  the result.
* Still can set argument `auto_report_uid` to `False` for test runner
  instance to disable automatically UUID generation, especially when
  writing code just for test purpose.