### PR TITLE
Reformat the code with prettier look

### DIFF
--- a/examples/Cpp/Cppunit/test_plan.py
+++ b/examples/Cpp/Cppunit/test_plan.py
@@ -32,9 +32,7 @@ def main(plan):
     else:
         plan.add(
             Cppunit(
-                name="My Cppunit",
-                binary=BINARY_PATH,
-                file_output_flag="-y",
+                name="My Cppunit", binary=BINARY_PATH, file_output_flag="-y"
             )
         )
         # You can apply Cppunit specific filtering via `filtering_flag` arg

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -318,7 +318,7 @@ class EntityStatus(object):
         self._metadata = OrderedDict()
 
     def transitions(self):
-        """ "
+        """
         Returns all legal transitions of the status of the
         :py:class:`Entity <testplan.common.entity.base.Entity>`.
         """
@@ -571,7 +571,7 @@ class RunnableStatus(EntityStatus):
     PAUSED = "PAUSED"
 
     def transitions(self):
-        """ "
+        """
         Defines the status transitions of a
         :py:class:`Runnable <testplan.common.entity.base.Runnable>` entity.
         """
@@ -937,7 +937,7 @@ class ResourceStatus(EntityStatus):
     STOPPED = "STOPPED"
 
     def transitions(self):
-        """ "
+        """
         Defines the status transitions of a
         :py:class:`Resource <testplan.common.entity.base.Resource>` entity.
         """

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -485,9 +485,8 @@ def _cmp_dicts(lhs, rhs, ignore, only, report_mode, value_cmp_func):
         """
         Decide if a key should be ignored.
 
-        Decision is based on ``ignore`` and ``only``.
-        If ``only`` is ``True`` then keys that are
-         not in ``lhs`` will be ignored.
+        Decision is based on ``ignore`` and ``only``. If ``only`` is ``True``
+        then keys that are not in ``lhs`` will be ignored.
         """
         if key in ignore:
             should_ignore = True

--- a/testplan/common/utils/difflib.py
+++ b/testplan/common/utils/difflib.py
@@ -1569,8 +1569,8 @@ def unified_diff(
     >>> difference = unified_diff('one\ntwo\nthree\n'.splitlines(True),
                                   'ore\nthree\nemu\n'.splitlines(True))
     >>> print(''.join(difference))
-    --- a.text  2018-08-28 11:36:46 UTC
-    +++ b.text  2018-08-28 11:36:46 UTC
+    --- a.text    2018-08-28 11:36:46 UTC
+    +++ b.text    2018-08-28 11:36:46 UTC
     @@ -1,3 +1,3 @@
     -one
     -two
@@ -1667,8 +1667,8 @@ def context_diff(
     >>> difference = context_diff('one\ntwo\nthree\n'.splitlines(True),
                                   'ore\nthree\nemu\n'.splitlines(True))
     >>> print(''.join(difference))
-    --- a.text  2018-08-28 11:40:17 UTC
-    +++ b.text  2018-08-28 11:40:17 UTC
+    --- a.text    2018-08-28 11:40:17 UTC
+    +++ b.text    2018-08-28 11:40:17 UTC
     ***************
     *** 1,3 ****
     ! one

--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -291,7 +291,7 @@ except AttributeError:
 
 
 def hash_file(filepath):
-    """ "
+    """
     Hashes the contents of a file. SHA1 algorithm is used.
 
     :param filepath: Path to file to hash.

--- a/testplan/exporters/testing/pdf/__init__.py
+++ b/testplan/exporters/testing/pdf/__init__.py
@@ -208,10 +208,7 @@ class PDFExporter(Exporter):
         if not override and os.path.exists(pdf_path):
             file_name, ext = os.path.splitext(pdf_path)
             pdf_path = "{}_{}{}".format(file_name, int(time.time()), ext)
-            self.logger.exporter_info(
-                "File %s exists!",
-                self.cfg.pdf_path,
-            )
+            self.logger.exporter_info("File %s exists!", self.cfg.pdf_path)
 
         template = SimpleDocTemplate(
             filename=pdf_path,

--- a/testplan/exporters/testing/pdf/renderers/entries/assertions.py
+++ b/testplan/exporters/testing/pdf/renderers/entries/assertions.py
@@ -167,8 +167,7 @@ class RegexMatchRenderer(AssertionRenderer):
 
     def get_detail(self, source, depth, row_idx):
         """
