### PR TITLE
Reset UID of report after test execution finished

### DIFF
--- a/testplan/base.py
+++ b/testplan/base.py
@@ -443,9 +443,9 @@ def default_runpath_mock(entity):
 
 class TestplanMock(Testplan):
     """
-    A mock Testplan class for testing purpose. It is recommended to use mockplan
-    fixture defined in conftest.py if you can. Only use this when necessary, e.g
-    you need to override default parameters.
+    A mock Testplan class for testing purpose. It is recommended to use
+    mockplan fixture defined in conftest.py if you can. Only use this when
+    necessary, e.g. you need to override default parameters.
     """
 
     def __init__(self, *args, **kwargs):
@@ -453,6 +453,6 @@ class TestplanMock(Testplan):
         kwargs.setdefault("abort_signals", [])
         kwargs.setdefault("runpath", default_runpath_mock)
         kwargs.setdefault("parse_cmdline", False)
-        kwargs.setdefault("reset_report_uid", False)
 
         super(TestplanMock, self).__init__(*args, **kwargs)
+        self._runnable._reset_report_uid = False

--- a/testplan/common/report/base.py
+++ b/testplan/common/report/base.py
@@ -190,7 +190,7 @@ class Report(object):
     def reset_uid(self, uid=None):
         """
         Reset uid of the report, it can be useful when need to generate
-        a standard UUID instead of the current one.
+        a global unique id instead of the current one.
         """
         self.uid = uid or strings.uuid4()
 
@@ -379,8 +379,9 @@ class ReportGroup(Report):
 
     def reset_uid(self, uid=None):
         """
-        Reset uid of the report and all of its children, it can be useful
-        when need to generate standard UUIDs instead of the current ones.
+        Reset uid of test report and all of its children, it can be useful
+        when need to generate global unique id for each report entry before
+        saving, by default strings in standard UUID format will be applied.
         """
         self.uid = uid or strings.uuid4()
         for entry in self:

--- a/testplan/testing/cpp/cppunit.py
+++ b/testplan/testing/cpp/cppunit.py
@@ -13,6 +13,7 @@ from testplan.common.utils.strings import slugify
 from testplan.report import (
     TestGroupReport,
     TestCaseReport,
+    ReportCategories,
     RuntimeStatus,
 )
 from testplan.testing.multitest.entries.assertions import RawAssertion
@@ -137,7 +138,7 @@ class Cppunit(ProcessRunnerTest):
 
         ./cppunit_bin -y /path/to/test/result
 
-    :param name: Test instance name. Also used as uid.
+    :param name: Test instance name, often used as uid of test entity.
     :type name: ``str``
     :param binary: Path the to application binary or script.
     :type binary: ``str``
@@ -240,7 +241,9 @@ class Cppunit(ProcessRunnerTest):
         for suite in test_data.getchildren():
             suite_name = suite.attrib["name"]
             suite_report = TestGroupReport(
-                name=suite_name, uid=suite_name, category="testsuite"
+                name=suite_name,
+                category=ReportCategories.TESTSUITE,
+                uid=suite_name,
             )
 
             for testcase in suite.getchildren():
@@ -249,8 +252,9 @@ class Cppunit(ProcessRunnerTest):
 
                 testcase_classname = testcase.attrib["classname"]
                 testcase_name = testcase.attrib["name"]
