### PR TITLE
Standalone log file for driver which produces too much output

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -532,7 +532,7 @@ class Entity(logger.Loggable):
             )
         self.logger.debug(
             "{} has {} runpath and pid {}".format(
-                self.__class__.__name__, self.runpath, os.getpid()
+                self, self.runpath, os.getpid()
             )
         )
 

--- a/testplan/common/utils/logger.py
+++ b/testplan/common/utils/logger.py
@@ -14,7 +14,7 @@ import os
 import sys
 import logging
 
-from testplan.common.utils.strings import Color
+from testplan.common.utils.strings import Color, uuid4
 from testplan.report import Status
 
 # Define our log-level constants. We add some extra levels between INFO and
@@ -222,7 +222,9 @@ class Loggable(object):
         if self._logger:
             return self._logger
 
-        logger_name = ".".join(("testplan", self.__class__.__name__))
+        logger_name = ".".join(
+            ["testplan", self.__class__.__name__, uuid4()[-8:]]
+        )
         self._logger = logging.getLogger(logger_name)
         return self._logger
 

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -4,7 +4,6 @@ import os
 import random
 import time
 import datetime
-import warnings
 import webbrowser
 from collections import OrderedDict
 
@@ -14,7 +13,6 @@ from schema import Or, And, Use
 from testplan import defaults
 from testplan.common.config import ConfigOption
 from testplan.common.entity import (
-    Entity,
     RunnableConfig,
     RunnableStatus,
     RunnableResult,

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -100,9 +100,7 @@ class TestRunnerConfig(RunnableConfig):
             "name": str,
             ConfigOption("description", default=None): Or(str, None),
             ConfigOption("logger_level", default=logger.TEST_INFO): int,
-            ConfigOption("file_log_level", default=logger.DEBUG): Or(
-                int, None
-            ),
+            ConfigOption("file_log_level", default=logger.DEBUG): int,
             ConfigOption("runpath", default=default_runpath): Or(
                 None, str, lambda x: callable(x)
             ),

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -41,6 +41,7 @@ class AppConfig(DriverConfig):
             ConfigOption("env", default=None): Or(None, dict),
             ConfigOption("binary_strategy", default="link"): lambda s: s
             in ("copy", "link", "noop"),
+            ConfigOption("logname", default=None): Or(None, basestring),
             ConfigOption("app_dir_name", default=None): Or(None, basestring),
             ConfigOption("working_dir", default=None): Or(None, basestring),
         }
@@ -68,10 +69,14 @@ class App(Driver):
     :type env: ``dict``
     :param binary_strategy: Whether to copy / link binary to runpath.
     :type binary_strategy: one of ("copy", "link", "noop")
+    :param logname: Base name of driver logfile under `app_path`, in which
+        Testplan will look for `log_regexps` as driver start-up condition.
+        Default to "stdout" (to match the output stream of binary).
+    :type logname: ``str``
     :param app_dir_name: Application directory name.
-    :type app_dir_name: ``str``
+    :type app_dir_name: ``str`` or ``NoneType``
     :param working_dir: Application working directory. Default: runpath
-    :type working_dir: ``str``
+    :type working_dir: ``str`` or ``NoneType``
 
     Also inherits all
     :py:class:`~testplan.testing.multitest.driver.base.Driver` options.
@@ -152,11 +157,18 @@ class App(Driver):
             return self.cfg.env
 
     @property
+    def logname(self):
+        """Configured logname."""
+        return self.cfg.logname
+
+    @property
     def logpath(self):
         """Path for log regex matching."""
-        if self.cfg.logname:
-            return os.path.join(self.app_path, self.cfg.logname)
-        return self.outpath
+        return (
+            os.path.join(self.app_path, self.logname)
+            if self.logname
+            else self.outpath
+        )
 
     @property
     def outpath(self):

--- a/testplan/testing/multitest/driver/base.py
+++ b/testplan/testing/multitest/driver/base.py
@@ -337,7 +337,11 @@ class Driver(Resource):
         formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
         handler = logging.FileHandler(path)
         handler.setFormatter(formatter)
-        logger = logging.getLogger("FileLogger_{}".format(self.cfg.name))
+        logger = logging.getLogger(
+            "FileLogger_{}.{}".format(self.parent.name, self.name)
+            if getattr(self, "parent", None)
+            else "FileLogger_{}".format(self.name)
+        )
         logger.addHandler(handler)
         logger.setLevel(self.logger.getEffectiveLevel())
         self.file_logger = logger

--- a/testplan/testing/multitest/driver/kafka.py
+++ b/testplan/testing/multitest/driver/kafka.py
@@ -49,7 +49,7 @@ class KafkaStandalone(app.App):
     def __init__(
         self, name, cfg_template, binary=KAFKA_START, port=0, **options
     ):
-        log_regexps = [
+        stdout_regexps = [
             re.compile(
                 r".*Awaiting socket connections on\s*(?P<host>[^:]+):(?P<port>[0-9]+).*"
             ),
@@ -60,7 +60,7 @@ class KafkaStandalone(app.App):
             cfg_template=cfg_template,
             binary=binary,
             port=port,
-            log_regexps=log_regexps,
+            stdout_regexps=stdout_regexps,
             **options
         )
 

--- a/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
+++ b/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
@@ -159,7 +159,7 @@ def test_binary_strategy(runpath, strategy):
     binary = os.path.join(
         os.path.abspath(os.path.dirname(__file__)), "example_binary.py"
     )
-    log_regexps = [
+    stdout_regexps = [
         re.compile(r".*Binary started.*"),
         re.compile(r".*Binary=(?P<value>[a-zA-Z0-9]*).*"),
     ]
@@ -167,7 +167,7 @@ def test_binary_strategy(runpath, strategy):
     params = {
         "name": "App",
         "binary": binary,
-        "log_regexps": log_regexps,
+        "stdout_regexps": stdout_regexps,
         "pre_args": [sys.executable],
         "binary_strategy": strategy,
         "runpath": runpath,
@@ -204,7 +204,7 @@ def test_install_files(runpath):
     bfile = os.path.join(
         os.path.abspath(os.path.dirname(__file__)), "binary_file"
     )
-    log_regexps = [
+    stdout_regexps = [
         re.compile(r".*binary=(?P<binary>.*)"),
         re.compile(r".*command=(?P<command>.*)"),
         re.compile(r".*app_path=(?P<app_path>.*)"),
@@ -220,7 +220,7 @@ def test_install_files(runpath):
             (config, os.path.join(dst, "config.yaml")),
             (config, os.path.join("rel_path", "config.yaml")),
         ],
-        log_regexps=log_regexps,
+        stdout_regexps=stdout_regexps,
         shell=True,
         runpath=runpath,
     )


### PR DESCRIPTION
* Multitest driver can setup file handler for logging, however, the
  names of log instances should be different, if there are 2 drivers
  with the same name but not in one Multitest, they would write
  the same content because `logging` is a global shared module
  and getLogger() by name returns the same instance.
* Since that some drivers might produce a large amount of output
  and be propagated to parent's logger, thus there could be too many
  things printed on console as well as in TestRunner's log. Thus make
  an improvement to provide a config option that Testplan can
  generate a standalone file under driver's runpath for logging and
  stop propagation.