-        Return highlighted patterns within the
-        string, if there is a match.
+        Return highlighted patterns within the string, if there is a match.
         """
         pattern_style = [
             RowStyle(

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -209,11 +209,7 @@ class TestRunnerIHandler(entity.Entity):
             when ready.
         """
         if not await_results:
-            return self._run_async(
-                self.run_test_suite,
-                test_uid,
-                suite_uid,
-            )
+            return self._run_async(self.run_test_suite, test_uid, suite_uid)
 
         test = self.test(test_uid)
 
@@ -231,13 +227,7 @@ class TestRunnerIHandler(entity.Entity):
             test.run_testcases_iter(testsuite_pattern=suite_uid)
         )
 
-    def run_test_case(
-        self,
-        test_uid,
-        suite_uid,
-        case_uid,
-        await_results=True,
-    ):
+    def run_test_case(self, test_uid, suite_uid, case_uid, await_results=True):
         """
         Run a single testcase.
 
@@ -346,10 +336,7 @@ class TestRunnerIHandler(entity.Entity):
             result objects.
         """
         if not await_results:
-            return self._run_async(
-                self.start_test_resources,
-                test_uid,
-            )
+            return self._run_async(self.start_test_resources, test_uid)
 
         self.logger.debug("Starting test resources for %s", test_uid)
 