+                testcase_prefix = testcase_classname.split(".")[-1]
                 testcase_report = TestCaseReport(
-                    name=testcase_name,
+                    name="{}::{}".format(testcase_prefix, testcase_name),
                     uid="{}::{}".format(
                         testcase_classname.replace(".", "::"), testcase_name
                     ),

--- a/testplan/testing/cpp/gtest.py
+++ b/testplan/testing/cpp/gtest.py
@@ -5,6 +5,7 @@ from testplan.common.config import ConfigOption
 from testplan.report import (
     TestGroupReport,
     TestCaseReport,
+    ReportCategories,
     RuntimeStatus,
 )
 from testplan.testing.multitest.entries.assertions import RawAssertion
@@ -60,7 +61,7 @@ class GTest(ProcessRunnerTest):
     Most of the configuratin options of GTest are
     just simple wrappers for native arguments.
 
-    :param name: Test instance name. Also used as uid.
+    :param name: Test instance name, often used as uid of test entity.
     :type name: ``str``
     :param binary: Path the to application binary or script.
     :type binary: ``str``
@@ -160,7 +161,9 @@ class GTest(ProcessRunnerTest):
         for suite in test_data.getchildren():
             suite_name = suite.attrib["name"]
             suite_report = TestGroupReport(
-                name=suite_name, uid=suite_name, category="testsuite"
+                name=suite_name,
+                category=ReportCategories.TESTSUITE,
+                uid=suite_name,
             )
             suite_has_run = False
 

--- a/testplan/testing/cpp/hobbestest.py
+++ b/testplan/testing/cpp/hobbestest.py
@@ -2,7 +2,12 @@ from schema import Or
 
 from testplan.common.config import ConfigOption
 
-from testplan.report import TestGroupReport, TestCaseReport, RuntimeStatus
+from testplan.report import (
+    TestGroupReport,
+    TestCaseReport,
+    ReportCategories,
+    RuntimeStatus,
+)
 from testplan.testing.multitest.entries.assertions import RawAssertion
 from testplan.testing.multitest.entries.schemas.base import registry
 
@@ -31,7 +36,7 @@ class HobbesTest(ProcessRunnerTest):
     Subprocess test runner for Hobbes Test:
     https://github.com/Morgan-Stanley/hobbes
 
-    :param name: Test instance name. Also used as uid.
+    :param name: Test instance name, often used as uid of test entity.
     :type name: ``str``
     :param binary: Path the to application binary or script.
     :type binary: ``str``
@@ -103,7 +108,9 @@ class HobbesTest(ProcessRunnerTest):
         result = []
         for suite in test_data:
             suite_report = TestGroupReport(
-                name=suite["name"], uid=suite["name"], category="testsuite"
+                name=suite["name"],
+                category=ReportCategories.TESTSUITE,
+                uid=suite["name"],
             )
             suite_has_run = False
 

--- a/testplan/testing/pyunit.py
+++ b/testplan/testing/pyunit.py
@@ -1,12 +1,16 @@
 """PyUnit test runner."""
 
+import unittest
+
 from testplan.testing import base as testing
-from testplan.report import testing as report_testing
 from testplan.testing.multitest.entries import assertions
 from testplan.testing.multitest.entries import schemas
 from testplan.testing.multitest.entries import base as base_entries
-
-import unittest
+from testplan.report import (
+    TestGroupReport,
+    TestCaseReport,
+    ReportCategories,
+)
 
 
 class PyUnitConfig(testing.TestConfig):
@@ -24,7 +28,7 @@ class PyUnit(testing.Test):
     """
     Test runner for PyUnit unit tests.
 
-    :param name: Test instance name. Also used as uid.
+    :param name: Test instance name, often used as uid of test entity.
     :type name: ``str``
     :param description: Description of test instance.
     :type description: ``str``
@@ -68,12 +72,12 @@ class PyUnit(testing.Test):
         test_report = self._new_test_report()
 
         for pyunit_testcase in self.cfg.testcases:
-            testsuite_report = report_testing.TestGroupReport(
+            testsuite_report = TestGroupReport(
                 name=pyunit_testcase.__name__,
                 uid=pyunit_testcase.__name__,
-                category=report_testing.ReportCategories.TESTSUITE,
+                category=ReportCategories.TESTSUITE,
                 entries=[
-                    report_testing.TestCaseReport(
+                    TestCaseReport(
                         name=self._TESTCASE_NAME, uid=self._TESTCASE_NAME,
                     )
                 ],
@@ -118,7 +122,7 @@ class PyUnit(testing.Test):
         # suite, we put all results into a single "testcase" report. This
         # will only list failures and errors and not give detail on individual
         # assertions like with MultiTest.
-        testcase_report = report_testing.TestCaseReport(
+        testcase_report = TestCaseReport(
             name=self._TESTCASE_NAME, uid=self._TESTCASE_NAME
         )
 
@@ -147,9 +151,9 @@ class PyUnit(testing.Test):
             testcase_report.append(schemas.base.registry.serialize(log_entry))
 
         # We have to wrap the testcase report in a testsuite report.
-        return report_testing.TestGroupReport(
+        return TestGroupReport(
             name=pyunit_testcase.__name__,
             uid=pyunit_testcase.__name__,
-            category=report_testing.ReportCategories.TESTSUITE,
+            category=ReportCategories.TESTSUITE,
             entries=[testcase_report],
         )

--- a/tests/functional/testplan/testing/fixtures/cpp/cppunit/failing/report.py
+++ b/tests/functional/testplan/testing/fixtures/cpp/cppunit/failing/report.py
@@ -12,39 +12,39 @@ expected_report = TestReport(
                     category="testsuite",
                     entries=[
                         TestCaseReport(
-                            name="testEqual",
+                            name="Comparison::testEqual",
                             entries=[
                                 {"type": "RawAssertion", "passed": False}
                             ],
                         ),
                         TestCaseReport(
-                            name="testAnd",
+                            name="LogicalOp::testAnd",
                             entries=[
                                 {"type": "RawAssertion", "passed": False}
                             ],
                         ),
                         TestCaseReport(
-                            name="testGreater",
+                            name="Comparison::testGreater",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testLess",
+                            name="Comparison::testLess",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testMisc",
+                            name="Comparison::testMisc",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testOr",
+                            name="LogicalOp::testOr",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testNot",
+                            name="LogicalOp::testNot",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testXor",
+                            name="LogicalOp::testXor",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                     ],

--- a/tests/functional/testplan/testing/fixtures/cpp/cppunit/passing/report.py
+++ b/tests/functional/testplan/testing/fixtures/cpp/cppunit/passing/report.py
@@ -12,35 +12,35 @@ expected_report = TestReport(
                     category="testsuite",
                     entries=[
                         TestCaseReport(
-                            name="testNotEqual",
+                            name="Comparison::testNotEqual",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testGreater",
+                            name="Comparison::testGreater",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testLess",
+                            name="Comparison::testLess",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testMisc",
+                            name="Comparison::testMisc",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testOr",
+                            name="LogicalOp::testOr",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testAnd",
+                            name="LogicalOp::testAnd",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testNot",
+                            name="LogicalOp::testNot",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                         TestCaseReport(
-                            name="testXor",
+                            name="LogicalOp::testXor",
                             entries=[{"type": "RawAssertion", "passed": True}],
                         ),
                     ],


### PR DESCRIPTION
* A test report object is created with a uid which is usually test
  entity's name, before saving report UIDs of the report and all of
  its children will be replaced with strings in UUID4 format.
* No need to reset UID when running interactively. Can set argument
  `reset_report_uid` to `False` when running unit/functional tests
  to disable automatically uid generation.
* Refine the code, replace some hard coded strings with constants.
* Update doc strings.
