### PR TITLE
Fix an issue that `LocalRunner` has no `runpath`

### DIFF
--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -382,8 +382,8 @@ class TestRunner(Runnable):
         :return: Resource uid assigned.
         :rtype:  ``str``
         """
-        resource.cfg.parent = self.cfg
         resource.parent = self
+        resource.cfg.parent = self.cfg
         return self.resources.add(
             resource, uid=uid or getattr(resource, "uid", strings.uuid4)()
         )

--- a/testplan/runners/local.py
+++ b/testplan/runners/local.py
@@ -82,6 +82,11 @@ class LocalRunner(Executor):
                 return
             time.sleep(self.cfg.active_loop_sleep)
 
+    def starting(self):
+        """Starting the local runner."""
+        self._runpath = self.parent.runpath
+        super(LocalRunner, self).starting()  # start the loop
+
     def aborting(self):
         """Aborting logic."""
         self.logger.critical("Discard pending tasks of {}.".format(self))


### PR DESCRIPTION
* When a task is directly added to `local_runner`, before executed it
  will be materialized and set `local_runner` as parent of test target, so
  its `runpath` should be a sub directory of the parent's runpath. But
  class `LocalRunner` does not have a `starting` method and no runpath
  is set, so test target wrapped in task will find a default runpath
  as superior directory, making it inconvenient to view output.
*  Since `local_runner` is not visible to users, just set its runpath the same
  as TestRunner's runpath.