@@ -374,10 +361,7 @@ class TestRunnerIHandler(entity.Entity):
             result objects.
         """
         if not await_results:
-            return self._run_async(
-                self.stop_test_resources,
-                test_uid,
-            )
+            return self._run_async(self.stop_test_resources, test_uid)
 
         self.logger.debug("Stopping test resources for %s", test_uid)
 
@@ -403,12 +387,7 @@ class TestRunnerIHandler(entity.Entity):
         test = self.test(test_uid)
         return test.resources[resource_uid]
 
-    def test_report(
-        self,
-        test_uid,
-        serialized=True,
-        exclude_assertions=False,
-    ):
+    def test_report(self, test_uid, serialized=True, exclude_assertions=False):
         """Get a test report."""
         test = self.test(test_uid)
         report = test.result.report
@@ -477,18 +456,12 @@ class TestRunnerIHandler(entity.Entity):
 
     def test_resource_start(self, test_uid, resource_uid):
         """Start a resource of a Test instance."""
-        resource = self.test_resource(
-            test_uid,
-            resource_uid,
-        )
+        resource = self.test_resource(test_uid, resource_uid)
         self.start_resource(resource)
 
     def test_resource_stop(self, test_uid, resource_uid):
         """Stop a resource of a Test instance."""
-        resource = self.test_resource(
-            test_uid,
-            resource_uid,
-        )
+        resource = self.test_resource(test_uid, resource_uid)
         self.stop_resource(resource)
 
     def get_environment_context(
@@ -587,10 +560,7 @@ class TestRunnerIHandler(entity.Entity):
                 "Operation {} for test: {}".format(operation, test_uid)
             )
             if operation == "run":
-                self.run_test(
-                    test_uid,
-                    await_results=await_results,
-                )
+                self.run_test(test_uid, await_results=await_results)
             elif operation == "start":
                 self.start_test_resources(test_uid)
             elif operation == "stop":

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -534,10 +534,7 @@ class Pool(Executor):
                     self.logger.test_info(
                         "Will rerun %(task)s due to `should_rerun` "
                         "config option of %(pool)s",
-                        {
-                            "task": task_result.task,
-                            "pool": self,
-                        },
+                        {"task": task_result.task, "pool": self},
                     )
                     self.unassigned.append(uid)
                     self._task_retries_cnt[uid] = 0

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -370,10 +370,7 @@ class Test(Runnable):
             )
 
             for testcase in testcases:
-                testcase_report = TestCaseReport(
-                    name=testcase,
-                    uid=testcase,
-                )
+                testcase_report = TestCaseReport(name=testcase, uid=testcase)
                 testsuite_report.append(testcase_report)
 
             self.result.report.append(testsuite_report)
@@ -698,12 +695,10 @@ class ProcessRunnerTest(Test):
                     passed=passed,
                 ).serialize(),
                 Log(
-                    message=stdout.read(),
-                    description="Process stdout",
+                    message=stdout.read(), description="Process stdout"
                 ).serialize(),
                 Log(
-                    message=stderr.read(),
-                    description="Process stderr",
+                    message=stderr.read(), description="Process stderr"
                 ).serialize(),
             ],
         )
@@ -726,9 +721,7 @@ class ProcessRunnerTest(Test):
             with open(self.stdout) as stdout, open(self.stderr) as stderr:
                 self.result.report.append(
                     self.get_process_check_report(
-                        self._test_process_retcode,
-                        stdout,
-                        stderr,
+                        self._test_process_retcode, stdout, stderr
                     )
                 )
             return
@@ -790,9 +783,7 @@ class ProcessRunnerTest(Test):
         report = result.report
 
         testcase_report = TestCaseReport(
-            name="ExitCodeCheck",
-            uid="ExitCodeCheck",
-            suite_related=True,
+            name="ExitCodeCheck", uid="ExitCodeCheck", suite_related=True
         )
         testsuite_report = TestGroupReport(
             name="ProcessChecks",

--- a/testplan/testing/cpp/gtest.py
+++ b/testplan/testing/cpp/gtest.py
@@ -265,8 +265,7 @@ class GTest(ProcessRunnerTest):
         if testsuite_pattern != "*" or testcase_pattern != "*":
             cmd.append(
                 "--gtest_filter={}.{}".format(
-                    testsuite_pattern,
-                    testcase_pattern,
+                    testsuite_pattern, testcase_pattern
                 )
             )
         return cmd

--- a/testplan/testing/listing.py
+++ b/testplan/testing/listing.py
@@ -16,8 +16,12 @@ MAX_TESTCASES = 25
 
 
 class BaseLister(object):
-    """Base of all listers, implement the :py:meth:`get_output` give it a name in :py:attr:`NAME` and a description in :py:attr:`DESCRIPTION` or
-    alternatively override :py:meth:`name` and/or :py:meth:`description` and it is good to be added to :py:data:`listing_registry`"""
+    """
+    Base of all listers, implement the :py:meth:`get_output` give it a name in
+    :py:attr:`NAME` and a description in :py:attr:`DESCRIPTION` or alternatively
+    override :py:meth:`name` and/or :py:meth:`description` and it is good to be
+    added to :py:data:`listing_registry`.
+    """
 
     NAME = None
     DESCRIPTION = None
@@ -145,11 +149,7 @@ class ExpandedPatternLister(ExpandedNameLister):
         if not isinstance(instance, MultiTest):
             return "{}::{}::{}".format(instance.name, suite, testcase)
 
-        pattern = "{}::{}::{}".format(
-            instance.name,
-            suite.name,
-            testcase.name,
-        )
+        pattern = "{}::{}::{}".format(instance.name, suite.name, testcase.name)
         return self.apply_tag_label(pattern, testcase)
 
 
@@ -236,8 +236,10 @@ class ListingArgMixin(ArgMixin):
 
 
 class ListingRegistry(object):
-    """A registry to store listers, add listers to the :py:data:`listing_registry` instance which is used to create the
-    commandline parser"""
+    """
+    A registry to store listers, add listers to the :py:data:`listing_registry`
+    instance which is used to create the commandline parser.
+    """
 
     def __init__(self):
         self.listers = []

--- a/testplan/testing/multitest/driver/base.py
+++ b/testplan/testing/multitest/driver/base.py
@@ -307,9 +307,7 @@ class Driver(Resource):
                 if not os.path.isfile(install_file):
                     raise ValueError("{} is not a file".format(install_file))
                 instantiate(
-                    install_file,
-                    self.context_input(),
-                    self._install_target(),
+                    install_file, self.context_input(), self._install_target()
                 )
             elif isinstance(install_file, tuple):
                 if len(install_file) != 2:
@@ -320,11 +318,7 @@ class Driver(Resource):
                 src, dst = install_file
                 if not os.path.isabs(dst):
                     dst = os.path.join(self._install_target(), dst)
-                instantiate(
-                    src,
-                    self.context_input(),
-                    dst,
-                )
+                instantiate(src, self.context_input(), dst)
 
     def _setup_file_logger(self, path):
         """

--- a/testplan/testing/multitest/driver/kafka.py
+++ b/testplan/testing/multitest/driver/kafka.py
@@ -17,7 +17,7 @@ KAFKA_START = "/opt/kafka/bin/kafka-server-start.sh"
 
 
 class KafkaStandaloneConfig(app.AppConfig):
-    """ "
+    """
     Configuration object for
     :py:class:`~testplan.testing.multitest.driver.kafka.KafkaStandalone` resource.
     """

--- a/testplan/testing/multitest/driver/zookeeper.py
+++ b/testplan/testing/multitest/driver/zookeeper.py
@@ -19,7 +19,7 @@ ZK_SERVER = "/usr/share/zookeeper/bin/zkServer.sh"
 
 
 class ZookeeperStandaloneConfig(DriverConfig):
-    """ "
+    """
     Configuration object for
     :py:class:`~testplan.testing.multitest.driver.zookeeper.ZookeeperStandalone` resource.
     """

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -69,9 +69,7 @@ class Assertion(BaseEntry):
 
     def __init__(self, description=None, category=None, flag=None):
         super(Assertion, self).__init__(
-            description=description,
-            category=category,
-            flag=flag,
+            description=description, category=category, flag=flag
         )
         self.passed = bool(self.evaluate())
 

--- a/testplan/testing/multitest/entries/stdout/assertions.py
+++ b/testplan/testing/multitest/entries/stdout/assertions.py
@@ -89,8 +89,7 @@ class RegexMatchRenderer(AssertionRenderer):
 
     def get_assertion_details(self, entry):
         """
-        Return highlighted patterns within the
-        string, if there is a match.
+        Return highlighted patterns within the string, if there is a match.
         """
 
         string = entry.string

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -1555,9 +1555,7 @@ class Result(object):
         if condition:
             if log_description:
                 return self.log(
-                    log_message,
-                    description=log_description,
-                    flag=flag,
+                    log_message, description=log_description, flag=flag
                 )
         else:
             return self.fail(fail_description, flag=flag)

--- a/testplan/testing/pyunit.py
+++ b/testplan/testing/pyunit.py
@@ -78,8 +78,7 @@ class PyUnit(testing.Test):
                 category=ReportCategories.TESTSUITE,
                 entries=[
                     TestCaseReport(
-                        name=self._TESTCASE_NAME,
-                        uid=self._TESTCASE_NAME,
+                        name=self._TESTCASE_NAME, uid=self._TESTCASE_NAME
                     )
                 ],
             )

--- a/tests/functional/exporters/testing/test_pdf.py
+++ b/tests/functional/exporters/testing/test_pdf.py
@@ -88,9 +88,8 @@ def test_create_pdf(tmpdir):
 
 def test_tag_filtered_pdf(tmpdir):
     """
-    Tag filtered PDF exporter should generate
-    multiple PDF files for matching report sub-trees
-    and skip empty reports.
+    Tag filtered PDF exporter should generate multiple PDF files
+    for matching report sub-trees and skip empty reports.
     """
     pdf_dir = tmpdir.mkdir("reports").strpath
 

--- a/tests/functional/exporters/testing/test_xml.py
+++ b/tests/functional/exporters/testing/test_xml.py
@@ -47,8 +47,7 @@ def test_xml_exporter(tmpdir):
     xml_dir = tmpdir.mkdir("xml")
 
     plan = TestplanMock(
-        name="plan",
-        exporters=XMLExporter(xml_dir=xml_dir.strpath),
+        name="plan", exporters=XMLExporter(xml_dir=xml_dir.strpath)
     )
     multitest_1 = multitest.MultiTest(name="Primary", suites=[Alpha()])
     multitest_2 = multitest.MultiTest(name="Secondary", suites=[Beta()])
@@ -169,7 +168,7 @@ sample_report = TestReport(
 
 def test_xml_exporter_cleanup(tmpdir):
     """
-    XMLExporter should purge & recreate XML dir
+    XMLExporter should purge & recreate XML dir.
     """
 
     xml_dir = tmpdir.mkdir("xml")

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -74,8 +74,7 @@ def plan(tmpdir):
 
     logfile = tmpdir / "attached_log.txt"
     logfile.write_text(
-        "This text will be written into the attached file.",
-        encoding="utf8",
+        "This text will be written into the attached file.", encoding="utf8"
     )
 
     plan.add(

--- a/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -55,8 +55,7 @@ class SuiteKillingWorker(object):
 def multitest_kill_one_worker(parent_pid, size):
     """Test that kills one worker."""
     return MultiTest(
-        name="MTestKiller",
-        suites=[SuiteKillingWorker(parent_pid, size)],
+        name="MTestKiller", suites=[SuiteKillingWorker(parent_pid, size)]
     )
 
 

--- a/tests/functional/testplan/runners/pools/test_pool_base.py
+++ b/tests/functional/testplan/runners/pools/test_pool_base.py
@@ -65,10 +65,7 @@ def schedule_tests_to_pool(plan, pool, **pool_cfg):
         Task(target=get_mtest_imported, kwargs=dict(name=6)),
         resource=pool_name,
     )
-    uid7 = plan.schedule(
-        Task(target=get_mtest(name=7)),
-        resource=pool_name,
-    )
+    uid7 = plan.schedule(Task(target=get_mtest(name=7)), resource=pool_name)
 
     # with log_propagation_disabled(TESTPLAN_LOGGER):
     assert plan.run().run is True

--- a/tests/functional/testplan/testing/fixtures/base/failing/report.py
+++ b/tests/functional/testplan/testing/fixtures/base/failing/report.py
@@ -15,14 +15,8 @@ testcase_report = TestCaseReport(
             "description": "Process exit code check",
             "passed": False,
         },
-        {
-            "type": "Log",
-            "description": "Process stdout",
-        },
-        {
-            "type": "Log",
-            "description": "Process stderr",
-        },
+        {"type": "Log", "description": "Process stdout"},
+        {"type": "Log", "description": "Process stderr"},
     ],
 )
 

--- a/tests/functional/testplan/testing/fixtures/base/passing/report.py
+++ b/tests/functional/testplan/testing/fixtures/base/passing/report.py
@@ -16,14 +16,8 @@ testcase_report = TestCaseReport(
             "description": "Process exit code check",
             "passed": True,
         },
-        {
-            "type": "Log",
-            "description": "Process stdout",
-        },
-        {
-            "type": "Log",
-            "description": "Process stderr",
-        },
+        {"type": "Log", "description": "Process stdout"},
+        {"type": "Log", "description": "Process stderr"},
     ],
 )
 

--- a/tests/functional/testplan/testing/fixtures/base/sleeping/report.py
+++ b/tests/functional/testplan/testing/fixtures/base/sleeping/report.py
@@ -16,14 +16,8 @@ testcase_report = TestCaseReport(
             "description": "Process exit code check",
             "passed": False,
         },
-        {
-            "type": "Log",
-            "description": "Process stdout",
-        },
-        {
-            "type": "Log",
-            "description": "Process stderr",
-        },
+        {"type": "Log", "description": "Process stdout"},
+        {"type": "Log", "description": "Process stderr"},
     ],
 )
 

--- a/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -124,12 +124,7 @@ def test_multitest_drivers(runpath):
 def test_multitest_drivers_in_testplan(runpath):
     """TODO."""
     for idx, opts in enumerate(
-        (
-            dict(name="MyPlan", runpath=runpath),
-            dict(
-                name="MyPlan",
-            ),
-        )
+        (dict(name="MyPlan", runpath=runpath), dict(name="MyPlan"))
     ):
         plan = TestplanMock(**opts)
         server = TCPServer(name="server")

--- a/tests/functional/testplan/testing/multitest/test_parametrization.py
+++ b/tests/functional/testplan/testing/multitest/test_parametrization.py
@@ -391,10 +391,7 @@ def test_custom_name(mockplan):
             lambda func_name, kwargs: "XXX_{a}_{b}_YYY".format(**kwargs),
             ("XXX_foo_bar_YYY", "XXX_alpha_beta_YYY"),
         ),
-        (
-            None,
-            ("Sample Test 0", "Sample Test 1"),
-        ),
+        (None, ("Sample Test 0", "Sample Test 1")),
     ),
 )
 def test_custom_name_func(mockplan, name_func, testcase_names):
@@ -572,10 +569,7 @@ def test_tag_func(tag_func, expected_tags, expected_tags_index):
 def test_docstring_func(docstring_func, expected_docstring):
     @testsuite
     class MySuite(object):
-        @testcase(
-            parameters=(("foo", "bar"),),
-            docstring_func=docstring_func,
-        )
+        @testcase(parameters=(("foo", "bar"),), docstring_func=docstring_func)
         def adder_test(self, env, result, first, second):
             """Original docstring"""
             pass
@@ -607,16 +601,13 @@ def test_parametrization_tagging(mockplan):
         tags={"simple": {"alpha"}},
         entries=[
             TestCaseReport(
-                name="dummy_test <color='red'>",
-                tags={"color": {"red"}},
+                name="dummy_test <color='red'>", tags={"color": {"red"}}
             ),
             TestCaseReport(
-                name="dummy_test <color='blue'>",
-                tags={"color": {"blue"}},
+                name="dummy_test <color='blue'>", tags={"color": {"blue"}}
             ),
             TestCaseReport(
-                name="dummy_test <color='green'>",
-                tags={"color": {"green"}},
+                name="dummy_test <color='green'>", tags={"color": {"green"}}
             ),
         ],
     )

--- a/tests/unit/testplan/testing/multitest/driver/mykafka/test_kafka.py
+++ b/tests/unit/testplan/testing/multitest/driver/mykafka/test_kafka.py
@@ -38,10 +38,7 @@ def zookeeper_server():
 
 @pytest.fixture(scope="module")
 def kafka_server(zookeeper_server):
-    server = kafka.KafkaStandalone(
-        "kafka",
-        cfg_template=kafka_cfg_template,
-    )
+    server = kafka.KafkaStandalone("kafka", cfg_template=kafka_cfg_template)
 
     testplan = TestplanMock("KafkaTest", parse_cmdline=False)
     env = entity.Environment(parent=testplan)

--- a/tests/unit/testplan/testing/multitest/driver/test_http.py
+++ b/tests/unit/testplan/testing/multitest/driver/test_http.py
@@ -15,10 +15,7 @@ from testplan.common.utils import path
 def http_server(runpath_module):
     """Start and yield an HTTP server driver."""
     server = http.HTTPServer(
-        name="http_server",
-        host="localhost",
-        port=0,
-        runpath=runpath_module,
+        name="http_server", host="localhost", port=0, runpath=runpath_module
     )
 
     with server:

--- a/tests/unit/testplan/testing/multitest/driver/test_tcp_server.py
+++ b/tests/unit/testplan/testing/multitest/driver/test_tcp_server.py
@@ -16,10 +16,7 @@ def tcp_server(runpath_module):
     """Start and yield a TCP server driver."""
     env = Environment()
     server = TCPServer(
-        name="server",
-        host="localhost",
-        port=0,
-        runpath=runpath_module,
+        name="server", host="localhost", port=0, runpath=runpath_module
     )
     env.add(server)
 

--- a/tests/unit/testplan/testing/pytest_expected_data.py
+++ b/tests/unit/testplan/testing/pytest_expected_data.py
@@ -14,12 +14,10 @@ EXPECTED_DRY_RUN_REPORT = testplan.report.TestGroupReport(
             category="testsuite",
             entries=[
                 testplan.report.TestCaseReport(
-                    name="test_success",
-                    uid="test_success",
+                    name="test_success", uid="test_success"
                 ),
                 testplan.report.TestCaseReport(
-                    name="test_failure",
-                    uid="test_failure",
+                    name="test_failure", uid="test_failure"
                 ),
                 testplan.report.TestGroupReport(
                     name="test_parametrization",
@@ -48,8 +46,7 @@ EXPECTED_DRY_RUN_REPORT = testplan.report.TestGroupReport(
             category="testsuite",
             entries=[
                 testplan.report.TestCaseReport(
-                    name="test_drivers",
-                    uid="test_drivers",
+                    name="test_drivers", uid="test_drivers"
                 )
             ],
         ),
@@ -59,28 +56,22 @@ EXPECTED_DRY_RUN_REPORT = testplan.report.TestGroupReport(
             category="testsuite",
             entries=[
                 testplan.report.TestCaseReport(
-                    name="test_skipped",
-                    uid="test_skipped",
+                    name="test_skipped", uid="test_skipped"
                 ),
                 testplan.report.TestCaseReport(
-                    name="test_skipif",
-                    uid="test_skipif",
+                    name="test_skipif", uid="test_skipif"
                 ),
                 testplan.report.TestCaseReport(
-                    name="test_xfail",
-                    uid="test_xfail",
+                    name="test_xfail", uid="test_xfail"
                 ),
                 testplan.report.TestCaseReport(
-                    name="test_unexpected_error",
-                    uid="test_unexpected_error",
+                    name="test_unexpected_error", uid="test_unexpected_error"
                 ),
                 testplan.report.TestCaseReport(
-                    name="test_xpass",
-                    uid="test_xpass",
+                    name="test_xpass", uid="test_xpass"
                 ),
                 testplan.report.TestCaseReport(
-                    name="test_xpass_strict",
-                    uid="test_xpass_strict",
+                    name="test_xpass_strict", uid="test_xpass_strict"
                 ),
             ],
         ),

--- a/tests/unit/testplan/testing/pyunit_expected_data.py
+++ b/tests/unit/testplan/testing/pyunit_expected_data.py
@@ -15,8 +15,7 @@ EXPECTED_DRY_RUN_REPORT = testplan.report.TestGroupReport(
             category=testplan.report.ReportCategories.TESTSUITE,
             entries=[
                 testplan.report.TestCaseReport(
-                    name="PyUnit test results",
-                    uid="PyUnit test results",
+                    name="PyUnit test results", uid="PyUnit test results"
                 )
             ],
         ),
@@ -26,8 +25,7 @@ EXPECTED_DRY_RUN_REPORT = testplan.report.TestGroupReport(
             category=testplan.report.ReportCategories.TESTSUITE,
             entries=[
                 testplan.report.TestCaseReport(
-                    name="PyUnit test results",
-                    uid="PyUnit test results",
+                    name="PyUnit test results", uid="PyUnit test results"
                 )
             ],
         ),


### PR DESCRIPTION
* The whole code had been automatically reformated by the latest Black
  but some lines get worse. For instance, if a list or tuple has only
  a few elements and the last one is followed with a "," symbol then
  this line will be split into several lines. Generally if arguments
  are passed with formal params like "a=some_a, b=some_b" and it's long
  enough then we recommand to write it in multi-lines, however, if only
  actual params are there like "func(a, b, c)" and the line not longer
  than 79 characters we should keep it simple and it is easy to read.